### PR TITLE
[FE] 하루일정모달의 달이 실제보다 하나 적은 버그 픽스

### DIFF
--- a/frontend/src/components/DailyScheduleModal/DailyScheduleModal.tsx
+++ b/frontend/src/components/DailyScheduleModal/DailyScheduleModal.tsx
@@ -52,7 +52,7 @@ const DailyScheduleModal = (props: DailyScheduleModalProps) => {
       <S.Container style={modalLocation}>
         <S.Header>
           <Text>
-            {month}월 {date}일
+            {month + 1}월 {date}일
           </Text>
           <Button
             variant="plain"


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> #223 

## PR 내용
Date 객체의 달을 사용하고 있어서 0~11까지 값을 보여주고 있던 것을 고쳤습니다 

## 참고자료

## 의논할 거리
