### PR TITLE
[BE] 스케쥴 테스트용 더미데이터 추가

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/ScheduleRepository.java
@@ -1,0 +1,6 @@
+package team.teamby.teambyteam.schedule.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/backend/src/test/resources/h2-data.sql
+++ b/backend/src/test/resources/h2-data.sql
@@ -1,0 +1,13 @@
+-- 테스트 케이스
+-- 1. 당일 N 시간
+-- 2. 하루 종일
+-- 3. N일
+-- 4. 현재보다 과거의 일정
+-- 5. 현재보다 미래의 일정
+-- 서로 다른 팀플레이스
+
+INSERT INTO schedule (name, team_place_id, start_date_time, end_date_time) VALUES ('N시간 일정', 1, '2023-07-12 10:00:00' ,'2023-07-12 18:00:00');
+INSERT INTO schedule (name, team_place_id, start_date_time, end_date_time) VALUES ('종일 일정', 1, '2023-07-12 00:00:00' ,'2023-07-12 23:59:59');
+INSERT INTO schedule (name, team_place_id, start_date_time, end_date_time) VALUES ('N일 일정', 1, '2023-07-12 10:00:00' ,'2023-07-15 12:00:00');
+INSERT INTO schedule (name, team_place_id, start_date_time, end_date_time) VALUES ('과거 일정', 1, TIMESTAMPADD(DAY, -2, CURRENT_TIMESTAMP()), TIMESTAMPADD(DAY, -1, CURRENT_TIMESTAMP()));
+INSERT INTO schedule (name, team_place_id, start_date_time, end_date_time) VALUES ('미래 일정', 1, TIMESTAMPADD(DAY, 3, CURRENT_TIMESTAMP()), TIMESTAMPADD(DAY, 5, CURRENT_TIMESTAMP()));


### PR DESCRIPTION
## 이슈번호
> #17 

## PR 내용

- h2-data.sql에 스케쥴 테스트용 더미데이터 추가
- ScheduleRepository domain 패키지에 추가

## 참고자료

## 의논할 거리

- mysql 문법으로 data.sql에 작성했었는데, 문법 오류가 나서
- 따로 h2-data.sql에 h2 문법을 사용해서 테스트를 진행하기로 함.
