### PR TITLE
[BE] 일정 추가 기능 문서화

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -15,7 +15,7 @@ build/
 .sts4-cache
 bin/
 !**/src/main/**/bin/
-!**/src/test/**/bin/가
+!**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
 .idea

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -15,7 +15,7 @@ build/
 .sts4-cache
 bin/
 !**/src/main/**/bin/
-!**/src/test/**/bin/
+!**/src/test/**/bin/가
 
 ### IntelliJ IDEA ###
 .idea
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### REST Docs ###
+src/main/resources/static/docs/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -13,6 +13,7 @@ java {
 }
 
 configurations {
+    asciidoctorExtensions // dependencies 에서 적용한 것 추가
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -38,6 +39,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
     runtimeOnly 'com.h2database:h2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -50,7 +53,24 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
+asciidoctor {
+    configurations 'asciidoctorExtensions'
+    baseDirFollowsSourceFile()
     inputs.dir snippetsDir
     dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+
+    from "${asciidoctor.outputDir}"
+    into file("src/main/resources/static/docs")
+}
+
+bootJar {
+    dependsOn copyDocument
 }

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,26 @@
+= Team-By-Team API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+=== 개요
+우아한테크코스 5기 팀바팀 프로젝트 API 문서입니다.
+
+=== 상태코드 (HttpStatus)
+응답시 다음과 같은 응답상태를 제공합니다.
+
+[cols="3,3"]
+|====
+|HttpStatus |설명
+
+|`OK(200)` |정상 응답
+|`UNAUTHORIZED(401)` |로그인되지 않은 상황에서 요청할 때 발생합니다.
+|`FORBIDDEN(403)` |권한이 없는 요청을 할 때 발생합니다.
+
+|====
+
+== API
+
+include::schedule.adoc[]

--- a/backend/src/docs/asciidoc/schedule.adoc
+++ b/backend/src/docs/asciidoc/schedule.adoc
@@ -1,0 +1,15 @@
+=== 캘린더 일정 API
+캘린더에 일정을 등록 / 조회 / 수정 / 삭제할 수 있습니다.
+
+=== 1. 팀 캘린더 일정 등록
+
+====== 요청 Header
+include::{snippets}/schedules/register/request-headers.adoc[]
+
+==== Request
+include::{snippets}/schedules/register/http-request.adoc[]
+include::{snippets}/schedules/register/request-fields.adoc[]
+
+
+==== Response
+include::{snippets}/schedules/register/http-response.adoc[]

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
@@ -76,8 +76,8 @@ public class ScheduleApiDocsTest {
                                 ),
                                 requestFields(
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("등록할 일정 제목"),
-                                        fieldWithPath("startDateTime").type(JsonFieldType.STRING).description("등록할 일정의 시작 일시"),
-                                        fieldWithPath("endDateTime").type(JsonFieldType.STRING).description("등록할 일정의 종료 일시")
+                                        fieldWithPath("startDateTime").type(JsonFieldType.STRING).description("등록할 일정의 시작 일시(형식 : yyyy-MM-dd HH:mm)"),
+                                        fieldWithPath("endDateTime").type(JsonFieldType.STRING).description("등록할 일정의 종료 일시(형식 : yyyy-MM-dd HH:mm)")
                                 )
                         )
                 );

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
@@ -1,0 +1,85 @@
+package team.teamby.teambyteam.schedule.docs;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import team.teamby.teambyteam.schedule.application.ScheduleService;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+import team.teamby.teambyteam.schedule.presentation.ScheduleController;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static team.teamby.teambyteam.fixtures.ScheduleFixtures.팀플_1번_N시간_일정;
+
+@AutoConfigureRestDocs
+@WebMvcTest(ScheduleController.class)
+public class ScheduleApiDocsTest {
+
+    private static final String AUTHORIZATION_HEADER_KEY = HttpHeaders.AUTHORIZATION;
+    private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaa.bbbb.cccc";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("일정 등록 문서화")
+    void registerScheduleDocs() throws Exception {
+        // given
+        final ScheduleRegisterRequest request = 팀플_1번_N시간_일정.REQUEST;
+        final Long teamPlaceId = 팀플_1번_N시간_일정.TEAM_PLACE_ID;
+        final Long registeredId = 1L;
+        given(scheduleService.register(request, teamPlaceId))
+                .willReturn(registeredId);
+
+        // when & then
+        mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                        .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId))
+                .andDo(print())
+                .andDo(document("schedules/register",
+                                preprocessRequest(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("teamPlaceId").description("멤버가 속한 팀 플레이스 ID")
+                                ),
+                                requestHeaders(
+                                        headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
+                                ),
+                                requestFields(
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("등록할 일정 제목"),
+                                        fieldWithPath("startDateTime").type(JsonFieldType.STRING).description("등록할 일정의 시작 일시"),
+                                        fieldWithPath("endDateTime").type(JsonFieldType.STRING).description("등록할 일정의 종료 일시")
+                                )
+                        )
+                );
+    }
+}


### PR DESCRIPTION
# [BE] 일정 추가 기능 문서화
## 이슈번호
> #81 

## PR 내용

- 일정 추가 기능 문서화

## 참고자료

> RestDocs 문서화 참고 자료

* Spring Rest Docs 공식 문서
https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/

* 우아한형제들 기술 블로그 - Spring Rest Docs 적용
https://techblog.woowahan.com/2597/

* 기타 블로그 - Spring REST Docs 적용 및 최적화하기 (굉장히 자세히 나와있음, 나중에 최적화도 이거 보고 할 수 있을듯?)
https://techblog.woowahan.com/2597/


## 의논할 거리
