### PR TITLE
[BE] refactor: @AllArgsConstructor & @NoArgsConstructor 추가 리팩토링

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -2,6 +2,7 @@ package team.teamby.teambyteam.member.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.domain.vo.Name;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member {
 
     @Id

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -2,11 +2,13 @@ package team.teamby.teambyteam.member.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberTeamPlace {
 
     @Id

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/ProfileImageUrl.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/ProfileImageUrl.java
@@ -3,11 +3,13 @@ package team.teamby.teambyteam.member.domain.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class ProfileImageUrl {
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
@@ -2,11 +2,13 @@ package team.teamby.teambyteam.schedule.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class Schedule {
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
@@ -1,13 +1,18 @@
 package team.teamby.teambyteam.schedule.domain;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Embeddable
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Span {
 
     @Column(nullable = false)

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlace.java
@@ -2,6 +2,7 @@ package team.teamby.teambyteam.teamplace.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class TeamPlace {
 
     @Id


### PR DESCRIPTION
## 이슈번호
> #46 

## PR 내용

- 몹 프로그래밍으로 도메인 작성 했던 것 중에서 @AllArgsConstructor, @NoArgsConstructor 누락됐던 거 추가 리팩토링


## 참고자료

## 의논할 거리

- `Member` 같은 경우는 필드 4개인데 Builder를 사용해야 할까? 생성자를 사용해야할까? (일단 @AllArgsConstructor 사용했음)
- `Span`은 이후에 시작 날짜가 끝 날짜보다 뒤인 경우 등 검증을 거칠 거라서 @AllArgsContructor 말고 이후에 직접 
  검증 로직이 있는 생성자를 생성할 것 같은데, 일단 구현 전이니 `@AllArgsConstructor`를 사용했음.
