### PR TITLE
[FE] 공통 Menu 컴포넌트 재사용성 개선

### DIFF
--- a/frontend/src/components/common/Menu/Menu.stories.tsx
+++ b/frontend/src/components/common/Menu/Menu.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { css } from 'styled-components';
 import Menu from '~/components/common/Menu/Menu';
+import MenuButton from '~/components/common/Menu/MenuButton/MenuButton';
+import MenuItem from '~/components/common/Menu/MenuItem/MenuItem';
+import MenuList from '~/components/common/Menu/MenuList/MenuList';
 
 const meta = {
   title: 'common/Menu',
@@ -8,10 +12,30 @@ const meta = {
 } satisfies Meta<typeof Menu>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    menuItems: ['메뉴 1', '메뉴 2', '메뉴 3'],
+  render: () => {
+    return (
+      <Menu>
+        <MenuButton
+          css={css`
+            background-color: #516fff;
+            width: 100px;
+            height: 50px;
+            border-radius: 4px;
+            color: #fff;
+          `}
+        >
+          메뉴 열기
+        </MenuButton>
+        <MenuList>
+          <MenuItem>메뉴 1</MenuItem>
+          <MenuItem>메뉴 2</MenuItem>
+          <MenuItem>메뉴 3</MenuItem>
+        </MenuList>
+      </Menu>
+    );
   },
 };

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,52 +1,10 @@
-import { useRef, useState } from 'react';
-import Button from '~/components/common/Button/Button';
-import * as S from './Menu.styled';
-import useClickOutside from '~/hooks/useClickOutside';
+import { MenuProvider } from '~/components/common/Menu/MenuContext';
+import type { PropsWithChildren } from 'react';
 
-interface MenuProps {
-  menuItems: string[];
-}
+const Menu = (props: PropsWithChildren) => {
+  const { children } = props;
 
-const Menu = (props: MenuProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const { menuItems } = props;
-  const menuRef = useRef<HTMLUListElement>(null);
-
-  const handleMenuOpen = () => {
-    setIsOpen((prev) => !prev);
-  };
-
-  useClickOutside(menuRef, (e: Event) => {
-    const { target } = e;
-
-    if (target instanceof HTMLButtonElement) {
-      return;
-    }
-
-    handleMenuOpen();
-  });
-
-  return (
-    <>
-      <Button
-        type="button"
-        aria-haspopup="true"
-        aria-expanded={isOpen}
-        onClick={handleMenuOpen}
-      >
-        메뉴 열기
-      </Button>
-      {isOpen && (
-        <S.MenuWrapper role="menu" ref={menuRef}>
-          {menuItems.map((menuItem) => (
-            <S.MenuItem role="menuitem" key={menuItem}>
-              {menuItem}
-            </S.MenuItem>
-          ))}
-        </S.MenuWrapper>
-      )}
-    </>
-  );
+  return <MenuProvider>{children}</MenuProvider>;
 };
 
 export default Menu;

--- a/frontend/src/components/common/Menu/MenuButton/MenuButton.tsx
+++ b/frontend/src/components/common/Menu/MenuButton/MenuButton.tsx
@@ -1,0 +1,26 @@
+import Button from '~/components/common/Button/Button';
+import type { ButtonProps } from '~/components/common/Button/Button';
+import type { PropsWithChildren } from 'react';
+import { useMenu } from '~/hooks/useMenu';
+
+type MenuButtonProps = ButtonProps;
+
+const MenuButton = (props: PropsWithChildren<MenuButtonProps>) => {
+  const { children, ...rest } = props;
+  const { isMenuOpen, handleMenuOpen } = useMenu();
+
+  return (
+    <Button
+      type="button"
+      variant="plain"
+      aria-haspopup="true"
+      aria-expanded={isMenuOpen}
+      onClick={handleMenuOpen}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export default MenuButton;

--- a/frontend/src/components/common/Menu/MenuContext.tsx
+++ b/frontend/src/components/common/Menu/MenuContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+
+interface MenuContextProps {
+  isMenuOpen: boolean;
+  handleMenuOpen: () => void;
+}
+
+export const MenuContext = createContext<MenuContextProps>(
+  {} as MenuContextProps,
+);
+
+export const MenuProvider = (props: PropsWithChildren) => {
+  const { children } = props;
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleMenuOpen = () => {
+    setIsMenuOpen((prev) => !prev);
+  };
+
+  const value = { isMenuOpen, handleMenuOpen };
+
+  return <MenuContext.Provider value={value}>{children}</MenuContext.Provider>;
+};

--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
@@ -1,0 +1,5 @@
+import { styled } from 'styled-components';
+
+export const Wrapper = styled.div`
+  padding: 8px 12px;
+`;

--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
@@ -1,5 +1,6 @@
 import { styled } from 'styled-components';
+import type { MenuItemProps } from '~/components/common/Menu/MenuItem/MenuItem';
 
-export const Wrapper = styled.li`
+export const Wrapper = styled.li<MenuItemProps>`
   padding: 8px 12px;
 `;

--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.li`
   padding: 8px 12px;
 `;

--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.styled.ts
@@ -3,4 +3,6 @@ import type { MenuItemProps } from '~/components/common/Menu/MenuItem/MenuItem';
 
 export const Wrapper = styled.li<MenuItemProps>`
   padding: 8px 12px;
+
+  ${({ css }) => css}
 `;

--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.tsx
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.tsx
@@ -1,0 +1,10 @@
+import * as S from './MenuItem.styled';
+import type { PropsWithChildren } from 'react';
+
+const MenuItem = (props: PropsWithChildren) => {
+  const { children } = props;
+
+  return <S.Wrapper role="menuitem">{children}</S.Wrapper>;
+};
+
+export default MenuItem;

--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.tsx
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.tsx
@@ -1,10 +1,19 @@
 import * as S from './MenuItem.styled';
 import type { PropsWithChildren } from 'react';
+import type { CSSProp } from 'styled-components';
 
-const MenuItem = (props: PropsWithChildren) => {
-  const { children } = props;
+export interface MenuItemProps {
+  css: CSSProp;
+}
 
-  return <S.Wrapper role="menuitem">{children}</S.Wrapper>;
+const MenuItem = (props: PropsWithChildren<MenuItemProps>) => {
+  const { children, css } = props;
+
+  return (
+    <S.Wrapper role="menuitem" css={css}>
+      {children}
+    </S.Wrapper>
+  );
 };
 
 export default MenuItem;

--- a/frontend/src/components/common/Menu/MenuList/MenuList.styled.ts
+++ b/frontend/src/components/common/Menu/MenuList/MenuList.styled.ts
@@ -1,14 +1,11 @@
 import { styled } from 'styled-components';
+import type { MenuListProps } from '~/components/common/Menu/MenuList/MenuList';
 
-export const MenuWrapper = styled.ul`
+export const Wrapper = styled.ul<MenuListProps>`
   max-height: 200px;
-  width: 200px;
+  width: ${({ width }) => width};
   overflow-y: auto;
 
   border: 1px solid ${({ theme }) => theme.color.GRAY200};
   border-radius: 6px;
-`;
-
-export const MenuItem = styled.li`
-  padding: 8px 12px;
 `;

--- a/frontend/src/components/common/Menu/MenuList/MenuList.tsx
+++ b/frontend/src/components/common/Menu/MenuList/MenuList.tsx
@@ -1,0 +1,36 @@
+import { useRef, type PropsWithChildren } from 'react';
+import { useMenu } from '~/hooks/useMenu';
+import useClickOutside from '~/hooks/useClickOutside';
+import * as S from './MenuList.styled';
+
+export interface MenuListProps {
+  width?: string;
+}
+
+const MenuList = (props: PropsWithChildren<MenuListProps>) => {
+  const { children, width = '100%' } = props;
+  const { isMenuOpen, handleMenuOpen } = useMenu();
+  const ref = useRef<HTMLUListElement>(null);
+
+  useClickOutside(ref, (e: Event) => {
+    const { target } = e;
+
+    if (target instanceof HTMLButtonElement) {
+      return;
+    }
+
+    handleMenuOpen();
+  });
+
+  return (
+    <>
+      {isMenuOpen && (
+        <S.Wrapper role="menu" ref={ref} width={width}>
+          {children}
+        </S.Wrapper>
+      )}
+    </>
+  );
+};
+
+export default MenuList;

--- a/frontend/src/hooks/useMenu.ts
+++ b/frontend/src/hooks/useMenu.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { MenuContext } from '~/components/common/Menu/MenuContext';
+
+export const useMenu = () => {
+  const context = useContext(MenuContext);
+
+  if (context === undefined) {
+    throw new Error('useMenu must be used within a MenuProvider');
+  }
+
+  return context;
+};


### PR DESCRIPTION
# [FE] 공통 Menu 컴포넌트 재사용성 개선
## 이슈번호
> close #204

## PR 내용
- Compound component 패턴을 적용하여 팀 플레이스, 시간대 선택 등 여러 파생 Menu로 재사용하기 용이하도록 개선
- 사용법은 Story를 보면 알 수 있습니다

## 참고자료
[Vercel - Menu](https://vercel.com/design/menu)
[합성 컴포넌트로 재사용성 극대화하기](https://fe-developers.kakaoent.com/2022/220731-composition-component/)
