### PR TITLE
[FE] 필요없는 타입설정 제거

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -32,7 +32,6 @@
     "noFallthroughCasesInSwitch": true /* Enable error reporting for fallthrough cases in switch statements. */,
 
     /* Completeness */
-    "skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["src"]


### PR DESCRIPTION
# [FE] 필요없는 타입설정 제거
## 이슈번호
#5 

## PR 내용
tsconfig의 속성 중 이제는 사용하지 않는 속성인 "skipDefaultLibCheck" 제거

## 참고자료
https://typescript-kr.github.io/pages/compiler-options.html
<img width="614" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/c1542fff-c913-4b99-9dc6-3419dfec28e7">
https://www.typescriptlang.org/ko/tsconfig#skipDefaultLibCheck

