### PR TITLE
[FE] 팀 피드 일정 알림 컴포넌트 UI 구현

### DIFF
--- a/frontend/src/components/Notification/Notification.stories.ts
+++ b/frontend/src/components/Notification/Notification.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Notification from '~/components/Notification/Notification';
+
+const meta = {
+  title: 'Feed/Notification',
+  component: Notification,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Notification>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    content: "'범죄심리학 발표자료..' 일정이 수정되었습니다.",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    content: "'범죄심리학 발표자료..' 일정이 수정되었습니다.",
+    size: 'sm',
+  },
+};

--- a/frontend/src/components/Notification/Notification.styled.ts
+++ b/frontend/src/components/Notification/Notification.styled.ts
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 import type { NotificationProps } from '~/components/Notification/Notification';
 
-export const Container = styled.div<Pick<NotificationProps, 'color' | 'size'>>`
+export const Wrapper = styled.div<Pick<NotificationProps, 'color' | 'size'>>`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/components/Notification/Notification.styled.ts
+++ b/frontend/src/components/Notification/Notification.styled.ts
@@ -1,0 +1,16 @@
+import { styled } from 'styled-components';
+import type { NotificationProps } from '~/components/Notification/Notification';
+
+export const Container = styled.div<Pick<NotificationProps, 'color' | 'size'>>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: ${({ size }) => (size === 'md' ? 50 : 42)}px;
+
+  background-color: ${({ color }) => color};
+  border-radius: 20px;
+
+  filter: brightness(1.7);
+`;

--- a/frontend/src/components/Notification/Notification.tsx
+++ b/frontend/src/components/Notification/Notification.tsx
@@ -1,0 +1,23 @@
+import Text from '~/components/common/Text/Text';
+import * as S from './Notification.styled';
+import type { NotificationSize, TextSize } from '~/types/size';
+
+export interface NotificationProps {
+  color?: string;
+  size?: NotificationSize;
+  content: string;
+}
+
+const Notification = (props: NotificationProps) => {
+  const { color = '#516FFF', content, size = 'md' } = props;
+  const textSize: Extract<TextSize, 'md' | 'xl'> = size === 'md' ? 'xl' : 'md';
+  return (
+    <S.Container color={color} size={size}>
+      <Text size={textSize} weight="bold">
+        {content}
+      </Text>
+    </S.Container>
+  );
+};
+
+export default Notification;

--- a/frontend/src/components/Notification/Notification.tsx
+++ b/frontend/src/components/Notification/Notification.tsx
@@ -11,6 +11,7 @@ export interface NotificationProps {
 const Notification = (props: NotificationProps) => {
   const { color = '#516FFF', content, size = 'md' } = props;
   const textSize: Extract<TextSize, 'md' | 'xl'> = size === 'md' ? 'xl' : 'md';
+
   return (
     <S.Container color={color} size={size}>
       <Text size={textSize} weight="bold">

--- a/frontend/src/components/Notification/Notification.tsx
+++ b/frontend/src/components/Notification/Notification.tsx
@@ -13,11 +13,11 @@ const Notification = (props: NotificationProps) => {
   const textSize: Extract<TextSize, 'md' | 'xl'> = size === 'md' ? 'xl' : 'md';
 
   return (
-    <S.Container color={color} size={size}>
+    <S.Wrapper color={color} size={size}>
       <Text size={textSize} weight="bold">
         {content}
       </Text>
-    </S.Container>
+    </S.Wrapper>
   );
 };
 

--- a/frontend/src/types/size.ts
+++ b/frontend/src/types/size.ts
@@ -5,3 +5,5 @@ export type ButtonSize = Extract<Size, 'sm' | 'md' | 'lg'>;
 export type TextSize = Size;
 
 export type DateCellSize = Extract<Size, 'sm' | 'md' | 'lg'>;
+
+export type NotificationSize = Extract<Size, 'sm' | 'md'>;


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> close #186 

## PR 내용
모아보기 페이지에서는 sm 사이즈
팀 피드 페이지에서는 md(기본)사이즈

<img width="786" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/28ac0d53-445f-4817-b099-eb7c326c9be8">

## 참고자료

## 의논할 거리
지금 팀플레이스 색상 영향을 받는 대부분의 컴포넌트가 위에서 color을 지정해주는 방식으로 하는데 어떻게 지정해서 보내줄지 슬슬 생각해보아야 할 것 같아요... 
