### PR TITLE
[FE] MenuItem의 css prop optional로 수정

### DIFF
--- a/frontend/src/components/common/Menu/MenuItem/MenuItem.tsx
+++ b/frontend/src/components/common/Menu/MenuItem/MenuItem.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react';
 import type { CSSProp } from 'styled-components';
 
 export interface MenuItemProps {
-  css: CSSProp;
+  css?: CSSProp;
 }
 
 const MenuItem = (props: PropsWithChildren<MenuItemProps>) => {


### PR DESCRIPTION
# [FE] MenuItem의 css prop optional로 수정
## 이슈번호
> 사소한 버그픽스라 이슈 제외

## PR 내용
MenuItem의 css prop optional로 수정
