### PR TITLE
[FE] Pretendard 폰트를 추가하고, 기본 폰트로 적용되도록 수정

### DIFF
--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+/>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
     <title>팀바팀</title>
   </head>
   <body>

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -9,8 +9,15 @@ const GlobalStyle = createGlobalStyle`
   }
 
   body {
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Open Sans', 'Helvetica Neue', sans-serif;
     color: ${theme.color.BLACK}
+  }
+  
+  body,
+  input,
+  select,
+  textarea,
+  button {
+    font-family: 'Pretendard', system-ui, -apple-system, BlinkMacSystemFont, 'Open Sans', 'Helvetica Neue', sans-serif;
   }
 
   body:has([role="dialog"]) {


### PR DESCRIPTION
## 이슈번호
> #83 

## PR 내용
본 PR에서는 프론트엔드 프로젝트에 `Pretendard` 폰트를 추가하고, 기본 폰트로 `Pretendard` 가 적용되도록 글로벌 스타일을 수정하였다.

## 적용 스크린샷
폰트를 적용하는 확장 프로그램 없이도 폰트가 스토리북에서 적용된 것을 확인할 수 있을 것이다.
<img src="https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/e4cc4777-20e0-4577-b943-104d2701d093" width="350px" />

## 의논할 거리
- 이 폰트를 적용할 경우 굵은 폰트와 얇은 폰트 간의 차이가 두드러진다. `Text` 컴포넌트의 `font-weight` 를 필요에 따라 바꾸는 것을 고려해 보면 좋을 것 같다.