### PR TITLE
[BE] MemberTeamPlace 연관관계 편의 메소드 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -1,15 +1,12 @@
 package team.teamby.teambyteam.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
 @Getter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class MemberTeamPlace {
 
@@ -24,4 +21,14 @@ public class MemberTeamPlace {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private TeamPlace teamPlace;
+
+    public MemberTeamPlace() {
+    }
+
+    public void setMemberAndTeamPlace(final Member member, final TeamPlace teamPlace) {
+        this.member = member;
+        this.teamPlace = teamPlace;
+        member.getMemberTeamPlaces().add(this);
+        teamPlace.getMemberTeamPlaces().add(this);
+    }
 }


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> #167 

## PR 내용

* MemberTeamPlace 연관관계 편의 메소드 구현

## 참고자료

## 의논할 거리
<img width="838" alt="연관관계 메소드" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/95729738/11fff355-5807-427a-8427-036b40bb31b4">

위 사진에서
Member, TeamPlace, MemberTeamPlace 모두 생성하는 건 같고,
a() 방식을 사용하면 Member와 TeamPlace 2군데에서 연관관계 편의 메소드를 호출해야하기 때문에
한 번에 MemberTeamPlace에서 호출하는 b방식으로 구현했습니다!
