### PR TITLE
[BE] 멤버 인증 인터셉터 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
@@ -1,17 +1,29 @@
 package team.teamby.teambyteam.global.configuration;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import team.teamby.teambyteam.member.configuration.MemberArgumentResolver;
+import team.teamby.teambyteam.member.configuration.MemberInterceptor;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    private final MemberInterceptor memberInterceptor;
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new MemberArgumentResolver());
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(memberInterceptor)
+                .addPathPatterns("/**");
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 public final class MemberInterceptor implements HandlerInterceptor {
 
     private static final String EMAIL_KEY = "email";
+
     private final MemberRepository memberRepository;
 
     @Override

--- a/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
@@ -1,0 +1,55 @@
+package team.teamby.teambyteam.member.configuration;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.json.JacksonJsonParser;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.vo.Email;
+import team.teamby.teambyteam.member.exception.MemberException;
+
+import java.util.Base64;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public final class MemberInterceptor implements HandlerInterceptor {
+
+    private static final String EMAIL_KEY = "email";
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+        final String token = extractToken(request);
+        if (token == null) {
+            throw new MemberException.IllegalTokenException("잘못된 토큰");
+        }
+        String email = extractEmailFromToken(token);
+        final Optional<Member> member = memberRepository.findByEmail(new Email(email));
+        if (member.isEmpty()) {
+            throw new MemberException.IllegalTokenException("멤버 조회 실패");
+        }
+        return true;
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public String extractEmailFromToken(String token) {
+        final String payLoad = token.split("\\.")[1];
+        final String decodedPayLoad = new String(Base64.getDecoder().decode(payLoad));
+        final JacksonJsonParser jacksonJsonParser = new JacksonJsonParser();
+        return (String) jacksonJsonParser.parseMap(decodedPayLoad)
+                .get(EMAIL_KEY);
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
@@ -26,7 +26,7 @@ public final class MemberInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
         final String token = extractToken(request);
-        String email = extractEmailFromToken(token);
+        final String email = extractEmailFromToken(token);
         if (notExistsByEmail(email)) {
             throw new MemberException.MemberNotFoundException("멤버 조회 실패");
         }
@@ -38,7 +38,7 @@ public final class MemberInterceptor implements HandlerInterceptor {
     }
 
     private String extractToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        final String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX_BEARER)) {
             return bearerToken.substring(PREFIX_BEARER.length());
         }

--- a/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberInterceptor.java
@@ -8,13 +8,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
-import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
 
 import java.util.Base64;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
@@ -29,11 +27,14 @@ public final class MemberInterceptor implements HandlerInterceptor {
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
         final String token = extractToken(request);
         String email = extractEmailFromToken(token);
-        final Optional<Member> member = memberRepository.findByEmail(new Email(email));
-        if (member.isEmpty()) {
+        if (notExistsByEmail(email)) {
             throw new MemberException.MemberNotFoundException("멤버 조회 실패");
         }
         return true;
+    }
+
+    private boolean notExistsByEmail(final String email) {
+        return !memberRepository.existsByEmail(new Email(email));
     }
 
     private String extractToken(HttpServletRequest request) {

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberRepository.java
@@ -1,7 +1,11 @@
 package team.teamby.teambyteam.member.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import team.teamby.teambyteam.member.domain.vo.Email;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    Optional<Member> findByEmail(@Param("email")Email email);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberRepository.java
@@ -4,8 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import team.teamby.teambyteam.member.domain.vo.Email;
 
-import java.util.Optional;
-
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(@Param("email")Email email);
+
+    boolean existsByEmail(@Param("email") Email email);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberException.java
@@ -17,4 +17,16 @@ public class MemberException extends RuntimeException {
             super(message);
         }
     }
+
+    public static class MemberNotFoundException extends MemberException {
+        public MemberNotFoundException(final String message) {
+            super(message);
+        }
+    }
+
+    public static class IllegalTokenException extends MemberException {
+        public IllegalTokenException(final String message) {
+            super(message);
+        }
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberException.java
@@ -24,8 +24,8 @@ public class MemberException extends RuntimeException {
         }
     }
 
-    public static class IllegalTokenException extends MemberException {
-        public IllegalTokenException(final String message) {
+    public static class UnSupportAuthenticationException extends MemberException {
+        public UnSupportAuthenticationException(final String message) {
             super(message);
         }
     }


### PR DESCRIPTION
## 이슈번호
#29 

## PR 내용
인터셉터 사용 경로: 모든 경로
보통 TokenProvider를 빈으로 만들어 토큰 생성(여기서는 상관 없음), 토큰 검증(이때 임의의 키가 들어감), PayLoad에서 필요한 부분 추출(이때도 임의의 키를 이용해 검증을 넣을 수 있음)을 담당하게 하는 것으로 보인다.
하지만 유효성 검증을 하지 않고 인터셉터를 구현하는 것을 목적으로 했기 때문에 내부 private 메서드로 필요 기능을 구현하였다.
1. 헤더에서 “Bearer “ 문자열 제거
2. 1에서 추출된 토큰에서 PayLoad를 분리하고 거기서 email 추출
3. email을 통해 Member를 조회하고 성공하면 정상, 실패하면 예외를 던지도록 구현

## 참고자료

## 의논할 거리
1. 요청할 때마다 MemberRepository를 조회하는 점
2. 커스텀 예외(현재 NotFoundException, IllegalTokenException을 만들어 적당한 때에 throw 중)