### PR TITLE
[BE] 일정 추가 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/exception/GlobalExceptionHandler.java
@@ -14,25 +14,25 @@ import java.time.format.DateTimeParseException;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    Logger log = LoggerFactory.getLogger(getClass());
+    final Logger log = LoggerFactory.getLogger(getClass());
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
-        String defaultErrorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+    public ResponseEntity<String> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
+        final String defaultErrorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         log.warn(defaultErrorMessage, exception);
 
         return ResponseEntity.badRequest().body(defaultErrorMessage);
     }
 
     @ExceptionHandler(DateTimeParseException.class)
-    public ResponseEntity<String> handleDateTimeParseException(DateTimeParseException exception) {
+    public ResponseEntity<String> handleDateTimeParseException(final DateTimeParseException exception) {
         log.warn(exception.getMessage(), exception);
 
         return ResponseEntity.badRequest().body("DateTime 형식이 잘못되었습니다. 서버 관리자에게 문의해주세요.");
     }
 
     @ExceptionHandler(TeamPlaceException.class)
-    public ResponseEntity<String> handleTeamPlaceException(TeamPlaceException exception) {
+    public ResponseEntity<String> handleTeamPlaceException(final TeamPlaceException exception) {
         log.warn(exception.getMessage(), exception);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());

--- a/backend/src/main/java/team/teamby/teambyteam/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package team.teamby.teambyteam.global.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+
+import java.time.format.DateTimeParseException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    Logger log = LoggerFactory.getLogger(getClass());
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        String defaultErrorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        log.warn(defaultErrorMessage, exception);
+
+        return ResponseEntity.badRequest().body(defaultErrorMessage);
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<String> handleDateTimeParseException(DateTimeParseException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return ResponseEntity.badRequest().body("DateTime 형식이 잘못되었습니다. 서버 관리자에게 문의해주세요.");
+    }
+
+    @ExceptionHandler(TeamPlaceException.class)
+    public ResponseEntity<String> handleTeamPlaceException(TeamPlaceException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
@@ -1,0 +1,42 @@
+package team.teamby.teambyteam.schedule.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+import team.teamby.teambyteam.schedule.domain.Schedule;
+import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
+import team.teamby.teambyteam.schedule.domain.Span;
+import team.teamby.teambyteam.schedule.domain.Title;
+import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final TeamPlaceRepository teamPlaceRepository;
+
+    public Long register(final ScheduleRegisterRequest scheduleRegisterRequest, final Long teamPlaceId) {
+        checkTeamPlaceExist(teamPlaceId);
+
+        Title title = new Title(scheduleRegisterRequest.title());
+        Span span = new Span(scheduleRegisterRequest.startDateTime(), scheduleRegisterRequest.endDateTime());
+        Schedule schedule = new Schedule(null, teamPlaceId, title, span);
+
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+        return savedSchedule.getId();
+    }
+
+    private void checkTeamPlaceExist(final Long teamPlaceId) {
+        if (notExistTeamPlace(teamPlaceId)) {
+            throw new TeamPlaceException.NotFoundException("ID에 해당하는 팀 플레이스를 찾을 수 없습니다.");
+        }
+    }
+
+    private boolean notExistTeamPlace(final Long teamPlaceId) {
+        return !teamPlaceRepository.existsById(teamPlaceId);
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
@@ -22,11 +22,11 @@ public class ScheduleService {
     public Long register(final ScheduleRegisterRequest scheduleRegisterRequest, final Long teamPlaceId) {
         checkTeamPlaceExist(teamPlaceId);
 
-        Title title = new Title(scheduleRegisterRequest.title());
-        Span span = new Span(scheduleRegisterRequest.startDateTime(), scheduleRegisterRequest.endDateTime());
-        Schedule schedule = new Schedule(teamPlaceId, title, span);
+        final Title title = new Title(scheduleRegisterRequest.title());
+        final Span span = new Span(scheduleRegisterRequest.startDateTime(), scheduleRegisterRequest.endDateTime());
+        final Schedule schedule = new Schedule(teamPlaceId, title, span);
 
-        Schedule savedSchedule = scheduleRepository.save(schedule);
+        final Schedule savedSchedule = scheduleRepository.save(schedule);
         return savedSchedule.getId();
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
@@ -24,7 +24,7 @@ public class ScheduleService {
 
         Title title = new Title(scheduleRegisterRequest.title());
         Span span = new Span(scheduleRegisterRequest.startDateTime(), scheduleRegisterRequest.endDateTime());
-        Schedule schedule = new Schedule(null, teamPlaceId, title, span);
+        Schedule schedule = new Schedule(teamPlaceId, title, span);
 
         Schedule savedSchedule = scheduleRepository.save(schedule);
         return savedSchedule.getId();

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/dto/ScheduleRegisterRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/dto/ScheduleRegisterRequest.java
@@ -1,0 +1,18 @@
+package team.teamby.teambyteam.schedule.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+public record ScheduleRegisterRequest(
+        @NotBlank(message = "제목은 빈 값일 수 없습니다.")
+        String title,
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime startDateTime,
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime endDateTime) {
+
+}

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/dto/ScheduleRegisterRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/dto/ScheduleRegisterRequest.java
@@ -1,7 +1,7 @@
 package team.teamby.teambyteam.schedule.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -9,10 +9,10 @@ public record ScheduleRegisterRequest(
         @NotBlank(message = "제목은 빈 값일 수 없습니다.")
         String title,
 
-        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime startDateTime,
 
-        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime endDateTime) {
 
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
@@ -26,7 +26,7 @@ public class Span {
         this.endDateTime = endDateTime;
     }
 
-    private void validateDateTimeOrder(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    private void validateDateTimeOrder(final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
         if (startDateTime.isAfter(endDateTime)) {
             throw new ScheduleException.SpanWrongOrderException("시작 일자가 종료 일자보다 이후일 수 없습니다.");
         }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
@@ -3,15 +3,14 @@ package team.teamby.teambyteam.schedule.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
 
 import java.time.LocalDateTime;
 
 @Embeddable
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Span {
 
@@ -20,4 +19,16 @@ public class Span {
 
     @Column(nullable = false)
     private LocalDateTime endDateTime;
+
+    public Span(final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        validateDateTimeOrder(startDateTime, endDateTime);
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+    }
+
+    private void validateDateTimeOrder(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        if (startDateTime.isAfter(endDateTime)) {
+            throw new ScheduleException.SpanWrongOrderException("시작 일자가 종료 일자보다 이후일 수 없습니다.");
+        }
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
@@ -1,0 +1,14 @@
+package team.teamby.teambyteam.schedule.exception;
+
+public class ScheduleException extends RuntimeException {
+
+    public ScheduleException(final String message) {
+        super(message);
+    }
+
+    public static class SpanWrongOrderException extends ScheduleException {
+        public SpanWrongOrderException(final String message) {
+            super(message);
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/ScheduleController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/ScheduleController.java
@@ -22,11 +22,11 @@ public class ScheduleController {
 
     @PostMapping("/{teamPlaceId}/calendar/schedules")
     public ResponseEntity<Void> register(
-            @RequestBody @Valid ScheduleRegisterRequest scheduleRegisterRequest,
-            @PathVariable Long teamPlaceId) {
+            @RequestBody @Valid final ScheduleRegisterRequest scheduleRegisterRequest,
+            @PathVariable final Long teamPlaceId) {
 
-        Long registeredId = scheduleService.register(scheduleRegisterRequest, teamPlaceId);
-        URI location = URI.create("/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId);
+        final Long registeredId = scheduleService.register(scheduleRegisterRequest, teamPlaceId);
+        final URI location = URI.create("/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId);
         return ResponseEntity.created(location).build();
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/ScheduleController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/ScheduleController.java
@@ -1,0 +1,32 @@
+package team.teamby.teambyteam.schedule.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import team.teamby.teambyteam.schedule.application.ScheduleService;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+
+import java.net.URI;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/team-place")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping("/{teamPlaceId}/calendar/schedules")
+    public ResponseEntity<Void> register(
+            @RequestBody @Valid ScheduleRegisterRequest scheduleRegisterRequest,
+            @PathVariable Long teamPlaceId) {
+
+        Long registeredId = scheduleService.register(scheduleRegisterRequest, teamPlaceId);
+        URI location = URI.create("/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId);
+        return ResponseEntity.created(location).build();
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceRepository.java
@@ -3,4 +3,6 @@ package team.teamby.teambyteam.teamplace.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamPlaceRepository extends JpaRepository<TeamPlace, Long> {
+
+    boolean existsById(Long id);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/exception/TeamPlaceException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/exception/TeamPlaceException.java
@@ -11,4 +11,11 @@ public class TeamPlaceException extends RuntimeException {
             super(message);
         }
     }
+
+    public static class NotFoundException extends TeamPlaceException {
+
+        public NotFoundException(final String message) {
+            super(message);
+        }
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
@@ -1,0 +1,27 @@
+package team.teamby.teambyteam.fixtures;
+
+import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+import team.teamby.teambyteam.schedule.domain.Schedule;
+import team.teamby.teambyteam.schedule.domain.Span;
+import team.teamby.teambyteam.schedule.domain.Title;
+
+import java.time.LocalDateTime;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class ScheduleFixtures {
+
+    public static class 팀플_1번_N시간_일정 {
+
+        public static final Long ID = 1L;
+        public static final String TITLE = "1번 팀플 N시간 일정";
+        public static final Long TEAM_PLACE_ID = 1L;
+        public static final LocalDateTime START_DATE_TIME = LocalDateTime.of(2023, 7, 12, 10, 0, 0);
+        public static final LocalDateTime END_DATE_TIME = LocalDateTime.of(2023, 7, 12, 18, 0, 0);
+
+        public static final ScheduleRegisterRequest REQUEST = new ScheduleRegisterRequest(TITLE, START_DATE_TIME, END_DATE_TIME);
+
+        public static Schedule ENTITY() {
+            return new Schedule(ID, TEAM_PLACE_ID, new Title(TITLE), new Span(START_DATE_TIME, END_DATE_TIME));
+        }
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -5,20 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.jdbc.Sql;
+import team.teamby.teambyteam.common.AcceptanceTest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 
 import java.util.HashMap;
@@ -27,11 +23,8 @@ import java.util.Map;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static team.teamby.teambyteam.fixtures.ScheduleFixtures.팀플_1번_N시간_일정;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @SuppressWarnings("NonAsciiCharacters")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@Sql({"/h2-reset-pk.sql", "/h2-data.sql"})
-public class ScheduleAcceptanceTest {
+public class ScheduleAcceptanceTest extends AcceptanceTest {
 
     private static final String JWT_PREFIX = "Bearer ";
     private static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZW1haWwiOiJhYmNkQGdtYWlsLmNvbSIsImlhdCI6MTUxNjIzOTAyMn0.2Amns5eXoGSqLw5KW-i22lH3S85-wfNd3j6Zs2z2Fg4";
@@ -41,14 +34,6 @@ public class ScheduleAcceptanceTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @LocalServerPort
-    private int port;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
 
     @Nested
     @DisplayName("일정 등록 시")

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -55,22 +55,6 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
             });
         }
 
-        @Test
-        @DisplayName("일정 등록에 성공한다.")
-        void success2() {
-            // given
-            Long teamPlaceId = 팀플_1번_N시간_일정.TEAM_PLACE_ID;
-
-            // when
-            ExtractableResponse<Response> 정상_일정_등록_요청 = 일정_등록_요청(teamPlaceId, 팀플_1번_N시간_일정.REQUEST);
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(정상_일정_등록_요청.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-                softly.assertThat(정상_일정_등록_요청.header(HttpHeaders.LOCATION)).contains("/api/team-place/" + teamPlaceId + "/calendar/schedules/");
-            });
-        }
-
         @ParameterizedTest
         @ValueSource(strings = {"", " ", "    "})
         @DisplayName("일정 제목이 빈 값인 요청이면 실패한다.")

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -1,0 +1,167 @@
+package team.teamby.teambyteam.schedule.acceptance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static team.teamby.teambyteam.fixtures.ScheduleFixtures.팀플_1번_N시간_일정;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SuppressWarnings("NonAsciiCharacters")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Sql({"/h2-reset-pk.sql", "/h2-data.sql"})
+public class ScheduleAcceptanceTest {
+
+    private static final String JWT_PREFIX = "Bearer ";
+    private static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZW1haWwiOiJhYmNkQGdtYWlsLmNvbSIsImlhdCI6MTUxNjIzOTAyMn0.2Amns5eXoGSqLw5KW-i22lH3S85-wfNd3j6Zs2z2Fg4";
+    private static final String REQUEST_TITLE_KEY = "title";
+    private static final String REQUEST_START_DATE_TIME_KEY = "startDateTime";
+    private static final String REQUEST_END_DATE_KEY = "endDateTime";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    @DisplayName("일정 등록 시")
+    class registerSchedule {
+
+        @Test
+        @DisplayName("일정 등록에 성공한다.")
+        void success() {
+            // given
+            Long teamPlaceId = 팀플_1번_N시간_일정.TEAM_PLACE_ID;
+
+            // when
+            ExtractableResponse<Response> 정상_일정_등록_요청 = 일정_등록_요청(teamPlaceId, 팀플_1번_N시간_일정.REQUEST);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(정상_일정_등록_요청.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+                softly.assertThat(정상_일정_등록_요청.header(HttpHeaders.LOCATION)).contains("/api/team-place/" + teamPlaceId + "/calendar/schedules/");
+            });
+        }
+
+        @Test
+        @DisplayName("일정 등록에 성공한다.")
+        void success2() {
+            // given
+            Long teamPlaceId = 팀플_1번_N시간_일정.TEAM_PLACE_ID;
+
+            // when
+            ExtractableResponse<Response> 정상_일정_등록_요청 = 일정_등록_요청(teamPlaceId, 팀플_1번_N시간_일정.REQUEST);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(정상_일정_등록_요청.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+                softly.assertThat(정상_일정_등록_요청.header(HttpHeaders.LOCATION)).contains("/api/team-place/" + teamPlaceId + "/calendar/schedules/");
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "    "})
+        @DisplayName("일정 제목이 빈 값인 요청이면 실패한다.")
+        void failBlankTitleRequest(String blankTitle) {
+            // given
+            Long teamPlaceId = 팀플_1번_N시간_일정.TEAM_PLACE_ID;
+            ScheduleRegisterRequest request = new ScheduleRegisterRequest(blankTitle, 팀플_1번_N시간_일정.START_DATE_TIME, 팀플_1번_N시간_일정.END_DATE_TIME);
+
+            // when
+            ExtractableResponse<Response> 일정_제목_빈_값_일정_등록_요청 = 일정_등록_요청(teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(일정_제목_빈_값_일정_등록_요청.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(일정_제목_빈_값_일정_등록_요청.body().asString()).isEqualTo("제목은 빈 값일 수 없습니다.");
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"2023-07-12 10-00", "2023:07:12 10:00", "2023-07-1210:10", "2023:07:12 10-00", "2023-07-12 10:00:00"})
+        @DisplayName("잘못된 날짜 형식 요청이면 실패한다.")
+        void failWrongDateTimeTypeRequest(String wrongStartDateTimeType) throws JsonProcessingException {
+            // given
+            Long teamPlaceId = 팀플_1번_N시간_일정.TEAM_PLACE_ID;
+            String title = 팀플_1번_N시간_일정.TITLE;
+            String correctEndDateTimeType = "2023-07-12 18:00";
+
+            Map<String, String> requestMap = new HashMap<>();
+            requestMap.put(REQUEST_TITLE_KEY, title);
+            requestMap.put(REQUEST_START_DATE_TIME_KEY, wrongStartDateTimeType);
+            requestMap.put(REQUEST_END_DATE_KEY, correctEndDateTimeType);
+
+            // when
+            ExtractableResponse<Response> 잘못된_날짜_형식_일정_등록_요청 = 잘못된_날짜_형식_일정_등록_요청(teamPlaceId, requestMap);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(잘못된_날짜_형식_일정_등록_요청.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(잘못된_날짜_형식_일정_등록_요청.body().asString()).isEqualTo("DateTime 형식이 잘못되었습니다. 서버 관리자에게 문의해주세요.");
+            });
+        }
+
+        @Test
+        @DisplayName("없는 팀 플레이스 ID로 요청하면 실패한다.")
+        void failNotExistTeamPlaceIdRequest() {
+            // given
+            Long notExistTeamPlaceId = -1L;
+
+            // when
+            ExtractableResponse<Response> 없는_팀_플레이스_ID_일정_등록_요청 = 일정_등록_요청(notExistTeamPlaceId, 팀플_1번_N시간_일정.REQUEST);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(없는_팀_플레이스_ID_일정_등록_요청.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+                softly.assertThat(없는_팀_플레이스_ID_일정_등록_요청.body().asString()).isEqualTo("ID에 해당하는 팀 플레이스를 찾을 수 없습니다.");
+            });
+        }
+    }
+
+    private ExtractableResponse<Response> 일정_등록_요청(final Long teamPlaceId, ScheduleRegisterRequest request) {
+        return RestAssured.given().log().all()
+                .header("Authorization", JWT_PREFIX + JWT_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 잘못된_날짜_형식_일정_등록_요청(final Long teamPlaceId, Map<String, String> requestMap) throws JsonProcessingException {
+        return RestAssured.given().log().all()
+                .header("Authorization", JWT_PREFIX + JWT_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(objectMapper.writeValueAsString(requestMap))
+                .post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -37,7 +37,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
 
     @Nested
     @DisplayName("일정 등록 시")
-    class registerSchedule {
+    class RegisterSchedule {
 
         @Test
         @DisplayName("일정 등록에 성공한다.")

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -28,7 +28,7 @@ class ScheduleServiceTest {
 
     @Nested
     @DisplayName("일정 등록 시")
-    class registerSchedule {
+    class RegisterSchedule {
 
         @Test
         @DisplayName("일정 등록에 성공한다.")

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -1,0 +1,76 @@
+package team.teamby.teambyteam.schedule.application;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import team.teamby.teambyteam.fixtures.ScheduleFixtures;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+@Sql({"/h2-reset-pk.sql", "/h2-data.sql"})
+class ScheduleServiceTest {
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Nested
+    @DisplayName("일정 등록 시")
+    class registerSchedule {
+
+        @Test
+        @DisplayName("일정 등록에 성공한다.")
+        void success() {
+            // given
+            Long teamPlaceId = 1L;
+            ScheduleRegisterRequest request = ScheduleFixtures.팀플_1번_N시간_일정.REQUEST;
+
+            // when
+            Long registeredId = scheduleService.register(request, teamPlaceId);
+
+            // then
+            Assertions.assertThat(registeredId).isNotNull();
+        }
+
+        @Test
+        @DisplayName("일정 등록 시 Span 순서가 맞지 않으면 예외가 발생한다.")
+        void failSpanWrongOrder() {
+            // given
+            String title = ScheduleFixtures.팀플_1번_N시간_일정.TITLE;
+            Long teamPlaceId = ScheduleFixtures.팀플_1번_N시간_일정.TEAM_PLACE_ID;
+            LocalDateTime startDateTime = ScheduleFixtures.팀플_1번_N시간_일정.START_DATE_TIME;
+            LocalDateTime wrongEndDateTime = ScheduleFixtures.팀플_1번_N시간_일정.START_DATE_TIME.minusDays(1);
+            ScheduleRegisterRequest request = new ScheduleRegisterRequest(title, startDateTime, wrongEndDateTime);
+
+            // when & then
+            assertThatThrownBy(() -> scheduleService.register(request, teamPlaceId))
+                    .isInstanceOf(ScheduleException.SpanWrongOrderException.class)
+                    .hasMessage("시작 일자가 종료 일자보다 이후일 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("일정 등록 시 팀 플레이스 ID에 해당하는 팀 플레이스가 존재하지 않으면 예외가 발생한다.")
+        void failTeamPlaceNotExistById() {
+            // given
+            ScheduleRegisterRequest request = ScheduleFixtures.팀플_1번_N시간_일정.REQUEST;
+            Long notExistTeamPlaceId = -1L;
+
+            // when & then
+            assertThatThrownBy(() -> scheduleService.register(request, notExistTeamPlaceId))
+                    .isInstanceOf(TeamPlaceException.NotFoundException.class)
+                    .hasMessage("ID에 해당하는 팀 플레이스를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/domain/SpanTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/domain/SpanTest.java
@@ -1,0 +1,25 @@
+package team.teamby.teambyteam.schedule.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SpanTest {
+
+    @Test
+    @DisplayName("Span 생성 시 시작일자가 종료일자보다 이후면 예외가 발생한다.")
+    void failSpanWrongRange() {
+        // given
+        LocalDateTime startDateTime = LocalDateTime.now();
+        LocalDateTime endDateTime = LocalDateTime.now().minusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Span(startDateTime, endDateTime))
+                .isInstanceOf(ScheduleException.SpanWrongOrderException.class)
+                .hasMessage("시작 일자가 종료 일자보다 이후일 수 없습니다.");
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceRepositoryTest.java
@@ -1,0 +1,31 @@
+package team.teamby.teambyteam.teamplace.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql(value = {"/h2-reset-pk.sql", "/h2-data.sql"})
+class TeamPlaceRepositoryTest {
+
+    @Autowired
+    private TeamPlaceRepository teamPlaceRepository;
+
+    @ParameterizedTest
+    @CsvSource(value = {"-1:false", "1:true"}, delimiter = ':')
+    @DisplayName("id에 해당하는 팀 플레이스가 존재하면 true, 존재하지 않으면 false를 반환한다.")
+    void isExistById(Long teamPlaceId, boolean expected) {
+        // when
+        boolean actual = teamPlaceRepository.existsById(teamPlaceId);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
# [BE] 일정 추가 기능 구현
## 이슈번호
> #18 

## PR 내용

- 일정 추가(등록) 기능 구현 

- Repository Test : commit(https://github.com/woowacourse-teams/2023-team-by-team/commit/e172724ff6939cf9527af023bbd559445f45dc33)
- Service Test : commit(https://github.com/woowacourse-teams/2023-team-by-team/commit/3c19012cc67744bf2bab113ddf0e2e0a2a9dc319)

- acceptance Test : commit(https://github.com/woowacourse-teams/2023-team-by-team/commit/4c17c936b9e0bb8b02e58ca196758e59a24ca435)

---
###  추가 구현 사항 (특이 사항)

* Span에서 @AllArgsContructor 삭제, 모든 파라미터를 받는 생성자에 검증 로직 추가

* Request로 요청보낸 StartDateTime, EndDateTime의 형식도 검증한다.

* GlobalExceptionHandler 추가 (+ Handle 시 에러 로깅 추가)

* ScheduleFixtures 추가

* Repository 테스트 시 @DataJpaTest + @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

* ServiceTest 시 @nested로 공통 부분 (일정 등록) 추출

* 인수 테스트 예외 네이밍은 `실패한다`로 했음. (예외가 발생한다고 하면 비개발자가 이해하지 못할 수도 있을 것 같아서)


## 참고자료

- 2022 달록팀 코드


## 의논할 거리


