### PR TITLE
[FE] 일정 등록 모달 UI 구현

### DIFF
--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Modal from '../common/Modal/Modal';
 import Button from '../common/Button/Button';
 import { useModal } from '~/hooks/useModal';
 import ScheduleAddModal from './ScheduleAddModal';

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Modal from '../common/Modal/Modal';
+import Button from '../common/Button/Button';
+import { useModal } from '~/hooks/useModal';
+import ScheduleAddModal from './ScheduleAddModal';
+
+/**
+ * `ScheduleAddModal` 컴포넌트는 일정 등록을 위한 폼을 포함하고 있는 모달 컴포넌트입니다.
+ */
+const meta = {
+  title: 'ScheduleAddModal',
+  component: ScheduleAddModal,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ScheduleAddModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const { openModal } = useModal();
+
+    return (
+      <>
+        <Button onClick={openModal}>모달 열기</Button>
+        <ScheduleAddModal teamPlaceLabel="Woowacourse TeamByTeam Corporation" />
+      </>
+    );
+  },
+  args: {
+    teamPlaceLabel: '',
+  },
+};

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
@@ -23,11 +23,11 @@ export const Default: Story = {
     return (
       <>
         <Button onClick={openModal}>모달 열기</Button>
-        <ScheduleAddModal teamPlaceLabel="Woowacourse TeamByTeam Corporation" />
+        <ScheduleAddModal teamPlaceName="Woowacourse TeamByTeam Corporation" />
       </>
     );
   },
   args: {
-    teamPlaceLabel: '',
+    teamPlaceName: '',
   },
 };

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
@@ -1,6 +1,4 @@
-import { styled } from 'styled-components';
-import Button from '~/components/common/Button/Button';
-import Text from '~/components/common/Text/Text';
+import { styled, css } from 'styled-components';
 
 interface InputProps {
   width: string;
@@ -46,17 +44,20 @@ export const Header = styled.div`
   border-bottom: ${({ theme }) => `1px solid ${theme.color.GRAY300}`};
 `;
 
-export const CloseButton = styled(Button)`
+export const closeButtonStyles = css`
   width: 22px;
   height: 38px;
   padding: 8px 0;
 `;
 
-export const TitleInput = styled.input`
+export const TitleWrapper = styled.div`
   width: 100%;
   height: 51px;
-  padding: 10px 20px;
   margin-bottom: 28px;
+`;
+
+export const titleStyles = css`
+  padding: 10px 20px;
 
   border: none;
   border-radius: 10px;
@@ -65,7 +66,7 @@ export const TitleInput = styled.input`
   font-size: 24px;
 `;
 
-export const TimeSelectMenu = styled.div`
+export const TimeSelectContainer = styled.div`
   display: flex;
   align-items: center;
 
@@ -88,7 +89,7 @@ export const Input = styled.input<InputProps>`
   font-size: 14px;
 `;
 
-export const TeamLabel = styled.div`
+export const TeamNameContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 5px;
@@ -105,7 +106,7 @@ export const Circle = styled.div`
   background-color: ${({ theme }) => theme.color.PRIMARY};
 `;
 
-export const TeamPlaceLabelText = styled(Text)`
+export const teamPlaceNameStyles = css`
   overflow: hidden;
 
   max-width: 250px;
@@ -114,7 +115,7 @@ export const TeamPlaceLabelText = styled(Text)`
   white-space: nowrap;
 `;
 
-export const ButtonMenu = styled.div`
+export const ControlButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
 

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
@@ -1,0 +1,129 @@
+import { styled } from 'styled-components';
+import Button from '~/components/common/Button/Button';
+import Text from '~/components/common/Text/Text';
+
+interface InputProps {
+  width: string;
+  marginright?: string;
+}
+
+export const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+export const Container = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+
+  width: 496px;
+  height: 386px;
+  padding: 20px 30px;
+
+  border-radius: 10px;
+  box-shadow:
+    0 0 1px #1b1d1f33,
+    0 15px 25px #1b1d1f33,
+    0 5px 10px #1b1d1f1f;
+  background-color: ${({ theme }) => theme.color.WHITE};
+`;
+
+export const Header = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  width: 100%;
+  height: 38px;
+  margin-bottom: 22px;
+
+  border-bottom: ${({ theme }) => `1px solid ${theme.color.GRAY300}`};
+`;
+
+export const CloseButton = styled(Button)`
+  width: 22px;
+  height: 38px;
+  padding: 8px 0;
+`;
+
+export const TitleInput = styled.input`
+  width: 100%;
+  height: 51px;
+  padding: 10px 20px;
+  margin-bottom: 28px;
+
+  border: none;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.color.GRAY200};
+
+  font-size: 24px;
+`;
+
+export const TimeSelectMenu = styled.div`
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  height: 40px;
+  margin-bottom: 28px;
+
+  column-gap: 10px;
+`;
+
+export const Input = styled.input<InputProps>`
+  width: ${({ width }) => width};
+  height: 40px;
+  padding: 6px;
+  margin-right: ${({ marginright }) => marginright};
+
+  border: 1px solid ${({ theme }) => theme.color.GRAY200};
+
+  text-align: center;
+  font-size: 14px;
+`;
+
+export const TeamLabel = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+
+  width: 100%;
+  height: 23px;
+`;
+
+export const Circle = styled.div`
+  width: 23px;
+  height: 23px;
+
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.color.PRIMARY};
+`;
+
+export const TeamPlaceLabelText = styled(Text)`
+  overflow: hidden;
+
+  max-width: 250px;
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const ButtonMenu = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  width: 100%;
+  height: 40px;
+`;
+
+/* TODO: 체크박스 공통 컴포넌트 구현 후 이 컴포넌트를 교체 */
+export const CheckBox = styled.input`
+  width: 25px;
+  height: 25px;
+`;

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
@@ -1,10 +1,5 @@
 import { styled, css } from 'styled-components';
 
-interface InputProps {
-  width: string;
-  marginright?: string;
-}
-
 export const Backdrop = styled.div`
   position: fixed;
   top: 0;
@@ -44,26 +39,10 @@ export const Header = styled.div`
   border-bottom: ${({ theme }) => `1px solid ${theme.color.GRAY300}`};
 `;
 
-export const closeButtonStyles = css`
-  width: 22px;
-  height: 38px;
-  padding: 8px 0;
-`;
-
 export const TitleWrapper = styled.div`
   width: 100%;
   height: 51px;
   margin-bottom: 28px;
-`;
-
-export const titleStyles = css`
-  padding: 10px 20px;
-
-  border: none;
-  border-radius: 10px;
-  background-color: ${({ theme }) => theme.color.GRAY200};
-
-  font-size: 24px;
 `;
 
 export const TimeSelectContainer = styled.div`
@@ -75,12 +54,6 @@ export const TimeSelectContainer = styled.div`
   margin-bottom: 28px;
 
   column-gap: 10px;
-`;
-
-export const dateTimeLocalInputStyles = css`
-  margin-right: 30px;
-
-  text-align: center;
 `;
 
 export const TeamNameContainer = styled.div`
@@ -100,15 +73,6 @@ export const Circle = styled.div`
   background-color: ${({ theme }) => theme.color.PRIMARY};
 `;
 
-export const teamPlaceNameStyles = css`
-  overflow: hidden;
-
-  max-width: 250px;
-
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
 export const ControlButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -121,4 +85,35 @@ export const ControlButtonWrapper = styled.div`
 export const CheckBox = styled.input`
   width: 25px;
   height: 25px;
+`;
+
+export const title = css`
+  padding: 10px 20px;
+
+  border: none;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.color.GRAY200};
+
+  font-size: 24px;
+`;
+
+export const closeButton = css`
+  width: 22px;
+  height: 38px;
+  padding: 8px 0;
+`;
+
+export const dateTimeLocalInput = css`
+  margin-right: 30px;
+
+  text-align: center;
+`;
+
+export const teamPlaceName = css`
+  overflow: hidden;
+
+  max-width: 250px;
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
@@ -77,16 +77,10 @@ export const TimeSelectContainer = styled.div`
   column-gap: 10px;
 `;
 
-export const Input = styled.input<InputProps>`
-  width: ${({ width }) => width};
-  height: 40px;
-  padding: 6px;
-  margin-right: ${({ marginright }) => marginright};
-
-  border: 1px solid ${({ theme }) => theme.color.GRAY200};
+export const dateTimeLocalInputStyles = css`
+  margin-right: 30px;
 
   text-align: center;
-  font-size: 14px;
 `;
 
 export const TeamNameContainer = styled.div`

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -42,8 +42,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
           <Text size="xxl" weight="bold">
             일정 시작
           </Text>
-          <S.Input type="date" width="100px" />
-          <S.Input width="80px" marginright="40px" />
+          <S.Input type="datetime-local" width="220px" />
           <Text size="xxl" weight="bold">
             종일
           </Text>
@@ -53,8 +52,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
           <Text size="xxl" weight="bold">
             일정 마감
           </Text>
-          <S.Input type="date" width="100px" />
-          <S.Input width="80px" />
+          <S.Input type="datetime-local" width="220px" />
         </S.TimeSelectContainer>
         <S.TeamNameContainer>
           <S.Circle title={teamPlaceLabel} />

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -1,8 +1,8 @@
 import * as S from './ScheduleAddModal.styled';
-import Modal from '~/components/common/Modal/Modal';
 import { useModal } from '~/hooks/useModal';
-import Text from '../common/Text/Text';
 import { CloseIcon } from '~/assets/svg';
+import Modal from '~/components/common/Modal/Modal';
+import Text from '../common/Text/Text';
 import Button from '../common/Button/Button';
 
 interface ScheduleAddModalProps {
@@ -24,28 +24,26 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
         </S.Header>
         <S.TitleInput placeholder="일정 제목" />
         <S.TimeSelectMenu>
-          <Text as="p" size="xxl" weight="bold">
+          <Text size="xxl" weight="bold">
             일정 시작
           </Text>
           <S.Input type="date" width="100px" />
           <S.Input width="80px" marginright="40px" />
-          <Text as="p" size="xxl" weight="bold">
+          <Text size="xxl" weight="bold">
             종일
           </Text>
           <S.CheckBox type="checkbox" />
         </S.TimeSelectMenu>
         <S.TimeSelectMenu>
-          <Text as="p" size="xxl" weight="bold">
+          <Text size="xxl" weight="bold">
             일정 마감
           </Text>
           <S.Input type="date" width="100px" />
           <S.Input width="80px" />
         </S.TimeSelectMenu>
         <S.TeamLabel>
-          <S.Circle />
-          <S.TeamPlaceLabelText as="p" size="md" title={teamPlaceLabel}>
-            {teamPlaceLabel}
-          </S.TeamPlaceLabelText>
+          <S.Circle title={teamPlaceLabel} />
+          <S.TeamPlaceLabelText>{teamPlaceLabel}</S.TeamPlaceLabelText>
         </S.TeamLabel>
         <S.ButtonMenu>
           <Button variant="primary" onClick={closeModal}>

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -7,11 +7,11 @@ import Button from '../common/Button/Button';
 import Input from '../common/Input/Input';
 
 interface ScheduleAddModalProps {
-  teamPlaceLabel: string;
+  teamPlaceName: string;
 }
 
 const ScheduleAddModal = (props: ScheduleAddModalProps) => {
-  const { teamPlaceLabel } = props;
+  const { teamPlaceName } = props;
   const { closeModal } = useModal();
 
   return (
@@ -64,9 +64,9 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             css={S.dateTimeLocalInputStyles}
           />
         </S.TimeSelectContainer>
-        <S.TeamNameContainer>
-          <S.Circle title={teamPlaceLabel} />
-          <Text css={S.teamPlaceNameStyles}>{teamPlaceLabel}</Text>
+        <S.TeamNameContainer title={teamPlaceName}>
+          <S.Circle />
+          <Text css={S.teamPlaceNameStyles}>{teamPlaceName}</Text>
         </S.TeamNameContainer>
         <S.ControlButtonWrapper>
           <Button variant="primary" onClick={closeModal}>

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -42,7 +42,12 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
           <Text size="xxl" weight="bold">
             일정 시작
           </Text>
-          <S.Input type="datetime-local" width="220px" />
+          <Input
+            width="220px"
+            height="40px"
+            type="datetime-local"
+            css={S.dateTimeLocalInputStyles}
+          />
           <Text size="xxl" weight="bold">
             종일
           </Text>
@@ -52,7 +57,12 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
           <Text size="xxl" weight="bold">
             일정 마감
           </Text>
-          <S.Input type="datetime-local" width="220px" />
+          <Input
+            width="220px"
+            height="40px"
+            type="datetime-local"
+            css={S.dateTimeLocalInputStyles}
+          />
         </S.TimeSelectContainer>
         <S.TeamNameContainer>
           <S.Circle title={teamPlaceLabel} />

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -4,6 +4,7 @@ import { CloseIcon } from '~/assets/svg';
 import Modal from '~/components/common/Modal/Modal';
 import Text from '../common/Text/Text';
 import Button from '../common/Button/Button';
+import Input from '../common/Input/Input';
 
 interface ScheduleAddModalProps {
   teamPlaceLabel: string;
@@ -18,17 +19,26 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
       <S.Backdrop onClick={closeModal} />
       <S.Container>
         <S.Header>
-          <S.CloseButton
+          <Button
             variant="plain"
             type="button"
             onClick={closeModal}
+            css={S.closeButtonStyles}
             aria-label="닫기"
           >
             <CloseIcon />
-          </S.CloseButton>
+          </Button>
         </S.Header>
-        <S.TitleInput placeholder="일정 제목" />
-        <S.TimeSelectMenu>
+        <S.TitleWrapper>
+          <Input
+            width="100%"
+            height="100%"
+            placeholder="일정 제목"
+            css={S.titleStyles}
+          />
+        </S.TitleWrapper>
+
+        <S.TimeSelectContainer>
           <Text size="xxl" weight="bold">
             일정 시작
           </Text>
@@ -38,23 +48,23 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             종일
           </Text>
           <S.CheckBox type="checkbox" />
-        </S.TimeSelectMenu>
-        <S.TimeSelectMenu>
+        </S.TimeSelectContainer>
+        <S.TimeSelectContainer>
           <Text size="xxl" weight="bold">
             일정 마감
           </Text>
           <S.Input type="date" width="100px" />
           <S.Input width="80px" />
-        </S.TimeSelectMenu>
-        <S.TeamLabel>
+        </S.TimeSelectContainer>
+        <S.TeamNameContainer>
           <S.Circle title={teamPlaceLabel} />
-          <S.TeamPlaceLabelText>{teamPlaceLabel}</S.TeamPlaceLabelText>
-        </S.TeamLabel>
-        <S.ButtonMenu>
+          <Text css={S.teamPlaceNameStyles}>{teamPlaceLabel}</Text>
+        </S.TeamNameContainer>
+        <S.ControlButtonWrapper>
           <Button variant="primary" onClick={closeModal}>
             등록
           </Button>
-        </S.ButtonMenu>
+        </S.ControlButtonWrapper>
       </S.Container>
     </Modal>
   );

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -1,0 +1,60 @@
+import * as S from './ScheduleAddModal.styled';
+import Modal from '~/components/common/Modal/Modal';
+import { useModal } from '~/hooks/useModal';
+import Text from '../common/Text/Text';
+import { CloseIcon } from '~/assets/svg';
+import Button from '../common/Button/Button';
+
+interface ScheduleAddModalProps {
+  teamPlaceLabel: string;
+}
+
+const ScheduleAddModal = (props: ScheduleAddModalProps) => {
+  const { teamPlaceLabel } = props;
+  const { closeModal } = useModal();
+
+  return (
+    <Modal>
+      <S.Backdrop onClick={closeModal} />
+      <S.Container>
+        <S.Header>
+          <S.CloseButton variant="plain" type="button" onClick={closeModal}>
+            <CloseIcon aria-label="닫기" />
+          </S.CloseButton>
+        </S.Header>
+        <S.TitleInput placeholder="일정 제목" />
+        <S.TimeSelectMenu>
+          <Text as="p" size="xxl" weight="bold">
+            일정 시작
+          </Text>
+          <S.Input type="datetime-local" width="100px" />
+          <S.Input width="80px" marginright="40px" />
+          <Text as="p" size="xxl" weight="bold">
+            종일
+          </Text>
+          <S.CheckBox type="checkbox" />
+        </S.TimeSelectMenu>
+        <S.TimeSelectMenu>
+          <Text as="p" size="xxl" weight="bold">
+            일정 마감
+          </Text>
+          <S.Input type="datetime-local" width="100px" />
+          <S.Input width="80px" />
+        </S.TimeSelectMenu>
+        <S.TeamLabel>
+          <S.Circle />
+          <S.TeamPlaceLabelText as="p" size="md" title={teamPlaceLabel}>
+            {teamPlaceLabel}
+          </S.TeamPlaceLabelText>
+        </S.TeamLabel>
+        <S.ButtonMenu>
+          <Button variant="primary" onClick={closeModal}>
+            등록
+          </Button>
+        </S.ButtonMenu>
+      </S.Container>
+    </Modal>
+  );
+};
+
+export default ScheduleAddModal;

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -23,7 +23,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             variant="plain"
             type="button"
             onClick={closeModal}
-            css={S.closeButtonStyles}
+            css={S.closeButton}
             aria-label="닫기"
           >
             <CloseIcon />
@@ -34,7 +34,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             width="100%"
             height="100%"
             placeholder="일정 제목"
-            css={S.titleStyles}
+            css={S.title}
           />
         </S.TitleWrapper>
 
@@ -46,7 +46,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             width="220px"
             height="40px"
             type="datetime-local"
-            css={S.dateTimeLocalInputStyles}
+            css={S.dateTimeLocalInput}
           />
           <Text size="xxl" weight="bold">
             종일
@@ -61,12 +61,12 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             width="220px"
             height="40px"
             type="datetime-local"
-            css={S.dateTimeLocalInputStyles}
+            css={S.dateTimeLocalInput}
           />
         </S.TimeSelectContainer>
         <S.TeamNameContainer title={teamPlaceName}>
           <S.Circle />
-          <Text css={S.teamPlaceNameStyles}>{teamPlaceName}</Text>
+          <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
         </S.TeamNameContainer>
         <S.ControlButtonWrapper>
           <Button variant="primary" onClick={closeModal}>

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -18,8 +18,13 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
       <S.Backdrop onClick={closeModal} />
       <S.Container>
         <S.Header>
-          <S.CloseButton variant="plain" type="button" onClick={closeModal}>
-            <CloseIcon aria-label="닫기" />
+          <S.CloseButton
+            variant="plain"
+            type="button"
+            onClick={closeModal}
+            aria-label="닫기"
+          >
+            <CloseIcon />
           </S.CloseButton>
         </S.Header>
         <S.TitleInput placeholder="일정 제목" />

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -27,7 +27,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
           <Text as="p" size="xxl" weight="bold">
             일정 시작
           </Text>
-          <S.Input type="datetime-local" width="100px" />
+          <S.Input type="date" width="100px" />
           <S.Input width="80px" marginright="40px" />
           <Text as="p" size="xxl" weight="bold">
             종일
@@ -38,7 +38,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
           <Text as="p" size="xxl" weight="bold">
             일정 마감
           </Text>
-          <S.Input type="datetime-local" width="100px" />
+          <S.Input type="date" width="100px" />
           <S.Input width="80px" />
         </S.TimeSelectMenu>
         <S.TeamLabel>

--- a/frontend/src/components/common/Input/Input.stories.tsx
+++ b/frontend/src/components/common/Input/Input.stories.tsx
@@ -1,0 +1,24 @@
+import Input from './Input';
+import type { Meta, StoryObj } from '@storybook/react';
+
+/**
+ * `Input` 은 공용 인풋 컴포넌트입니다.
+ *
+ * <b>이 컴포넌트는 확정되지 않은 임시 공용 컴포넌트입니다. 추후 컴포넌트의 재작성이 필요합니다.</b>
+ */
+const meta = {
+  title: 'common/Input',
+  component: Input,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    width: '200px',
+    height: '50px',
+    placeholder: '예시 인풋입니다',
+  },
+};

--- a/frontend/src/components/common/Input/Input.stories.tsx
+++ b/frontend/src/components/common/Input/Input.stories.tsx
@@ -17,8 +17,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    width: '200px',
-    height: '50px',
+    width: '150px',
+    height: '40px',
     placeholder: '예시 인풋입니다',
   },
 };

--- a/frontend/src/components/common/Input/Input.styled.ts
+++ b/frontend/src/components/common/Input/Input.styled.ts
@@ -4,12 +4,11 @@ import type { InputProps } from './Input';
 export const Input = styled.input<InputProps>`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
-  padding: 10px 20px;
+  padding: 6px;
 
   border: 1px solid ${({ theme }) => theme.color.GRAY200};
-  border-radius: 10px;
 
-  font-size: 16px;
+  font-size: 14px;
 
   && {
     ${(props) => props.css}

--- a/frontend/src/components/common/Input/Input.styled.ts
+++ b/frontend/src/components/common/Input/Input.styled.ts
@@ -1,0 +1,17 @@
+import { styled } from 'styled-components';
+import type { InputProps } from './Input';
+
+export const Input = styled.input<InputProps>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  padding: 10px 20px;
+
+  border: 1px solid ${({ theme }) => theme.color.GRAY200};
+  border-radius: 10px;
+
+  font-size: 16px;
+
+  && {
+    ${(props) => props.css}
+  }
+`;

--- a/frontend/src/components/common/Input/Input.tsx
+++ b/frontend/src/components/common/Input/Input.tsx
@@ -1,0 +1,17 @@
+import * as S from './Input.styled';
+import type { CSSProp } from 'styled-components';
+import type { InputHTMLAttributes } from 'react';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  width: string;
+  height: string;
+  css?: CSSProp;
+}
+
+const Input = (props: InputProps) => {
+  const { width, height, css, ...rest } = props;
+
+  return <S.Input width={width} height={height} css={css} {...rest}></S.Input>;
+};
+
+export default Input;


### PR DESCRIPTION
## 이슈번호
> #61 

## PR 내용
본 PR에서는 팀 플레이스 캘린더에서의 일정 등록을 위한 모달의 UI를 구현하였다.
모달 밖을 클릭하거나 닫기 버튼을 누르면 모달이 닫히는 등의 기본적인 상호작용이 포함되어 있다.

## 참고자료
- 스토리북
<img src="https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/ce0bb3b6-1ea5-401b-90c3-b845b4bcb686" width="500px" />


## 의논할 거리
`YYYY-MM-DD` 형식으로 필드를 작성할 수 있도록 하기 위해 `<input type="date" />` 를 사용하여 구현했는데, `<input type="datetime-local" />` 을 사용하면 `YYYY-MM-DD HH:MM` 까지 설정할 수 있는 것 같아.
둘을 서로 비교해봐도 좋을 듯?

- `datetime-local`
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/9d88d34c-c76d-4ee4-90a8-bd4c8b83879b)

코드가 많이 어지러운 편인데, 부디 바로잡아 줬으면 좋겠다. 많이 개선하면서 배울게...