### PR TITLE
[FE] h태그 및 cssProp 스타일 적용안되는 현상 fix

### DIFF
--- a/frontend/src/components/common/Text/Text.styled.ts
+++ b/frontend/src/components/common/Text/Text.styled.ts
@@ -39,9 +39,14 @@ export const Text = styled.p<TextProps>`
   h4& {
     font-size: 24px;
   }
-  &&& {
+  p&,
+  span&,
+  strong&,
+  small& {
     font-size: ${({ size = 'md' }) => fontSize[size] || 'initial'};
     font-weight: ${({ weight = 'normal' }) => fontWeight[weight] || 'initial'};
+  }
+  && {
     ${(props) => props.css}
   }
 `;


### PR DESCRIPTION
# [FE] h태그 및 cssProp 스타일 적용안되는 현상 fix
## 이슈번호
> close #75 
## PR 내용
스타일 우선순위로 인해 h1 태그들의 스타일이 씹히는 현상을 발견,
대응가능한 태그 모두에게 적당한 스타일이 대응가능하도록 변경하고 cssprops의 우선순위를 높임.

## 참고자료

## 의논할 거리
