### PR TITLE
[BE] member interceptor경로설정,인증예외설정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
@@ -27,7 +27,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(memberInterceptor)
                 .order(1)
-                .addPathPatterns("/**");
+                .addPathPatterns("/api/**");
         registry.addInterceptor(teamPlaceInterceptor)
                 .order(2)
                 .addPathPatterns("/**/team-place/**");

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
@@ -34,6 +35,17 @@ public class GlobalExceptionHandler {
         log.warn(exception.getMessage(), exception);
 
         return ResponseEntity.badRequest().body("DateTime 형식이 잘못되었습니다. 서버 관리자에게 문의해주세요.");
+    }
+
+    @ExceptionHandler(value = {
+            MemberException.MemberNotFoundException.class,
+            MemberException.UnSupportAuthenticationException.class
+    })
+    public ResponseEntity<String> handleAuthenticationException(final RuntimeException exception) {
+        final String message = exception.getMessage();
+        log.warn(message, exception);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
     }
 
     @ExceptionHandler(value = {


### PR DESCRIPTION
## 이슈번호
#117

## PR 내용
member interceptor 작동 경로를 /api/**로 경로설정, 인터셉터 내부에서 발생하는 예외를 global handler로 설정

## 참고자료

## 의논할 거리
