### PR TITLE
[FE] 캘린더 바 버그 수정 및 안정성 개선

### DIFF
--- a/frontend/src/utils/generateScheduleBars.ts
+++ b/frontend/src/utils/generateScheduleBars.ts
@@ -11,15 +11,15 @@ interface Position {
 type CalendarObject = Record<string, Position>;
 
 /**
- * 《convertSchedulesToBars》
+ * 《generateScheduleBars》
  * 이 유틸 함수는 가공 전의 스케줄 데이터를 받고, 이를 즉시 랜더링이 가능한 바 형태로 내보내는 역할을 수행합니다.
  * - 스케줄 바를 한 줄에 랜더링할 수 있도록 여러 줄에 걸친 스케줄을 여러 개의 작은 스케줄로 쪼갭니다.
  * - 스케줄이 중첩될 경우 겹치지 않는 적절한 위치에 랜더링할 수 있도록 level 값을 포함하여 제공합니다.
  *
- *
  * @param year - 스케줄 바를 표시할 연도
- * @param month - 스케줄 바를 표시할 월 (주의: 일상생활에서의 월 그대로를 사용해 주세요 - 7월일 경우: 7)
+ * @param month - 스케줄 바를 표시할 월
  * @param schedules - 가공되기 전의 스케줄 데이터가 저장된 배열
+ * @returns leveledScheduleBars - ScheduleBarProps 타입의 형태로 결과물을 반환합니다
  */
 export const generateScheduleBars = (
   year: number,
@@ -27,26 +27,41 @@ export const generateScheduleBars = (
   schedules: Schedule[],
 ) => {
   const calendarObject = generateCalendarObject(year, month);
-  const rawScheduleBars = generateRawScheduleBars(schedules, calendarObject);
+  const rawScheduleBars = generateRawScheduleBars(
+    year,
+    month,
+    schedules,
+    calendarObject,
+  );
   const slicedScheduleBars = sliceScheduleBars(rawScheduleBars);
   const leveledScheduleBars = giveLevelToScheduleBars(slicedScheduleBars);
 
   return leveledScheduleBars;
 };
 
-const generateCalendarObject = (year: number, month: number) => {
-  const firstDayOfMonth = new Date(year, month);
-  const firstDayOfCalendar = new Date(
-    firstDayOfMonth.getTime() - ONE_DAY * firstDayOfMonth.getDay(),
+const getFirstLastDateOfCalendar = (year: number, month: number) => {
+  const firstDateOfMonth = new Date(year, month);
+  const firstDateOfCalendar = new Date(
+    firstDateOfMonth.getTime() - ONE_DAY * firstDateOfMonth.getDay(),
+  );
+  const lastDateOfCalendar = new Date(
+    firstDateOfCalendar.getTime() +
+      CALENDAR.ROW_SIZE * CALENDAR.COLUMN_SIZE * ONE_DAY -
+      1,
   );
 
+  return { firstDateOfCalendar, lastDateOfCalendar };
+};
+
+const generateCalendarObject = (year: number, month: number) => {
+  const { firstDateOfCalendar } = getFirstLastDateOfCalendar(year, month);
   const calendarObject: CalendarObject = {};
 
   Array.from(
     { length: CALENDAR.ROW_SIZE * CALENDAR.COLUMN_SIZE },
     (_, index) => {
       const currentDate = new Date(
-        firstDayOfCalendar.getTime() + index * ONE_DAY,
+        firstDateOfCalendar.getTime() + index * ONE_DAY,
       );
       const formattedDate = formatDate(currentDate);
       const position = {
@@ -62,34 +77,51 @@ const generateCalendarObject = (year: number, month: number) => {
 };
 
 const formatDate = (rawDate: Date) => {
-  const { month, date } = parseDate(rawDate);
-  const formattedDate = `${month + 1}/${date}`;
+  const { year, month, date } = parseDate(rawDate);
+  const formattedDate = `${year}/${month + 1}/${date}`;
 
   return formattedDate;
 };
 
 const generateRawScheduleBars = (
+  year: number,
+  month: number,
   schedules: Schedule[],
   calendarObject: CalendarObject,
 ) => {
-  const rawScheduleBars: ScheduleBarProps[] = schedules.map((schedule) => {
-    const { startDateTime, endDateTime, id: scheduleId, title } = schedule;
-    const startDate = new Date(startDateTime);
-    const duration = calcDuration(startDateTime, endDateTime);
-    const { row, column } = calendarObject[formatDate(startDate)];
-    const id = crypto.randomUUID();
-    const randomColor = Math.floor(Math.random() * 16777215).toString(16);
+  const rawScheduleBars: ScheduleBarProps[] = [];
 
-    return {
-      id,
-      scheduleId,
-      title,
-      row,
-      column,
-      duration,
-      level: 0,
-      color: `#${randomColor}`,
-    };
+  schedules.forEach((schedule) => {
+    const { startDateTime, endDateTime, id: scheduleId, title } = schedule;
+    const { firstDateOfCalendar, lastDateOfCalendar } =
+      getFirstLastDateOfCalendar(year, month);
+    const startDate = new Date(
+      Math.max(
+        new Date(startDateTime).getTime(),
+        firstDateOfCalendar.getTime(),
+      ),
+    );
+    const endDate = new Date(
+      Math.min(new Date(endDateTime).getTime(), lastDateOfCalendar.getTime()),
+    );
+
+    if (startDate <= endDate) {
+      const duration = calcDuration(startDateTime, endDateTime);
+      const id = crypto.randomUUID();
+      const randomColor = Math.floor(Math.random() * 16777215).toString(16);
+      const { row, column } = calendarObject[formatDate(startDate)];
+
+      rawScheduleBars.push({
+        id,
+        scheduleId,
+        title,
+        row,
+        column,
+        duration,
+        level: 0,
+        color: `#${randomColor}`,
+      });
+    }
   });
 
   return rawScheduleBars;
@@ -129,7 +161,7 @@ const sliceScheduleBars = (rawScheduleBars: ScheduleBarProps[]) => {
     let currentRow = row;
     let currentColumn = column;
 
-    while (remainingDuration > 0 && currentRow <= CALENDAR.ROW_SIZE) {
+    while (remainingDuration > 0 && currentRow < CALENDAR.ROW_SIZE) {
       const currentDuration = Math.min(
         remainingDuration,
         CALENDAR.COLUMN_SIZE - currentColumn,


### PR DESCRIPTION
## 이슈번호
> close #109

## PR 내용
**본 PR에서는 캘린더가 오작동하고 불안정하게 작동하는 현상을 개선했다.**

여러 일정이 겹칠 경우 캘린더 바가 겹치지 않도록 서로 다른 높이에 랜더링되는데, 이를 **level** 이라 정의한다.
level 0의 경우 해당 캘린더 바가 해당 행의 최상단에 위치함을 의미하며, level이 1씩 증가할 수록 한 칸씩 아래에 위치함을 의미한다.

- 여러 주에 걸쳐 같은 일정의 캘린더 바가 랜더링 될 경우 서로 다른 level에 위치하는 문제점을 해결하였다.
- 현재 달에서의 일정의 범위를 일부분 벗어나는 경우, 혹은 아예 벗어나는 경우 오류를 발생시키지 않고 현재 달에 해당하는 일정에 한하여 일부분을 랜더링할 수 있도록 개선하였다.
- 일정의 시작 날짜가 끝 날짜보다 뒤에 오는 잘못된 입력이 주어질 경우 오류를 발생시키지 않고 해당 일정을 랜더링시키지 않도록 개선했다.

## 참고자료
- 여러 주에 걸쳐 하나의 스케줄 바가 랜더링되어도 level이 유지된다.
![pr1](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/838899b7-ecff-44e2-87f7-112ea69bc7fa)

- 여러 달에 걸쳐 스케줄 바를 랜더링할 수 있다.
![pr2](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/913efe61-30b2-4d62-ab58-820df0ed6605)

- 잘못된 일정은 랜더링되지 않으며, 다른 스케줄 바의 level에 영향을 주지 않는다.
![pr3](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/5008ee05-18c1-4338-9bec-898367462187)
