### PR TITLE
[FE] 좌표 날짜 변환 유틸함수 구현

### DIFF
--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -26,7 +26,7 @@ const Calendar = () => {
     calendar,
     handlers: { handlePrevButtonClick, handleNextButtonClick },
   } = useCalendar();
-  const schedules = useFetchSchedules(1, year, month + 1);
+  const schedules = useFetchSchedules(1, year, month);
   const { isModalOpen, openModal } = useModal();
   const {
     modalScheduleId,

--- a/frontend/src/hooks/queries/useFetchDailySchedules.ts
+++ b/frontend/src/hooks/queries/useFetchDailySchedules.ts
@@ -8,7 +8,7 @@ export const useFetchDailySchedules = (
   day: number,
 ) => {
   const { data } = useQuery(['dailySchedules', year, month, day], () =>
-    fetchSchedules(teamPlaceId, year, month, day),
+    fetchSchedules(teamPlaceId, year, month + 1, day),
   );
 
   if (data === undefined) return [];

--- a/frontend/src/hooks/queries/useFetchSchedules.ts
+++ b/frontend/src/hooks/queries/useFetchSchedules.ts
@@ -7,7 +7,7 @@ export const useFetchSchedules = (
   month: number,
 ) => {
   const { data } = useQuery(['schedules', year, month], () =>
-    fetchSchedules(teamPlaceId, year, month),
+    fetchSchedules(teamPlaceId, year, month + 1),
   );
 
   if (data === undefined) return [];

--- a/frontend/src/utils/getDateByPosition.test.ts
+++ b/frontend/src/utils/getDateByPosition.test.ts
@@ -1,0 +1,39 @@
+import { getDateByPosition } from './getDateByPosition';
+
+describe('날짜 객체 반환 테스트', () => {
+  test.each([
+    [2023, 6, 0, 0, new Date(2023, 5, 25)],
+    [2023, 6, 0, 1, new Date(2023, 5, 26)],
+    [2023, 6, 0, 4, new Date(2023, 5, 29)],
+    [2023, 6, 0, 6, new Date(2023, 6, 1)],
+    [2023, 6, 1, 1, new Date(2023, 6, 3)],
+    [2023, 6, 2, 3, new Date(2023, 6, 12)],
+    [2023, 6, 3, 4, new Date(2023, 6, 20)],
+    [2023, 6, 4, 0, new Date(2023, 6, 23)],
+    [2023, 6, 4, 5, new Date(2023, 6, 28)],
+    [2023, 6, 5, 5, new Date(2023, 7, 4)],
+    [2023, 6, 5, 6, new Date(2023, 7, 5)],
+    [2023, 5, 0, 0, new Date(2023, 4, 28)],
+    [2023, 9, 5, 6, new Date(2023, 10, 11)],
+    [2022, 11, 3, 3, new Date(2022, 11, 21)],
+  ])(
+    'year = %s, month = %s, row = %s, column = %s -> %s 가 반환되어야 한다.',
+    (year, month, row, column, expectedDate) => {
+      expect(getDateByPosition(year, month, row, column)).toEqual(expectedDate);
+    },
+  );
+});
+
+describe('예외 처리 테스트', () => {
+  test.each([
+    [2023, 6, -1, 0],
+    [2021, 9, 6, 6],
+    [2023, 4, 10, 23],
+    [2022, 11, 4, 7],
+  ])(
+    'year = %s, month = %s, row = %s, column = %s -> 에러가 발생해야 한다.',
+    (year, month, row, column) => {
+      expect(() => getDateByPosition(year, month, row, column)).toThrow();
+    },
+  );
+});

--- a/frontend/src/utils/getDateByPosition.ts
+++ b/frontend/src/utils/getDateByPosition.ts
@@ -1,6 +1,7 @@
+import { ONE_DAY } from '~/constants/calendar';
+
 const ROW_REGEX = /^[0-5]$/;
 const COLUMN_REGEX = /^[0-6]$/;
-const ONE_DAY = 86_400_000;
 const ERROR_MESSAGE =
   '잘못된 행 또는 열이 대입되었습니다. 입력 데이터가 아래의 조건을 지키는 지 확인해 주세요:\n- 행은 0 이상 5 이하의 정수여야 합니다.\n- 열은 0 이상 6 이하의 정수여야 합니다.';
 

--- a/frontend/src/utils/getDateByPosition.ts
+++ b/frontend/src/utils/getDateByPosition.ts
@@ -1,0 +1,31 @@
+const ROW_REGEX = /^[0-5]$/;
+const COLUMN_REGEX = /^[0-6]$/;
+const ONE_DAY = 86_400_000;
+const ERROR_MESSAGE =
+  '잘못된 행 또는 열이 대입되었습니다. 입력 데이터가 아래의 조건을 지키는 지 확인해 주세요:\n- 행은 0 이상 5 이하의 정수여야 합니다.\n- 열은 0 이상 6 이하의 정수여야 합니다.';
+
+export const getDateByPosition = (
+  year: number,
+  month: number,
+  row: number,
+  column: number,
+) => {
+  throwIfInvalidRowColumn(row, column);
+
+  const firstDateOfMonth = new Date(year, month, 1);
+  const desiredDate = new Date(
+    firstDateOfMonth.getTime() +
+      ONE_DAY * (row * 7 + column - firstDateOfMonth.getDay()),
+  );
+
+  return desiredDate;
+};
+
+const throwIfInvalidRowColumn = (row: number, column: number) => {
+  if (
+    !ROW_REGEX.test(row.toString()) ||
+    !COLUMN_REGEX.test(column.toString())
+  ) {
+    throw Error(ERROR_MESSAGE);
+  }
+};


### PR DESCRIPTION
 ## 이슈번호
> close #173 

## PR 내용
본 PR에서는 년/월 정보, 그리고 캘린더의 좌표가 주어지면 이에 해당하는 날짜를 `Date` 객체로 반환하는 유틸 함수를 구현하였다.
- 예를 들어 `year = 2023`, `month = 6`, `row = 4`, `column = 3` 이라는 정보가 주어지면, 이 유틸함수는 `Wed Jul 26 2023 00:00:00 GMT+0900 (한국 표준시)` 값을 지니는 `Date` 객체를 반환한다.
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/1176d9c3-12c4-41b0-89ac-9691eb94361c)

이 유틸 함수는 스케줄 바에서의 행과 열의 정보를 바탕으로 날짜의 정보를 편리하게 받아오기 위해 사용될 예정이다.

## 참고자료
### 테스트 결과
![날짜유닛테스트](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/a497c9be-e020-4a8e-a7a5-abacbbd3d131)

## 주의사항
프론트엔드에서 백엔드로 요청할 때는 월에 대한 정보를 우리가 알고 있는 월 그대로 요청하고 (7월이면 `7`), 프론트엔드 내부에서 월에 대한 정보를 다룰 때에는 1을 뺀 값을 사용하도록 (7월이면 `6`) 일관성을 지키기 위해 루루와 함께 일부 함수의 월 대입 로직을 변경하였다. 이슈 외의 내용이므로 추가 검토가 필요하다.
