### PR TITLE
[FE] 일정더보기와 하루일정모달 연결

### DIFF
--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -18,6 +18,7 @@ import { arrayOf } from '~/utils/arrayOf';
 import ScheduleMoreCell from '~/components/ScheduleMoreCell/ScheduleMoreCell';
 import type { Position, ModalOpenType } from '~/types/schedule';
 import DailyScheduleModal from '~/components/DailyScheduleModal/DailyScheduleModal';
+import { getDateByPosition } from '~/utils/getDateByPosition';
 
 const Calendar = () => {
   const {
@@ -107,12 +108,27 @@ const Calendar = () => {
                       const { id, scheduleId, row, column, level, duration } =
                         scheduleBar;
                       if (row === rowIndex && level > 2)
-                        return arrayOf(duration).map((_, index) => (
-                          <ScheduleMoreCell
-                            key={id + index}
-                            column={column + index}
-                          />
-                        ));
+                        return arrayOf(duration).map((_, index) => {
+                          const date = getDateByPosition(
+                            year,
+                            month,
+                            row,
+                            column + index,
+                          );
+                          return (
+                            <ScheduleMoreCell
+                              key={id + index}
+                              column={column + index}
+                              onClick={() =>
+                                handleDailyScheduleModalOpen(
+                                  date,
+                                  row,
+                                  column + index,
+                                )
+                              }
+                            />
+                          );
+                        });
 
                       if (row === rowIndex)
                         return (

--- a/frontend/src/components/ScheduleMoreCell/ScheduleMoreCell.tsx
+++ b/frontend/src/components/ScheduleMoreCell/ScheduleMoreCell.tsx
@@ -7,9 +7,9 @@ interface ScheduleMoreCellProps extends Pick<Position, 'column'> {
 }
 
 const ScheduleMoreCell = (props: ScheduleMoreCellProps) => {
-  const { column } = props;
+  const { column, onClick } = props;
   return (
-    <S.Wrapper column={column}>
+    <S.Wrapper column={column} onClick={onClick}>
       <Text size="xs" css={S.moreText}>
         일정 더보기
       </Text>


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> close #199 

## PR 내용
유틸함수 이용해서 일정더보기를 누를 때 하루일정 모달이 뜨도록 함
위에서 3줄까지는 아래에 렌더링, 그 이후는 위에 렌더링
## 참고자료
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/6d4770af-e9ff-4bf4-9fcb-5551a0bef91a)
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/09545c24-2a8a-45be-a9d1-4d9e71fbc2c3)


## 의논할 거리
