### PR TITLE
[BE] 일정 수정 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/schedule.adoc
+++ b/backend/src/docs/asciidoc/schedule.adoc
@@ -4,12 +4,45 @@
 === 1. 팀 캘린더 일정 등록
 
 ====== 요청 Header
-include::{snippets}/schedules/register/request-headers.adoc[]
+include::{snippets}/schedules/register/success/request-headers.adoc[]
 
 ==== Request
-include::{snippets}/schedules/register/http-request.adoc[]
-include::{snippets}/schedules/register/request-fields.adoc[]
+include::{snippets}/schedules/register/success/http-request.adoc[]
+include::{snippets}/schedules/register/success/request-fields.adoc[]
 
 
 ==== Response
-include::{snippets}/schedules/register/http-response.adoc[]
+include::{snippets}/schedules/register/success/http-response.adoc[]
+
+=== 1-1. 일정 등록 실패 (등록할 일정 제목 빈 값)
+
+==== Request
+include::{snippets}/schedules/register/failBlankTitle/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/register/failBlankTitle/http-response.adoc[]
+
+=== 1-2. 일정 등록 실패 (존재하지 않는 팀 플레이스 ID)
+
+==== Request
+include::{snippets}/schedules/register/failNotExistTeamPlaceId/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/register/failNotExistTeamPlaceId/http-response.adoc[]
+
+=== 1-3. 일정 등록 실패 (등록할 시작 날짜가 등록할 종료 날짜보다 이후)
+
+==== Request
+include::{snippets}/schedules/register/failSpanWrongOrder/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/register/failSpanWrongOrder/http-response.adoc[]
+
+=== 1-4. 일정 등록 실패 (등록할 날짜 형식 잘못된 경우)
+
+==== Request
+include::{snippets}/schedules/register/failWrongDateTimeType/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/register/failWrongDateTimeType/http-response.adoc[]
+

--- a/backend/src/docs/asciidoc/schedule.adoc
+++ b/backend/src/docs/asciidoc/schedule.adoc
@@ -1,4 +1,4 @@
-=== 캘린더 일정 API
+== 캘린더 일정 API
 캘린더에 일정을 등록 / 조회 / 수정 / 삭제할 수 있습니다.
 
 === 1. 팀 캘린더 일정 등록
@@ -45,4 +45,59 @@ include::{snippets}/schedules/register/failWrongDateTimeType/http-request.adoc[]
 
 ==== Response
 include::{snippets}/schedules/register/failWrongDateTimeType/http-response.adoc[]
+
+
+=== 2. 팀 캘린더 일정 수정
+
+====== 요청 Header
+include::{snippets}/schedules/update/success/request-headers.adoc[]
+
+==== Request
+include::{snippets}/schedules/update/success/http-request.adoc[]
+include::{snippets}/schedules/update/success/request-fields.adoc[]
+
+
+==== Response
+include::{snippets}/schedules/update/success/http-response.adoc[]
+
+=== 2-1. 일정 수정 실패 (수정할 일정 제목 빈 값)
+
+==== Request
+include::{snippets}/schedules/update/failBlankTitle/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/update/failBlankTitle/http-response.adoc[]
+
+=== 2-2. 일정 수정 실패 (존재하지 않는 팀 플레이스 ID)
+
+==== Request
+include::{snippets}/schedules/update/failNotExistTeamPlaceId/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/update/failNotExistTeamPlaceId/http-response.adoc[]
+
+=== 2-3. 일정 수정 실패 (수정할 시작 날짜가 등록할 종료 날짜보다 이후)
+
+==== Request
+include::{snippets}/schedules/update/failSpanWrongOrder/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/update/failSpanWrongOrder/http-response.adoc[]
+
+=== 2-4. 일정 수정 실패 (수정할 날짜 형식 잘못된 경우)
+
+==== Request
+include::{snippets}/schedules/update/failWrongDateTimeType/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/update/failWrongDateTimeType/http-response.adoc[]
+
+=== 2-5. 일정 수정 실패 (존재하지 않는 수정할 일정 ID)
+
+==== Request
+include::{snippets}/schedules/update/failNotExistScheduleId/http-request.adoc[]
+
+==== Response
+include::{snippets}/schedules/update/failNotExistScheduleId/http-response.adoc[]
+
 

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -51,4 +51,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(message);
     }
+
+    @ExceptionHandler(value = {ScheduleException.SpanWrongOrderException.class})
+    public ResponseEntity<String> handleSpanWrongOrderException(final ScheduleException exception) {
+        final String message = exception.getMessage();
+        log.warn(message, exception);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(message);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = {ScheduleException.TeamAccessForbidden.class})
-    public ResponseEntity<String> handleCustomForbiddenException(final ScheduleException exception) {
+    public ResponseEntity<String> handleCustomForbiddenException(final RuntimeException exception) {
         final String message = exception.getMessage();
         log.warn(message, exception);
 
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = {ScheduleException.SpanWrongOrderException.class})
-    public ResponseEntity<String> handleCustomBadRequestException(final ScheduleException exception) {
+    public ResponseEntity<String> handleCustomBadRequestException(final RuntimeException exception) {
         final String message = exception.getMessage();
         log.warn(message, exception);
 

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = {ScheduleException.SpanWrongOrderException.class})
-    public ResponseEntity<String> handleSpanWrongOrderException(final ScheduleException exception) {
+    public ResponseEntity<String> handleCustomBadRequestException(final ScheduleException exception) {
         final String message = exception.getMessage();
         log.warn(message, exception);
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleResponse;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
 import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
 import team.teamby.teambyteam.schedule.domain.Span;
@@ -60,5 +61,15 @@ public class ScheduleService {
 
     private boolean isNotScheduleOfTeam(final Long teamPlaceId, final Schedule schedule) {
         return !schedule.isScheduleOfTeam(teamPlaceId);
+    }
+
+    public void update(final ScheduleUpdateRequest scheduleUpdateRequest, final Long teamPlaceId, final Long scheduleId) {
+        checkTeamPlaceExist(teamPlaceId);
+
+        final Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ScheduleException.NotFoundException("ID에 해당하는 일정을 찾을 수 없습니다."));
+
+        schedule.change(scheduleUpdateRequest.title(),
+                scheduleUpdateRequest.startDateTime(), scheduleUpdateRequest.endDateTime());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/ScheduleService.java
@@ -67,7 +67,7 @@ public class ScheduleService {
         checkTeamPlaceExist(teamPlaceId);
 
         final Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ScheduleException.NotFoundException("ID에 해당하는 일정을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ScheduleException.ScheduleNotFoundException("ID에 해당하는 일정을 찾을 수 없습니다."));
 
         schedule.change(scheduleUpdateRequest.title(),
                 scheduleUpdateRequest.startDateTime(), scheduleUpdateRequest.endDateTime());

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/dto/ScheduleUpdateRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/dto/ScheduleUpdateRequest.java
@@ -1,0 +1,18 @@
+package team.teamby.teambyteam.schedule.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+
+public record ScheduleUpdateRequest(
+        @NotBlank(message = "제목은 빈 값일 수 없습니다.")
+        String title,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime startDateTime,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime endDateTime) {
+
+}

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -34,5 +36,12 @@ public class Schedule {
 
     public boolean isScheduleOfTeam(final Long teamPlaceId) {
         return Objects.equals(teamPlaceId, this.teamPlaceId);
+    }
+
+    public void change(final String titleToUpdate,
+                       final LocalDateTime startDateTimeToUpdate,
+                       final LocalDateTime endDateTimeToUpdate) {
+        this.title = title.change(titleToUpdate);
+        this.span = span.change(startDateTimeToUpdate, endDateTimeToUpdate);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Span.java
@@ -31,4 +31,8 @@ public class Span {
             throw new ScheduleException.SpanWrongOrderException("시작 일자가 종료 일자보다 이후일 수 없습니다.");
         }
     }
+
+    public Span change(final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        return new Span(startDateTime, endDateTime);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Title.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Title.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
 
 import java.util.Objects;
 
@@ -24,6 +25,10 @@ public class Title {
     private void validate(final String value) {
         if (Objects.isNull(value)) {
             throw new NullPointerException("일정의 제목이 null일 수 없습니다.");
+        }
+
+        if (value.isBlank()) {
+            throw new ScheduleException.TitleBlankException("일정의 제목은 빈 칸일 수 없습니다.");
         }
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Title.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Title.java
@@ -26,4 +26,8 @@ public class Title {
             throw new NullPointerException("일정의 제목이 null일 수 없습니다.");
         }
     }
+
+    public Title change(final String value) {
+        return new Title(value);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
@@ -23,4 +23,11 @@ public class ScheduleException extends RuntimeException {
             super(message);
         }
     }
+
+    public static class TitleBlankException extends ScheduleException {
+
+        public TitleBlankException(final String message) {
+            super(message);
+        }
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
@@ -30,11 +30,4 @@ public class ScheduleException extends RuntimeException {
             super(message);
         }
     }
-
-    public static class NotFoundException extends ScheduleException {
-
-        public NotFoundException(final String message) {
-            super(message);
-        }
-    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
@@ -30,4 +30,11 @@ public class ScheduleException extends RuntimeException {
             super(message);
         }
     }
+
+    public static class NotFoundException extends ScheduleException {
+
+        public NotFoundException(final String message) {
+            super(message);
+        }
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/TeamPlaceScheduleController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/TeamPlaceScheduleController.java
@@ -9,6 +9,7 @@ import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.schedule.application.ScheduleService;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleResponse;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
 
 import java.net.URI;
 
@@ -39,5 +40,15 @@ public class TeamPlaceScheduleController {
         final Long registeredId = scheduleService.register(scheduleRegisterRequest, teamPlaceId);
         final URI location = URI.create("/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId);
         return ResponseEntity.created(location).build();
+    }
+
+    @PatchMapping("/{teamPlaceId}/calendar/schedules/{scheduleId}")
+    public ResponseEntity<Void> update(
+            @RequestBody @Valid final ScheduleUpdateRequest scheduleUpdateRequest,
+            @PathVariable final Long teamPlaceId,
+            @PathVariable final Long scheduleId) {
+
+        scheduleService.update(scheduleUpdateRequest, teamPlaceId, scheduleId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
@@ -1,6 +1,7 @@
 package team.teamby.teambyteam.fixtures;
 
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
 import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.Span;
 import team.teamby.teambyteam.schedule.domain.Title;
@@ -13,14 +14,21 @@ public class ScheduleFixtures {
 
         public static final Long ID = 1L;
         public static final String TITLE = "1번 팀플 N시간 일정";
+        public static final String UPDATE_TITLE = "업데이트 1번 팀플 N시간 일정";
         public static final Long TEAM_PLACE_ID = 1L;
         public static final LocalDateTime START_DATE_TIME = LocalDateTime.of(2023, 7, 12, 10, 0, 0);
         public static final LocalDateTime END_DATE_TIME = LocalDateTime.of(2023, 7, 12, 18, 0, 0);
+        public static final LocalDateTime UPDATE_END_DATE_TIME = LocalDateTime.of(2023, 7, 13, 15, 0, 0);
 
         public static final ScheduleRegisterRequest REGISTER_REQUEST = new ScheduleRegisterRequest(TITLE, START_DATE_TIME, END_DATE_TIME);
+        public static final ScheduleUpdateRequest UPDATE_REQUEST = new ScheduleUpdateRequest(UPDATE_TITLE, START_DATE_TIME, UPDATE_END_DATE_TIME);
 
         public static Schedule ENTITY() {
             return new Schedule(ID, TEAM_PLACE_ID, new Title(TITLE), new Span(START_DATE_TIME, END_DATE_TIME));
+        }
+
+        public static Schedule UPDATE_ENTITY() {
+            return new Schedule(ID, TEAM_PLACE_ID, new Title(UPDATE_TITLE), new Span(START_DATE_TIME, UPDATE_END_DATE_TIME));
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
@@ -17,7 +17,7 @@ public class ScheduleFixtures {
         public static final LocalDateTime START_DATE_TIME = LocalDateTime.of(2023, 7, 12, 10, 0, 0);
         public static final LocalDateTime END_DATE_TIME = LocalDateTime.of(2023, 7, 12, 18, 0, 0);
 
-        public static final ScheduleRegisterRequest REQUEST = new ScheduleRegisterRequest(TITLE, START_DATE_TIME, END_DATE_TIME);
+        public static final ScheduleRegisterRequest REGISTER_REQUEST = new ScheduleRegisterRequest(TITLE, START_DATE_TIME, END_DATE_TIME);
 
         public static Schedule ENTITY() {
             return new Schedule(ID, TEAM_PLACE_ID, new Title(TITLE), new Span(START_DATE_TIME, END_DATE_TIME));

--- a/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/fixtures/ScheduleFixtures.java
@@ -20,7 +20,7 @@ public class ScheduleFixtures {
         public static final LocalDateTime END_DATE_TIME = LocalDateTime.of(2023, 7, 12, 18, 0, 0);
         public static final LocalDateTime UPDATE_END_DATE_TIME = LocalDateTime.of(2023, 7, 13, 15, 0, 0);
 
-        public static final ScheduleRegisterRequest REGISTER_REQUEST = new ScheduleRegisterRequest(TITLE, START_DATE_TIME, END_DATE_TIME);
+        public static final ScheduleRegisterRequest REQUEST = new ScheduleRegisterRequest(TITLE, START_DATE_TIME, END_DATE_TIME);
         public static final ScheduleUpdateRequest UPDATE_REQUEST = new ScheduleUpdateRequest(UPDATE_TITLE, START_DATE_TIME, UPDATE_END_DATE_TIME);
 
         public static Schedule ENTITY() {

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -98,7 +98,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
             final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
 
             // when
-            final ExtractableResponse<Response> successRequest = registerScheduleRequest(teamPlaceId, Schedule1_N_Hour.REGISTER_REQUEST);
+            final ExtractableResponse<Response> successRequest = registerScheduleRequest(teamPlaceId, Schedule1_N_Hour.REQUEST);
 
             // then
             assertSoftly(softly -> {
@@ -156,7 +156,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
             final Long notExistTeamPlaceId = -1L;
 
             // when
-            final ExtractableResponse<Response> notExistTeamPlaceIdRequest = registerScheduleRequest(notExistTeamPlaceId, Schedule1_N_Hour.REGISTER_REQUEST);
+            final ExtractableResponse<Response> notExistTeamPlaceIdRequest = registerScheduleRequest(notExistTeamPlaceId, Schedule1_N_Hour.REQUEST);
 
             // then
             assertSoftly(softly -> {

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -16,9 +16,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import team.teamby.teambyteam.common.AcceptanceTest;
+import team.teamby.teambyteam.fixtures.ScheduleFixtures;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -147,6 +149,26 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
             assertSoftly(softly -> {
                 softly.assertThat(wrongDateTimeTypeRequest.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
                 softly.assertThat(wrongDateTimeTypeRequest.body().asString()).isEqualTo("DateTime 형식이 잘못되었습니다. 서버 관리자에게 문의해주세요.");
+            });
+        }
+
+        @Test
+        @DisplayName("시작 일자와 종료 일자의 순서가 맞지 않으면 실패한다.")
+        void failSpanWrongOrder() {
+            // given
+            final String title = ScheduleFixtures.Schedule1_N_Hour.TITLE;
+            final Long teamPlaceId = ScheduleFixtures.Schedule1_N_Hour.TEAM_PLACE_ID;
+            final LocalDateTime startDateTime = ScheduleFixtures.Schedule1_N_Hour.START_DATE_TIME;
+            final LocalDateTime wrongEndDateTime = ScheduleFixtures.Schedule1_N_Hour.START_DATE_TIME.minusDays(1);
+            final ScheduleRegisterRequest request = new ScheduleRegisterRequest(title, startDateTime, wrongEndDateTime);
+
+            // when & then
+            final ExtractableResponse<Response> wrongSpanOrderResponse = registerScheduleRequest(teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(wrongSpanOrderResponse.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(wrongSpanOrderResponse.body().asString()).isEqualTo("시작 일자가 종료 일자보다 이후일 수 없습니다.");
             });
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/ScheduleAcceptanceTest.java
@@ -36,7 +36,6 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
     private static final String REQUEST_START_DATE_TIME_KEY = "startDateTime";
     private static final String REQUEST_END_DATE_KEY = "endDateTime";
 
-
     @Nested
     @DisplayName("팀플레이스 내 특정 일정 조회")
     class FindTest {
@@ -99,7 +98,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
             final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
 
             // when
-            final ExtractableResponse<Response> successRequest = registerScheduleRequest(teamPlaceId, Schedule1_N_Hour.REQUEST);
+            final ExtractableResponse<Response> successRequest = registerScheduleRequest(teamPlaceId, Schedule1_N_Hour.REGISTER_REQUEST);
 
             // then
             assertSoftly(softly -> {
@@ -157,7 +156,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
             final Long notExistTeamPlaceId = -1L;
 
             // when
-            final ExtractableResponse<Response> notExistTeamPlaceIdRequest = registerScheduleRequest(notExistTeamPlaceId, Schedule1_N_Hour.REQUEST);
+            final ExtractableResponse<Response> notExistTeamPlaceIdRequest = registerScheduleRequest(notExistTeamPlaceId, Schedule1_N_Hour.REGISTER_REQUEST);
 
             // then
             assertSoftly(softly -> {

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -203,5 +203,19 @@ class ScheduleServiceTest {
                     .isInstanceOf(TeamPlaceException.NotFoundException.class)
                     .hasMessage("ID에 해당하는 팀 플레이스를 찾을 수 없습니다.");
         }
+
+        @Test
+        @DisplayName("일정 수정 시 수정할 일정 ID에 해당하는 일정이 존재하지 않으면 예외가 발생한다.")
+        void failScheduleNotExistById() {
+            // given
+            final Long notExistScheduleId = -1L;
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final ScheduleUpdateRequest request = Schedule1_N_Hour.UPDATE_REQUEST;
+
+            // when & then
+            assertThatThrownBy(() -> scheduleService.update(request, teamPlaceId, notExistScheduleId))
+                    .isInstanceOf(ScheduleException.ScheduleNotFoundException.class)
+                    .hasMessage("ID에 해당하는 일정을 찾을 수 없습니다.");
+        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -5,6 +5,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
@@ -12,12 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.fixtures.ScheduleFixtures;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleResponse;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
+import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static team.teamby.teambyteam.fixtures.ScheduleFixtures.Schedule1_N_Hour;
 
@@ -127,6 +132,62 @@ class ScheduleServiceTest {
             assertThatThrownBy(() -> scheduleService.register(request, notExistTeamPlaceId))
                     .isInstanceOf(TeamPlaceException.NotFoundException.class)
                     .hasMessage("ID에 해당하는 팀 플레이스를 찾을 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("일정 수정 시")
+    class UpdateSchedule {
+
+        @Test
+        @DisplayName("일정 수정에 성공한다.")
+        void success() {
+            // given
+            Long id = Schedule1_N_Hour.ID;
+            Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            ScheduleUpdateRequest request = Schedule1_N_Hour.UPDATE_REQUEST;
+
+            // when
+            scheduleService.update(request, teamPlaceId, id);
+            Schedule updatedSchedule = scheduleRepository.findById(id).get();
+
+            // then
+            assertThat(updatedSchedule).usingRecursiveComparison()
+                    .isEqualTo(Schedule1_N_Hour.UPDATE_ENTITY());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "    "})
+        @DisplayName("일정 수정 시 수정할 일정 제목이 빈 값이면 예외가 발생한다.")
+        void failUpdateTitleBlank(String titleToUpdate) {
+            // given
+            Long id = Schedule1_N_Hour.ID;
+            Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            LocalDateTime startDateTime = Schedule1_N_Hour.START_DATE_TIME;
+            LocalDateTime endDateTime = Schedule1_N_Hour.END_DATE_TIME;
+            ScheduleUpdateRequest request = new ScheduleUpdateRequest(titleToUpdate, startDateTime, endDateTime);
+
+            // when & then
+            assertThatThrownBy(() -> scheduleService.update(request, teamPlaceId, id))
+                    .isInstanceOf(ScheduleException.TitleBlankException.class)
+                    .hasMessage("일정의 제목은 빈 칸일 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("일정 수정 시 Span 순서가 맞지 않으면 예외가 발생한다.")
+        void failSpanWrongOrder() {
+            // given
+            Long id = Schedule1_N_Hour.ID;
+            String title = Schedule1_N_Hour.TITLE;
+            Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            LocalDateTime startDateTime = Schedule1_N_Hour.START_DATE_TIME;
+            LocalDateTime wrongEndDateTime = Schedule1_N_Hour.START_DATE_TIME.minusDays(1);
+            ScheduleUpdateRequest request = new ScheduleUpdateRequest(title, startDateTime, wrongEndDateTime);
+
+            // when & then
+            assertThatThrownBy(() -> scheduleService.update(request, teamPlaceId, id))
+                    .isInstanceOf(ScheduleException.SpanWrongOrderException.class)
+                    .hasMessage("시작 일자가 종료 일자보다 이후일 수 없습니다.");
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -143,13 +143,13 @@ class ScheduleServiceTest {
         @DisplayName("일정 수정에 성공한다.")
         void success() {
             // given
-            Long id = Schedule1_N_Hour.ID;
-            Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
-            ScheduleUpdateRequest request = Schedule1_N_Hour.UPDATE_REQUEST;
+            final Long id = Schedule1_N_Hour.ID;
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final ScheduleUpdateRequest request = Schedule1_N_Hour.UPDATE_REQUEST;
 
             // when
             scheduleService.update(request, teamPlaceId, id);
-            Schedule updatedSchedule = scheduleRepository.findById(id).get();
+            final Schedule updatedSchedule = scheduleRepository.findById(id).get();
 
             // then
             assertThat(updatedSchedule).usingRecursiveComparison()
@@ -161,11 +161,11 @@ class ScheduleServiceTest {
         @DisplayName("일정 수정 시 수정할 일정 제목이 빈 값이면 예외가 발생한다.")
         void failUpdateTitleBlank(String titleToUpdate) {
             // given
-            Long id = Schedule1_N_Hour.ID;
-            Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
-            LocalDateTime startDateTime = Schedule1_N_Hour.START_DATE_TIME;
-            LocalDateTime endDateTime = Schedule1_N_Hour.END_DATE_TIME;
-            ScheduleUpdateRequest request = new ScheduleUpdateRequest(titleToUpdate, startDateTime, endDateTime);
+            final Long id = Schedule1_N_Hour.ID;
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final LocalDateTime startDateTime = Schedule1_N_Hour.START_DATE_TIME;
+            final LocalDateTime endDateTime = Schedule1_N_Hour.END_DATE_TIME;
+            final ScheduleUpdateRequest request = new ScheduleUpdateRequest(titleToUpdate, startDateTime, endDateTime);
 
             // when & then
             assertThatThrownBy(() -> scheduleService.update(request, teamPlaceId, id))
@@ -177,12 +177,12 @@ class ScheduleServiceTest {
         @DisplayName("일정 수정 시 Span 순서가 맞지 않으면 예외가 발생한다.")
         void failSpanWrongOrder() {
             // given
-            Long id = Schedule1_N_Hour.ID;
-            String title = Schedule1_N_Hour.TITLE;
-            Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
-            LocalDateTime startDateTime = Schedule1_N_Hour.START_DATE_TIME;
-            LocalDateTime wrongEndDateTime = Schedule1_N_Hour.START_DATE_TIME.minusDays(1);
-            ScheduleUpdateRequest request = new ScheduleUpdateRequest(title, startDateTime, wrongEndDateTime);
+            final Long id = Schedule1_N_Hour.ID;
+            final String title = Schedule1_N_Hour.TITLE;
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final LocalDateTime startDateTime = Schedule1_N_Hour.START_DATE_TIME;
+            final LocalDateTime wrongEndDateTime = Schedule1_N_Hour.START_DATE_TIME.minusDays(1);
+            final ScheduleUpdateRequest request = new ScheduleUpdateRequest(title, startDateTime, wrongEndDateTime);
 
             // when & then
             assertThatThrownBy(() -> scheduleService.update(request, teamPlaceId, id))

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -12,12 +12,14 @@ import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.fixtures.ScheduleFixtures;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleResponse;
+import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static team.teamby.teambyteam.fixtures.ScheduleFixtures.Schedule1_N_Hour;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Transactional
@@ -27,6 +29,8 @@ class ScheduleServiceTest {
     @Autowired
     private ScheduleService scheduleService;
 
+    @Autowired
+    private ScheduleRepository scheduleRepository;
 
     @Nested
     @DisplayName("일정 정보 조회시")

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/ScheduleServiceTest.java
@@ -189,5 +189,19 @@ class ScheduleServiceTest {
                     .isInstanceOf(ScheduleException.SpanWrongOrderException.class)
                     .hasMessage("시작 일자가 종료 일자보다 이후일 수 없습니다.");
         }
+
+        @Test
+        @DisplayName("일정 수정 시 팀 플레이스 ID에 해당하는 팀 플레이스가 존재하지 않으면 예외가 발생한다.")
+        void failTeamPlaceNotExistById() {
+            // given
+            final Long id = Schedule1_N_Hour.ID;
+            final ScheduleUpdateRequest request = Schedule1_N_Hour.UPDATE_REQUEST;
+            final Long notExistTeamPlaceId = -1L;
+
+            // when & then
+            assertThatThrownBy(() -> scheduleService.update(request, notExistTeamPlaceId, id))
+                    .isInstanceOf(TeamPlaceException.NotFoundException.class)
+                    .hasMessage("ID에 해당하는 팀 플레이스를 찾을 수 없습니다.");
+        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
@@ -57,7 +57,7 @@ public class ScheduleApiDocsTest {
     @DisplayName("일정 등록 문서화")
     void registerScheduleDocs() throws Exception {
         // given
-        final ScheduleRegisterRequest request = Schedule1_N_Hour.REGISTER_REQUEST;
+        final ScheduleRegisterRequest request = Schedule1_N_Hour.REQUEST;
         final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
         final Long registeredId = 1L;
         given(scheduleService.register(request, teamPlaceId))

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.schedule.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -12,19 +13,27 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import team.teamby.teambyteam.fixtures.ScheduleFixtures;
 import team.teamby.teambyteam.member.configuration.MemberInterceptor;
 import team.teamby.teambyteam.schedule.application.ScheduleService;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
+import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
 import team.teamby.teambyteam.schedule.presentation.TeamPlaceScheduleController;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -40,6 +49,9 @@ public class ScheduleApiDocsTest {
 
     private static final String AUTHORIZATION_HEADER_KEY = HttpHeaders.AUTHORIZATION;
     private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaa.bbbb.cccc";
+    private static final String REQUEST_TITLE_KEY = "title";
+    private static final String REQUEST_START_DATE_TIME_KEY = "startDateTime";
+    private static final String REQUEST_END_DATE_KEY = "endDateTime";
 
     @Autowired
     private MockMvc mockMvc;
@@ -53,40 +65,165 @@ public class ScheduleApiDocsTest {
     @MockBean
     private MemberInterceptor memberInterceptor;
 
-    @Test
+    @Nested
     @DisplayName("일정 등록 문서화")
-    void registerScheduleDocs() throws Exception {
-        // given
-        final ScheduleRegisterRequest request = Schedule1_N_Hour.REQUEST;
-        final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
-        final Long registeredId = 1L;
-        given(scheduleService.register(request, teamPlaceId))
-                .willReturn(registeredId);
-        given(memberInterceptor.preHandle(any(), any(), any()))
-                .willReturn(true);
+    class RegisterScheduleDocs {
 
-        // when & then
-        mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
-                        .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(header().string(HttpHeaders.LOCATION, "/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId))
-                .andDo(print())
-                .andDo(document("schedules/register",
-                                preprocessRequest(prettyPrint()),
-                                pathParameters(
-                                        parameterWithName("teamPlaceId").description("멤버가 속한 팀 플레이스 ID")
-                                ),
-                                requestHeaders(
-                                        headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
-                                ),
-                                requestFields(
-                                        fieldWithPath("title").type(JsonFieldType.STRING).description("등록할 일정 제목"),
-                                        fieldWithPath("startDateTime").type(JsonFieldType.STRING).description("등록할 일정의 시작 일시(형식 : yyyy-MM-dd HH:mm)"),
-                                        fieldWithPath("endDateTime").type(JsonFieldType.STRING).description("등록할 일정의 종료 일시(형식 : yyyy-MM-dd HH:mm)")
-                                )
-                        )
-                );
+        @Test
+        @DisplayName("일정 등록 성공")
+        void success() throws Exception {
+            // given
+            final ScheduleRegisterRequest request = Schedule1_N_Hour.REQUEST;
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final Long registeredId = 1L;
+            given(scheduleService.register(request, teamPlaceId))
+                    .willReturn(registeredId);
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willReturn(true);
+
+            // when & then
+            mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string(HttpHeaders.LOCATION, "/api/team-place/" + teamPlaceId + "/calendar/schedules/" + registeredId))
+                    .andDo(print())
+                    .andDo(document("schedules/register/success",
+                                    preprocessRequest(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("teamPlaceId").description("멤버가 속한 팀 플레이스 ID")
+                                    ),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("title").type(JsonFieldType.STRING).description("등록할 일정 제목"),
+                                            fieldWithPath("startDateTime").type(JsonFieldType.STRING).description("등록할 일정의 시작 일시(형식 : yyyy-MM-dd HH:mm)"),
+                                            fieldWithPath("endDateTime").type(JsonFieldType.STRING).description("등록할 일정의 종료 일시(형식 : yyyy-MM-dd HH:mm)")
+                                    )
+                            )
+                    );
+
+        }
+
+        @Test
+        @DisplayName("제목이 빈 값이면 실패")
+        void failBlankTitle() throws Exception {
+            // given
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final String blankTitle = " ";
+            ScheduleUpdateRequest request = new ScheduleUpdateRequest(blankTitle, Schedule1_N_Hour.START_DATE_TIME, Schedule1_N_Hour.END_DATE_TIME);
+            willThrow(new ScheduleException.TitleBlankException("제목은 빈 값일 수 없습니다."))
+                    .given(scheduleService)
+                    .register(any(ScheduleRegisterRequest.class), eq(teamPlaceId));
+
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willReturn(true);
+
+            // when & then
+            mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(print())
+                    .andDo(document("schedules/register/failBlankTitle",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("잘못된 날짜 형식이면 실패")
+        void failWrongDateTimeType() throws Exception {
+            // given
+            final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
+            final String wrongStartDateTime = "2023:07:12 10:00";
+            final String correctEndDateTimeType = "2023-07-12 18:00";
+
+            final Map<String, String> requestMap = new HashMap<>();
+            requestMap.put(REQUEST_TITLE_KEY, Schedule1_N_Hour.TITLE);
+            requestMap.put(REQUEST_START_DATE_TIME_KEY, wrongStartDateTime);
+            requestMap.put(REQUEST_END_DATE_KEY, correctEndDateTimeType);
+
+            willThrow(DateTimeParseException.class)
+                    .given(scheduleService)
+                    .register(any(ScheduleRegisterRequest.class), eq(teamPlaceId));
+
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willReturn(true);
+
+            // when & then
+            mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestMap)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(print())
+                    .andDo(document("schedules/register/failWrongDateTimeType",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("없는 팀 플레이스 ID면 실패")
+        void failNotExistTeamPlaceId() throws Exception {
+            // given
+            final Long notExistTeamPlaceId = -1L;
+            ScheduleRegisterRequest request = Schedule1_N_Hour.REQUEST;
+            willThrow(new TeamPlaceException.NotFoundException("ID에 해당하는 팀 플레이스를 찾을 수 없습니다."))
+                    .given(scheduleService)
+                    .register(any(), eq(notExistTeamPlaceId));
+
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willReturn(true);
+
+            // when & then
+            mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", notExistTeamPlaceId)
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andDo(print())
+                    .andDo(document("schedules/register/failNotExistTeamPlaceId",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("시작 일자와 종료 일자의 순서가 맞지 않으면 실패")
+        void failSpanWrongOrder() throws Exception {
+            // given
+            final String title = ScheduleFixtures.Schedule1_N_Hour.TITLE;
+            final Long teamPlaceId = ScheduleFixtures.Schedule1_N_Hour.TEAM_PLACE_ID;
+            final LocalDateTime startDateTime = ScheduleFixtures.Schedule1_N_Hour.START_DATE_TIME;
+            final LocalDateTime wrongEndDateTime = ScheduleFixtures.Schedule1_N_Hour.START_DATE_TIME.minusDays(1);
+            final ScheduleRegisterRequest request = new ScheduleRegisterRequest(title, startDateTime, wrongEndDateTime);
+
+            willThrow(new ScheduleException.SpanWrongOrderException("시작 일자가 종료 일자보다 이후일 수 없습니다."))
+                    .given(scheduleService)
+                    .register(request, teamPlaceId);
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willReturn(true);
+
+            // when & then
+            mockMvc.perform(post("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(print())
+                    .andDo(document("schedules/register/failSpanWrongOrder",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/ScheduleApiDocsTest.java
@@ -57,7 +57,7 @@ public class ScheduleApiDocsTest {
     @DisplayName("일정 등록 문서화")
     void registerScheduleDocs() throws Exception {
         // given
-        final ScheduleRegisterRequest request = Schedule1_N_Hour.REQUEST;
+        final ScheduleRegisterRequest request = Schedule1_N_Hour.REGISTER_REQUEST;
         final Long teamPlaceId = Schedule1_N_Hour.TEAM_PLACE_ID;
         final Long registeredId = 1L;
         given(scheduleService.register(request, teamPlaceId))

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceRepositoryTest.java
@@ -23,7 +23,7 @@ class TeamPlaceRepositoryTest {
     @DisplayName("id에 해당하는 팀 플레이스가 존재하면 true, 존재하지 않으면 false를 반환한다.")
     void isExistById(Long teamPlaceId, boolean expected) {
         // when
-        boolean actual = teamPlaceRepository.existsById(teamPlaceId);
+        final boolean actual = teamPlaceRepository.existsById(teamPlaceId);
 
         // then
         assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> #22 

## PR 내용

- 일정 수정 기능 구현
- 일정 수정 문서화 
- 일정 수정 테스트 구현

- 대부분이 등록 기능, API 코드와 비슷하지만, 등록 코드에서 `ScheduleId`가 존재하지 않을 때 예외만 추가

## 참고자료

## 의논할 거리
