### PR TITLE
[FE] QueryClientProvider를 사용해서 컴포넌트가 스토리북에 제대로 보여지지 않는 문제 해결

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -5,6 +5,7 @@ import { handlers } from '../src/mocks/handlers/index';
 import { theme } from '../src/styles/theme';
 import GlobalStyle from '../src/styles/GlobalStyle';
 import { ModalProvider } from '../src/components/common/Modal/ModalContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Preview } from '@storybook/react';
 
 initialize();
@@ -22,14 +23,18 @@ const preview: Preview = {
   },
 };
 
+const queryClient = new QueryClient();
+
 export const decorators = [
   (Story) => (
-    <ThemeProvider theme={theme}>
-      <ModalProvider>
-        <GlobalStyle />
-        <Story />
-      </ModalProvider>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <ModalProvider>
+          <GlobalStyle />
+          <Story />
+        </ModalProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   ),
   mswDecorator,
 ];


### PR DESCRIPTION
## 이슈번호
> close #160 

## PR 내용
본 PR에서는 스토리북의 `preview` 파일에 `@tanstack/react-query` 의 `QueryClientProvider` 를 추가하여 `react-query` 를 사용하는 컴포넌트들이 제대로 랜더링되지 않는 현상을 해결하였다.

## 참고자료
- 발생했던 오류는 아래와 같다.
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/c27215c3-8844-407c-a922-aff0be72b561)
