### PR TITLE
[BE] 팀 캘린더 하루 일정 조회 로직 리팩토링

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
@@ -3,7 +3,6 @@ package team.teamby.teambyteam.schedule.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleResponse;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
@@ -91,7 +90,7 @@ public class TeamCalendarScheduleService {
 
         final CalendarPeriod dailyPeriod = CalendarPeriod.of(targetYear, targetMonth, targetDay);
         final List<Schedule> dailySchedules = scheduleRepository
-                .findAllByTeamPlaceIdAndDailyPeriod(teamPlaceId, dailyPeriod.startDateTime(), dailyPeriod.endDatetime());
+                .findAllByTeamPlaceIdAndPeriod(teamPlaceId, dailyPeriod.startDateTime(), dailyPeriod.endDatetime());
 
         return SchedulesResponse.of(dailySchedules);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/CalendarPeriod.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/CalendarPeriod.java
@@ -10,8 +10,8 @@ public record CalendarPeriod(
 ) {
     private static final int FIRST_DAY_OF_MONTH = 1;
     private static final LocalTime START_TIME_OF_DAY = LocalTime.of(0, 0, 0);
-    private static final LocalTime END_TIME_OF_DAY = LocalTime.of(23, 59, 59);
-    public static final int NEXT_MONTH_OFFSET = 1;
+    private static final int NEXT_MONTH_OFFSET = 1;
+    private static final int NEXT_DAY_OFFSET = 1;
 
     public static CalendarPeriod of(final int year, final int month) {
         final LocalDate startDate = LocalDate.of(year, month, FIRST_DAY_OF_MONTH);
@@ -22,7 +22,8 @@ public record CalendarPeriod(
 
     public static CalendarPeriod of(final int year, final int month, final int day) {
         LocalDate dailyDate = LocalDate.of(year, month, day);
+        LocalDate nextDay = dailyDate.plusDays(NEXT_DAY_OFFSET);
 
-        return new CalendarPeriod(LocalDateTime.of(dailyDate, START_TIME_OF_DAY), LocalDateTime.of(dailyDate, END_TIME_OF_DAY));
+        return new CalendarPeriod(LocalDateTime.of(nextDay, START_TIME_OF_DAY), LocalDateTime.of(dailyDate, START_TIME_OF_DAY));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/CalendarPeriod.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/CalendarPeriod.java
@@ -24,6 +24,6 @@ public record CalendarPeriod(
         LocalDate dailyDate = LocalDate.of(year, month, day);
         LocalDate nextDay = dailyDate.plusDays(NEXT_DAY_OFFSET);
 
-        return new CalendarPeriod(LocalDateTime.of(nextDay, START_TIME_OF_DAY), LocalDateTime.of(dailyDate, START_TIME_OF_DAY));
+        return new CalendarPeriod(LocalDateTime.of(dailyDate, START_TIME_OF_DAY), LocalDateTime.of(nextDay, START_TIME_OF_DAY));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/ScheduleRepository.java
@@ -48,10 +48,18 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             LocalDateTime lastDateTime
     );
 
+    /**
+     * Find All schedules contains daily schedules
+     * @param teamPlaceId teamPlaceId for the schedule
+     * EX Daily : 2023-07-12
+     * @param firstDateTime first-date-time of the period (2023-07-13 00:00:00)
+     * @param lastDateTime last-date-time of the period (2023-07-12 00:00:00)
+     * @return List of the Schedules. If there is no Schedule, it will return the List with size 0.
+     */
     @Query("SELECT s FROM Schedule s " +
             "WHERE s.teamPlaceId = :teamPlaceId " +
-            "AND s.span.startDateTime >= :firstDateTime " +
-            "AND s.span.endDateTime <= :lastDateTime " +
+            "AND s.span.startDateTime < :firstDateTime " +
+            "AND s.span.endDateTime >= :lastDateTime " +
             "ORDER BY s.span.startDateTime ASC"
     )
     List<Schedule> findAllByTeamPlaceIdAndDailyPeriod(

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/ScheduleRepository.java
@@ -47,24 +47,4 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             LocalDateTime firstDateTime,
             LocalDateTime lastDateTime
     );
-
-    /**
-     * Find All schedules contains daily schedules
-     * @param teamPlaceId teamPlaceId for the schedule
-     * EX Daily : 2023-07-12
-     * @param firstDateTime first-date-time of the period (2023-07-13 00:00:00)
-     * @param lastDateTime last-date-time of the period (2023-07-12 00:00:00)
-     * @return List of the Schedules. If there is no Schedule, it will return the List with size 0.
-     */
-    @Query("SELECT s FROM Schedule s " +
-            "WHERE s.teamPlaceId = :teamPlaceId " +
-            "AND s.span.startDateTime < :firstDateTime " +
-            "AND s.span.endDateTime >= :lastDateTime " +
-            "ORDER BY s.span.startDateTime ASC"
-    )
-    List<Schedule> findAllByTeamPlaceIdAndDailyPeriod(
-            Long teamPlaceId,
-            LocalDateTime firstDateTime,
-            LocalDateTime lastDateTime
-    );
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/ScheduleFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/ScheduleFixtures.java
@@ -15,7 +15,7 @@ public class ScheduleFixtures {
      */
     public static final String MONTH_5_FIRST_DAY_SCHEDULE_TITLE = "5월 첫 날 일정";
     public static final String MONTH_5_LAST_DAY_SCHEDULE_TITLE = "5월 마지막 날 일정";
-    public static final String MONTH_6_AND_MONTH_7_SCHEDULE_TITLE = "6월~7월 일정";
+    public static final String MONTH_6_AND_MONTH_7_SCHEDULE_TITLE = "6월~7월 12일 일정";
     public static final String MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_TITLE = "7월 12일 N시간 일정";
     public static final String MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE_TITLE = "7월 12일 종일 일정";
     public static final String MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE_TITLE = "7월 28일~8월 일정";
@@ -58,7 +58,7 @@ public class ScheduleFixtures {
         return new Schedule(teamPlaceId, new Title(teamPlaceId + "번 팀플 " + MONTH_5_LAST_DAY_SCHEDULE_TITLE), new Span(DATE_2023_05_31_00_00_00, DATE_2023_05_31_23_59_59));
     }
 
-    public static Schedule MONTH_6_AND_MONTH_7_SCHEDULE(final Long teamPlaceId) {
+    public static Schedule MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE(final Long teamPlaceId) {
         return new Schedule(teamPlaceId, new Title(teamPlaceId + "번 팀플 " + MONTH_6_AND_MONTH_7_SCHEDULE_TITLE), new Span(DATE_2023_06_25_10_00_00, DATE_2023_07_12_18_00_00));
     }
 

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
@@ -102,7 +102,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
         void findAllInPeriod() {
             // given
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            final Schedule MONTH_6_AND_MONTH_7_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_6_AND_MONTH_7_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
+            final Schedule MONTH_6_AND_MONTH_7_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
             final Schedule MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
             final Schedule MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
             final Schedule MONTH_7_DAY_29_AND_MONTH_8_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_DAY_29_AND_MONTH_8_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
@@ -176,6 +176,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final Long ENGLISH_TEAM_PLACE_ID = ENGLISH_TEAM_PLACE.getId();
             final Schedule MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE_ID));
             final Schedule MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE(ENGLISH_TEAM_PLACE_ID));
+            final Schedule MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE(ENGLISH_TEAM_PLACE_ID));
 
             final int year = MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getSpan().getStartDateTime().getYear();
             final int month = MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getSpan().getStartDateTime().getMonthValue();
@@ -188,10 +189,14 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(dailyTeamCalendarSchedulesResponses).hasSize(2);
+                softly.assertThat(dailyTeamCalendarSchedulesResponses).hasSize(3);
                 softly.assertThat(dailyTeamCalendarSchedulesResponses.stream()
                                 .map(ScheduleResponse::title))
-                        .containsExactly(MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE.getTitle().getValue(), MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getTitle().getValue());
+                        .containsExactly(
+                                MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE.getTitle().getValue(),
+                                MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE.getTitle().getValue(),
+                                MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getTitle().getValue()
+                                );
             });
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/domain/ScheduleRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/domain/ScheduleRepositoryTest.java
@@ -82,11 +82,11 @@ public class ScheduleRepositoryTest extends RepositoryTest {
         );
         final List<Schedule> expectedSchedule = testFixtureBuilder.buildSchedules(schedulesToSave);
 
-        final LocalDateTime startDateTime = LocalDateTime.of(2023, 7, 13, 0, 0, 0);
-        final LocalDateTime endDateTime = LocalDateTime.of(2023, 7, 12, 0, 0, 0);
+        final LocalDateTime startDateTime = LocalDateTime.of(2023, 7, 12, 0, 0, 0);
+        final LocalDateTime endDateTime = LocalDateTime.of(2023, 7, 13, 0, 0, 0);
 
         // when
-        final List<Schedule> actualSchedules = scheduleRepository.findAllByTeamPlaceIdAndDailyPeriod(ENGLISH_TEAM_PLACE_ID, startDateTime, endDateTime);
+        final List<Schedule> actualSchedules = scheduleRepository.findAllByTeamPlaceIdAndPeriod(ENGLISH_TEAM_PLACE_ID, startDateTime, endDateTime);
 
         // then
         Assertions.assertThat(actualSchedules).usingRecursiveFieldByFieldElementComparator()

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/domain/ScheduleRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/domain/ScheduleRepositoryTest.java
@@ -75,11 +75,15 @@ public class ScheduleRepositoryTest extends RepositoryTest {
         // given
         final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
         final Long ENGLISH_TEAM_PLACE_ID = ENGLISH_TEAM_PLACE.getId();
-        final List<Schedule> schedulesToSave = List.of(MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE(ENGLISH_TEAM_PLACE_ID), MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE_ID));
+        final List<Schedule> schedulesToSave = List.of(
+                MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE(ENGLISH_TEAM_PLACE_ID),
+                MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE(ENGLISH_TEAM_PLACE_ID),
+                MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE_ID)
+        );
         final List<Schedule> expectedSchedule = testFixtureBuilder.buildSchedules(schedulesToSave);
 
-        final LocalDateTime startDateTime = LocalDateTime.of(2023, 7, 12, 0, 0, 0);
-        final LocalDateTime endDateTime = LocalDateTime.of(2023, 7, 12, 23, 59, 59);
+        final LocalDateTime startDateTime = LocalDateTime.of(2023, 7, 13, 0, 0, 0);
+        final LocalDateTime endDateTime = LocalDateTime.of(2023, 7, 12, 0, 0, 0);
 
         // when
         final List<Schedule> actualSchedules = scheduleRepository.findAllByTeamPlaceIdAndDailyPeriod(ENGLISH_TEAM_PLACE_ID, startDateTime, endDateTime);


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> #231 

## PR 내용

- ScheduleRepository 기존 쿼리 사용
```java
// ScheduleRepository
    @Query("SELECT s FROM Schedule s " +
            "WHERE s.teamPlaceId = :teamPlaceId " +
            "AND s.span.startDateTime < :lastDateTime " +
            "AND s.span.endDateTime >= :firstDateTime " +
            "ORDER BY s.span.startDateTime ASC"
    )
```

```java
// CalendarPeriod
        public static CalendarPeriod of(final int year, final int month, final int day) {
        LocalDate dailyDate = LocalDate.of(year, month, day);
        LocalDate nextDay = dailyDate.plusDays(NEXT_DAY_OFFSET);

        return new CalendarPeriod(LocalDateTime.of(dailyDate, START_TIME_OF_DAY), LocalDateTime.of(nextDay, START_TIME_OF_DAY));
    }
    }
```

- 7월 12일 하루 일정 조회 시
  - firstDateTime : 2023-07-13 00:00:00 으로 DB Schedule의 startDateTime이 firstDateTime보다 이전인 경우 조건
  - lastDateTime : 2023-07-12 00:00:00 으로 DB Schedule의 endDateTime이 lastDateTime보다 이후인 경우 조건

## 참고자료

## 의논할 거리
