### PR TITLE
[BE] Member, MemberTeamPlace, TeamPlace 구조 및 연관관계 리팩터링

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/presentation/TeamPlaceInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/presentation/TeamPlaceInterceptor.java
@@ -8,9 +8,9 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import team.teamby.teambyteam.auth.jwt.JwtTokenExtractor;
 import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
-import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.Map;
@@ -21,7 +21,7 @@ public final class TeamPlaceInterceptor implements HandlerInterceptor {
 
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenProvider jwtTokenProvider;
-    private final TeamPlaceRepository teamPlaceRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
@@ -37,8 +37,8 @@ public final class TeamPlaceInterceptor implements HandlerInterceptor {
     }
 
     private boolean hasNotMemberInTeamPlace(final Long teamPlaceId, final String email) {
-        final TeamPlace teamPlace = teamPlaceRepository.findById(teamPlaceId)
+        final Member member = memberRepository.findByEmail(new Email(email))
                 .orElseThrow(TeamPlaceException.NotFoundException::new);
-        return !teamPlace.hasMemberByMemberEmail(new Email(email));
+        return !member.isMemberOf(teamPlaceId);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/presentation/TeamPlaceParticipationInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/presentation/TeamPlaceParticipationInterceptor.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public final class TeamPlaceInterceptor implements HandlerInterceptor {
+public final class TeamPlaceParticipationInterceptor implements HandlerInterceptor {
 
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenProvider jwtTokenProvider;

--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import team.teamby.teambyteam.member.configuration.MemberArgumentResolver;
 import team.teamby.teambyteam.auth.presentation.MemberInterceptor;
-import team.teamby.teambyteam.auth.presentation.TeamPlaceInterceptor;
+import team.teamby.teambyteam.auth.presentation.TeamPlaceParticipationInterceptor;
 
 import java.util.List;
 
@@ -16,7 +16,7 @@ import java.util.List;
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
     private final MemberInterceptor memberInterceptor;
-    private final TeamPlaceInterceptor teamPlaceInterceptor;
+    private final TeamPlaceParticipationInterceptor teamPlaceParticipationInterceptor;
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
@@ -28,7 +28,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
         registry.addInterceptor(memberInterceptor)
                 .order(1)
                 .addPathPatterns("/api/**");
-        registry.addInterceptor(teamPlaceInterceptor)
+        registry.addInterceptor(teamPlaceParticipationInterceptor)
                 .order(2)
                 .addPathPatterns("/**/team-place/**");
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -1,6 +1,13 @@
 package team.teamby.teambyteam.member.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,5 +57,11 @@ public class Member extends BaseEntity {
         return getMemberTeamPlaces().stream()
                 .map(MemberTeamPlace::getTeamPlace)
                 .toList();
+    }
+
+    public boolean isMemberOf(final Long targetTeamPlaceId) {
+        return getMemberTeamPlaces().stream()
+                .mapToLong(memberTeamPlace -> memberTeamPlace.getMember().getId())
+                .anyMatch(teamPlaceId -> teamPlaceId == targetTeamPlaceId);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberIdAndDisplayNameOnly.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberIdAndDisplayNameOnly.java
@@ -1,0 +1,9 @@
+package team.teamby.teambyteam.member.domain;
+
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
+
+public record MemberIdAndDisplayNameOnly(
+        Long id,
+        DisplayMemberName displayMemberName
+) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -25,11 +25,11 @@ public class MemberTeamPlace extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(nullable = false, updatable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(nullable = false, updatable = false)
     private TeamPlace teamPlace;
 
     @Embedded
@@ -44,6 +44,5 @@ public class MemberTeamPlace extends BaseEntity {
         this.displayMemberName = new DisplayMemberName(member.getName().getValue());
         this.displayTeamPlaceName = new DisplayTeamPlaceName(teamPlace.getName().getValue());
         member.getMemberTeamPlaces().add(this);
-        teamPlace.getMemberTeamPlaces().add(this);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -1,9 +1,18 @@
 package team.teamby.teambyteam.member.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
+import team.teamby.teambyteam.member.domain.vo.DisplayTeamPlaceName;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
 @Getter
@@ -23,9 +32,17 @@ public class MemberTeamPlace extends BaseEntity {
     @JoinColumn(nullable = false)
     private TeamPlace teamPlace;
 
+    @Embedded
+    private DisplayMemberName displayMemberName;
+
+    @Embedded
+    private DisplayTeamPlaceName displayTeamPlaceName;
+
     public void setMemberAndTeamPlace(final Member member, final TeamPlace teamPlace) {
         this.member = member;
         this.teamPlace = teamPlace;
+        this.displayMemberName = new DisplayMemberName(member.getName().getValue());
+        this.displayTeamPlaceName = new DisplayTeamPlaceName(teamPlace.getName().getValue());
         member.getMemberTeamPlaces().add(this);
         teamPlace.getMemberTeamPlaces().add(this);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
@@ -2,5 +2,12 @@ package team.teamby.teambyteam.member.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MemberTeamPlaceRepository extends JpaRepository<MemberTeamPlace, Long> {
+
+    Optional<MemberIdAndDisplayNameOnly> findByTeamPlaceIdAndMemberId(Long teamPlaceId, Long memberId);
+
+    List<MemberIdAndDisplayNameOnly> findAllByTeamPlaceId(Long teamPlaceId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberName.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberName.java
@@ -1,0 +1,40 @@
+package team.teamby.teambyteam.member.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class DisplayMemberName {
+
+    private static final int MAX_LENGTH = 20;
+
+    @Column(name = "display_member_name", nullable = false, length = MAX_LENGTH)
+    private String value;
+
+    public DisplayMemberName(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (Objects.isNull(value)) {
+            throw new NullPointerException("멤버 이름은 null일 수 없습니다.");
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new MemberTeamPlaceException.MemberDisplayNameLengthException();
+        }
+        if (value.isBlank()) {
+            throw new MemberTeamPlaceException.MemberNameBlankException();
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/DisplayTeamPlaceName.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/DisplayTeamPlaceName.java
@@ -1,0 +1,40 @@
+package team.teamby.teambyteam.member.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class DisplayTeamPlaceName {
+
+    private static final int MAX_LENGTH = 30;
+
+    @Column(name = "display_team_place_name", nullable = false, length = MAX_LENGTH)
+    private String value;
+
+    public DisplayTeamPlaceName(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (Objects.isNull(value)) {
+            throw new NullPointerException("팀플레이스의 이름은 null일 수 없습니다.");
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new MemberTeamPlaceException.TeamPlaceDisplayNameLengthException();
+        }
+        if (value.isBlank()) {
+            throw new MemberTeamPlaceException.TeamPlaceNameBlankException();
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberTeamPlaceException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberTeamPlaceException.java
@@ -1,0 +1,32 @@
+package team.teamby.teambyteam.member.exception;
+
+public class MemberTeamPlaceException extends RuntimeException {
+
+    public MemberTeamPlaceException(final String message) {
+        super(message);
+    }
+
+    public static class MemberDisplayNameLengthException extends MemberTeamPlaceException {
+        public MemberDisplayNameLengthException() {
+            super("멤버 이름의 길이가 최대 이름 길이를 초과했습니다.");
+        }
+    }
+
+    public static class MemberNameBlankException extends MemberTeamPlaceException {
+        public MemberNameBlankException() {
+            super("멤버 이름은 공백을 제외한 1자 이상이어야합니다.");
+        }
+    }
+
+    public static class TeamPlaceDisplayNameLengthException extends MemberTeamPlaceException {
+        public TeamPlaceDisplayNameLengthException() {
+            super("팀플레이스의 이름의 길이가 최대 이름 길이를 초과했습니다.");
+        }
+    }
+
+    public static class TeamPlaceNameBlankException extends MemberTeamPlaceException {
+        public TeamPlaceNameBlankException() {
+            super("팀플레이스의 이름은 공백을 제외한 1자 이상이어야합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlace.java
@@ -1,16 +1,15 @@
 package team.teamby.teambyteam.teamplace.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.global.domain.BaseEntity;
-import team.teamby.teambyteam.member.domain.MemberTeamPlace;
-import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.teamplace.domain.vo.Name;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -24,18 +23,7 @@ public class TeamPlace extends BaseEntity {
     @Embedded
     private Name name;
 
-    @OneToMany(mappedBy = "teamPlace", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
-    private List<MemberTeamPlace> memberTeamPlaces;
-
     public TeamPlace(final Name name) {
         this.name = name;
-        this.memberTeamPlaces = new ArrayList<>();
-    }
-
-    public boolean hasMemberByMemberEmail(final Email email) {
-        return memberTeamPlaces.stream()
-                .anyMatch(memberTeamPlace -> memberTeamPlace.getMember()
-                        .getEmail()
-                        .equals(email));
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
@@ -1,0 +1,62 @@
+package team.teamby.teambyteam.member.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import team.teamby.teambyteam.common.RepositoryTest;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import java.util.List;
+
+class MemberTeamPlaceRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private MemberTeamPlaceRepository memberTeamPlaceRepository;
+
+    @Test
+    @DisplayName("멤버아이디와 소속된 팀의 아이디로 해당 팀에서의 사용자 이름을 조회한다.")
+    void findMemberIdAndDisplayNameByTeamPlaceIdAndMemberId() {
+        // given
+        final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+        final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+        testFixtureBuilder.buildMemberTeamPlace(PHILIP, ENGLISH_TEAM_PLACE);
+
+        // when
+        final MemberIdAndDisplayNameOnly actual = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(ENGLISH_TEAM_PLACE.getId(), PHILIP.getId()).get();
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(actual.id()).isEqualTo(PHILIP.getId());
+            softly.assertThat(actual.displayMemberName().getValue()).isEqualTo(PHILIP.getName().getValue());
+        });
+    }
+
+    @Test
+    @DisplayName("팀플레이스에 소속된 모든 멤버들의 아이디와 해당 팀에서의 사용자 이름을 조회한다.")
+    void findAllMemberIdAndDisplayNameByTeamPlace() {
+        // given
+        final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+        final Member ENDLE = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+        final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+        testFixtureBuilder.buildMemberTeamPlace(PHILIP, ENGLISH_TEAM_PLACE);
+        testFixtureBuilder.buildMemberTeamPlace(ENDLE, ENGLISH_TEAM_PLACE);
+
+        // when
+        final List<MemberIdAndDisplayNameOnly> actual = memberTeamPlaceRepository.findAllByTeamPlaceId(ENGLISH_TEAM_PLACE.getId());
+        final List<String> displayNames = actual.stream()
+                .map(MemberIdAndDisplayNameOnly::displayMemberName)
+                .map(DisplayMemberName::getValue)
+                .toList();
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(actual).hasSize(2);
+            softly.assertThat(displayNames).containsExactlyInAnyOrder(PHILIP.getName().getValue(), ENDLE.getName().getValue());
+        });
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
@@ -58,5 +58,4 @@ class MemberTeamPlaceRepositoryTest extends RepositoryTest {
             softly.assertThat(displayNames).containsExactlyInAnyOrder(PHILIP.getName().getValue(), ENDLE.getName().getValue());
         });
     }
-
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceTest.java
@@ -9,7 +9,6 @@ import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
 class MemberTeamPlaceTest {
 
-
     @Test
     @DisplayName("멤버와 팀플레이스를 통해 멤버팀플레이스를 생성시 기본 이름으로 display name들이 설정된다.")
     void setDefaultDisplayName() {
@@ -27,5 +26,4 @@ class MemberTeamPlaceTest {
             softly.assertThat(memberTeamPlace.getDisplayTeamPlaceName().getValue()).isEqualTo(japaneseTeamPlace.getName().getValue());
         });
     }
-
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceTest.java
@@ -1,0 +1,31 @@
+package team.teamby.teambyteam.member.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+class MemberTeamPlaceTest {
+
+
+    @Test
+    @DisplayName("멤버와 팀플레이스를 통해 멤버팀플레이스를 생성시 기본 이름으로 display name들이 설정된다.")
+    void setDefaultDisplayName() {
+        // given
+        final Member philip = MemberFixtures.PHILIP();
+        final TeamPlace japaneseTeamPlace = TeamPlaceFixtures.JAPANESE_TEAM_PLACE();
+        final MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+
+        // when
+        memberTeamPlace.setMemberAndTeamPlace(philip, japaneseTeamPlace);
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(memberTeamPlace.getDisplayMemberName().getValue()).isEqualTo(philip.getName().getValue());
+            softly.assertThat(memberTeamPlace.getDisplayTeamPlaceName().getValue()).isEqualTo(japaneseTeamPlace.getName().getValue());
+        });
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberNameTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberNameTest.java
@@ -1,0 +1,43 @@
+package team.teamby.teambyteam.member.domain.vo;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+
+class DisplayMemberNameTest {
+
+    @Test
+    @DisplayName("팀플레이스에 사용할 멤버의 이름으로 null value가 입력되면 예외를 발생시킨다.")
+    void failWithNullValue() {
+        // given
+        final String nullString = null;
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> new DisplayMemberName(nullString))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("멤버 이름은 null일 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   "})
+    @DisplayName("팀플레이스에 사용할 멤버의 이름으로는 공백이 들어올 수 없다.")
+    void failWithBlankDisplayName(final String value) {
+        // when & then
+        Assertions.assertThatThrownBy(() -> new DisplayMemberName(value))
+                .isInstanceOf(MemberTeamPlaceException.MemberNameBlankException.class)
+                .hasMessage("멤버 이름은 공백을 제외한 1자 이상이어야합니다.");
+    }
+
+    @Test
+    @DisplayName("팀플레이스에 사용할 멤버의 이름으로는 20자가 초과할 수 없다.")
+    void failWithOverNameLength() {
+        // when & then
+        Assertions.assertThatThrownBy(() -> new DisplayMemberName(".".repeat(21)))
+                .isInstanceOf(MemberTeamPlaceException.MemberDisplayNameLengthException.class)
+                .hasMessage("멤버 이름의 길이가 최대 이름 길이를 초과했습니다.");
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberNameTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberNameTest.java
@@ -39,5 +39,4 @@ class DisplayMemberNameTest {
                 .isInstanceOf(MemberTeamPlaceException.MemberDisplayNameLengthException.class)
                 .hasMessage("멤버 이름의 길이가 최대 이름 길이를 초과했습니다.");
     }
-
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayTeamPlaceNameTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayTeamPlaceNameTest.java
@@ -1,0 +1,44 @@
+package team.teamby.teambyteam.member.domain.vo;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+
+class DisplayTeamPlaceNameTest {
+
+    @Test
+    @DisplayName("팀플레이스의 별명으로 null value가 입력되면 예외를 발생시킨다.")
+    void failWithNullValue() {
+        // given
+        final String nullString = null;
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> new DisplayTeamPlaceName(nullString))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("팀플레이스의 이름은 null일 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   "})
+    @DisplayName("팀플레이스의 별명으로는 공백이 들어올 수 없다.")
+    void failWithBlankDisplayName(final String value) {
+        // when & then
+        Assertions.assertThatThrownBy(() -> new DisplayTeamPlaceName(value))
+                .isInstanceOf(MemberTeamPlaceException.TeamPlaceNameBlankException.class)
+                .hasMessage("팀플레이스의 이름은 공백을 제외한 1자 이상이어야합니다.");
+    }
+
+    @Test
+    @DisplayName("팀플레이스의 별명으로는 20자가 초과할 수 없다.")
+    void failWithOverNameLength() {
+        // when & then
+        Assertions.assertThatThrownBy(() -> new DisplayTeamPlaceName(".".repeat(31)))
+                .isInstanceOf(MemberTeamPlaceException.TeamPlaceDisplayNameLengthException.class)
+                .hasMessage("팀플레이스의 이름의 길이가 최대 이름 길이를 초과했습니다.");
+    }
+
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayTeamPlaceNameTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayTeamPlaceNameTest.java
@@ -39,6 +39,4 @@ class DisplayTeamPlaceNameTest {
                 .isInstanceOf(MemberTeamPlaceException.TeamPlaceDisplayNameLengthException.class)
                 .hasMessage("팀플레이스의 이름의 길이가 최대 이름 길이를 초과했습니다.");
     }
-
-
 }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/TeamCalendarScheduleAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/acceptance/TeamCalendarScheduleAcceptanceTest.java
@@ -34,10 +34,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
 import static team.teamby.teambyteam.common.fixtures.MemberTeamPlaceFixtures.PHILIP_ENGLISH_TEAM_PLACE;
-import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.*;
+import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_ALL_DAY_SCHEDULE;
+import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE;
+import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_REGISTER_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_TITLE;
+import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_UPDATE_REQUEST;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
-import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.*;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.DELETE_SCHEDULE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.FIND_DAILY_SCHEDULE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.FIND_PERIOD_SCHEDULE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.FIND_SPECIFIC_SCHEDULE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.REGISTER_SCHEDULE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamCalendarScheduleAcceptanceFixtures.UPDATE_SCHEDULE_REQUEST;
 
 public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
 
@@ -270,7 +279,7 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("조회할 팀 플레이스가 존재하지 않으면 조회에 실패한다.")
+        @DisplayName("조회할 팀 플레이스에 속해있지 않으면 조회에 실패한다.")
         void failTeamPlaceNotExist() {
             // given
             final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
@@ -284,8 +293,8 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(response.body().asString()).isEqualTo("조회한 팀 플레이스가 존재하지 않습니다.");
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(response.body().asString()).isEqualTo("접근할 수 없는 팀플레이스입니다.");
             });
         }
     }
@@ -472,7 +481,7 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("없는 팀 플레이스 ID로 요청하면 실패한다.")
+        @DisplayName("소속되지 않는 팀 플레이스 ID로 요청하면 실패한다.")
         void failNotExistTeamPlaceIdRequest() {
             // given
             Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
@@ -483,8 +492,8 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(notExistTeamPlaceIdRequest.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(notExistTeamPlaceIdRequest.body().asString()).isEqualTo("조회한 팀 플레이스가 존재하지 않습니다.");
+                softly.assertThat(notExistTeamPlaceIdRequest.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(notExistTeamPlaceIdRequest.body().asString()).isEqualTo("접근할 수 없는 팀플레이스입니다.");
             });
         }
 
@@ -579,7 +588,7 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("없는 팀 플레이스 ID로 요청하면 실패한다.")
+        @DisplayName("소속되지 않는 팀 플레이스 ID로 요청하면 실패한다.")
         void failNotExistTeamPlaceIdRequest() {
             // given
             final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
@@ -597,8 +606,8 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(notExistTeamPlaceIdRequest.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(notExistTeamPlaceIdRequest.body().asString()).isEqualTo("조회한 팀 플레이스가 존재하지 않습니다.");
+                softly.assertThat(notExistTeamPlaceIdRequest.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(notExistTeamPlaceIdRequest.body().asString()).isEqualTo("접근할 수 없는 팀플레이스입니다.");
             });
         }
 
@@ -636,7 +645,7 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("없는 팀 플레이스의 ID로 요청하면 실패한다.")
+        @DisplayName("소속되지 않는 팀 플레이스의 ID로 요청하면 실패한다.")
         void failNotExistTeamPlaceIdRequest() {
             // given
             final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
@@ -653,8 +662,8 @@ public class TeamCalendarScheduleAcceptanceTest extends AcceptanceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(notExistTeamPlaceIdDeleteScheduleResponse.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(notExistTeamPlaceIdDeleteScheduleResponse.body().asString()).isEqualTo("조회한 팀 플레이스가 존재하지 않습니다.");
+                softly.assertThat(notExistTeamPlaceIdDeleteScheduleResponse.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(notExistTeamPlaceIdDeleteScheduleResponse.body().asString()).isEqualTo("접근할 수 없는 팀플레이스입니다.");
             });
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/TeamCalendarScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/TeamCalendarScheduleApiDocsTest.java
@@ -16,7 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import team.teamby.teambyteam.auth.presentation.MemberInterceptor;
-import team.teamby.teambyteam.auth.presentation.TeamPlaceInterceptor;
+import team.teamby.teambyteam.auth.presentation.TeamPlaceParticipationInterceptor;
 import team.teamby.teambyteam.schedule.application.TeamCalendarScheduleService;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
@@ -73,13 +73,13 @@ public class TeamCalendarScheduleApiDocsTest {
     private MemberInterceptor memberInterceptor;
 
     @MockBean
-    private TeamPlaceInterceptor teamPlaceInterceptor;
+    private TeamPlaceParticipationInterceptor teamPlaceParticipationInterceptor;
 
     @BeforeEach
     void setup() throws Exception {
         given(memberInterceptor.preHandle(any(), any(), any()))
                 .willReturn(true);
-        given(teamPlaceInterceptor.preHandle(any(), any(), any()))
+        given(teamPlaceParticipationInterceptor.preHandle(any(), any(), any()))
                 .willReturn(true);
     }
 


### PR DESCRIPTION
## 이슈번호
> close #237 

## PR 내용
- MemberTeamPlace 필드 추가
  - DisplayMemberName
  - DisplayTeamPlaceName

- MemberTeamPlace와 TeamPlace간 의존관계 단방향으로 변경
  - MemberTeamPlace -> TeamPlace (n:1)

- 사용자가 요청을 보낸 팀플레이스 소속인지 확인하는 로직 변경
  - 기존 : 팀플레이스 엔티티 사용
  - 변경내용 : 멤버도메인 사용
  - 해당 변경으로 없는 팀플레이스로의 요청시 예외 메시지 및 코드 변경 - 자세한 내용은 의논할 거리 확인

- TeamPlaceInterceptor의 이름을 더 직관적으로 변경
  - 변경된 이름 : TeamPlaceParticipationInterceptor

- 멤버팀플레이스에서 사용자의 디스플레이네임과 아이디만 조회하는 repository method 구현
  - @SproutMJ 이 작업중인 피드조회시에 확인해보고 필요한거 사용하면 될듯

## 참고자료

## 의논할 거리

기존에 멤버가 팀플레이스 소속인지 확인하던 방식
- 팀플레이스 엔티티에서 확인
수정후 사용할 방식
- 멤버 엔티티에서 확인
  - 이유 : 팀플레이스 도메인에서 멤버팀플레이스 안가지고있음

생긴문제
- 없는 팀플레이스로 요청시
  - 기존 : 없는 팀플레이스에 대한 요청이라는 오류 반환
  - 변경후 : 접근할 수 없는 팀플레이스라는 오류 반환

해결방안
1. 소속확인 전에 팀플레이스 아이디로 있는지 확인한다.
  - 장점 : 기존의 예외발생대로 처리를 할 수 있다.
  - 단점 : 리팩터링을 진행함으로 팀플레이스에 대한 쿼리를 안날려도 되도록 조회 요청 횟수가 줄게되었는데, 다시 팀플레이스로 조회요청이 들어가야한다.

2. 해당 오류를 접근할 수 있는 팀플레이스 오류 반환하는것으로 한다. (바뀐 오류대로 한다)
  - 장점 : 팀플레이스 db에 접근을 하지 않아도 된다.
  - 단점 : 기존 테스트들에 대한 수정이 (약간?) 들어가야한다.
    - 혹시라도 컨플릭트가 난다면 유감인 상황이 발생하게 된다..^^;

내생각
- 2번 방향으로 한다. (해당 케이스에서 발생하는 예외를 수정하는 방향으로)

이유
- team_place 엔티티에 대한 접근을 줄여 db연결을 줄이고, 해당 트랜색션에서 물리는 엔티티를 줄일 수 있다.
- 사용자가 속하지 않은 팀이니까 해당 팀의 존재 유무에 대한 정보를 알려주지 않아도 될 것 같다.
  - 오히려 사용자가 팀플레이스 아이디를 조작해 마구잡이로 보내서 존재하는 팀플레이스인지 아닌지에 대한 확인을 못하게 할 수 있다.

이러한 이유로 해당 테스트케이들에 대한 예외 검증을 바꾸었습니다.
