### PR TITLE
[FE] 팀피드 스레드 작성 바텀시트 구현

### DIFF
--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.stories.tsx
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ThreadAddBottomSheet from '~/components/ThreadAddBottomSheet/ThreadAddBottomSheet';
+import Button from '~/components/common/Button/Button';
+import { useModal } from '~/hooks/useModal';
+
+const meta = {
+  title: 'Thread/ThreadAddBottomSheet',
+  component: ThreadAddBottomSheet,
+} satisfies Meta<typeof ThreadAddBottomSheet>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Example = () => {
+  const { openModal } = useModal();
+
+  return (
+    <>
+      <Button onClick={openModal}>바텀시트 열기</Button>
+      <ThreadAddBottomSheet />
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Example />,
+  args: {},
+};

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
@@ -35,7 +35,7 @@ export const Textarea = styled.textarea`
 
   background-color: ${({ theme }) => theme.color.GRAY100};
 
-  font-size: 14px;
+  font-size: 16px;
 
   padding: 20px;
 

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
@@ -29,6 +29,19 @@ export const Container = styled.div<{ isClosing: boolean }>`
     0.3s ease-in-out forwards;
 `;
 
+export const TitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const NoticeWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  column-gap: 10px;
+`;
+
 export const Textarea = styled.textarea`
   width: 100%;
   height: 200px;
@@ -46,12 +59,25 @@ export const Textarea = styled.textarea`
 `;
 
 export const ButtonWrapper = styled.div`
+  display: flex;
+
   margin-left: auto;
+  column-gap: 20px;
 `;
 
 export const title = css`
   font-size: 24px;
   font-weight: 700;
+`;
+
+export const notice = css`
+  font-size: 18px;
+  font-weight: 500;
+`;
+
+export const cancelButton = css`
+  width: 100px;
+  background-color: ${({ theme }) => theme.color.GRAY500};
 `;
 
 export const button = css`

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
@@ -15,11 +15,10 @@ export const Container = styled.div<{ isClosing: boolean }>`
   bottom: 0;
   left: 0;
 
-  padding: 20px 20px;
-  row-gap: 20px;
-
   width: 100%;
   min-height: 400px;
+  padding: 20px;
+  row-gap: 20px;
 
   border-top-left-radius: 40px;
   border-top-right-radius: 40px;
@@ -45,15 +44,13 @@ export const NoticeWrapper = styled.div`
 export const Textarea = styled.textarea`
   width: 100%;
   height: 200px;
-
-  background-color: ${({ theme }) => theme.color.GRAY100};
-
-  font-size: 16px;
-
   padding: 20px;
 
   border: none;
   border-radius: 4px;
+  background-color: ${({ theme }) => theme.color.GRAY100};
+
+  font-size: 16px;
 
   resize: none;
 `;
@@ -77,9 +74,10 @@ export const notice = css`
 
 export const cancelButton = css`
   width: 100px;
+
   background-color: ${({ theme }) => theme.color.GRAY500};
 `;
 
-export const button = css`
+export const submitButton = css`
   width: 100px;
 `;

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
@@ -1,0 +1,59 @@
+import { css, styled } from 'styled-components';
+
+export const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+export const Container = styled.div<{ isClosing: boolean }>`
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+
+  padding: 20px 20px;
+  row-gap: 20px;
+
+  width: 100%;
+  min-height: 400px;
+
+  border-top-left-radius: 40px;
+  border-top-right-radius: 40px;
+
+  animation: ${({ theme, isClosing }) =>
+      isClosing ? theme.animation.slideDown : theme.animation.slideUp}
+    0.3s ease-in-out forwards;
+`;
+
+export const Textarea = styled.textarea`
+  width: 100%;
+  height: 200px;
+
+  background-color: ${({ theme }) => theme.color.GRAY100};
+
+  font-size: 14px;
+
+  padding: 20px;
+
+  border: none;
+  border-radius: 4px;
+
+  resize: none;
+`;
+
+export const ButtonWrapper = styled.div`
+  margin-left: auto;
+`;
+
+export const title = css`
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+export const button = css`
+  width: 100px;
+`;

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.styled.ts
@@ -25,7 +25,7 @@ export const Container = styled.div<{ isClosing: boolean }>`
 
   animation: ${({ theme, isClosing }) =>
       isClosing ? theme.animation.slideDown : theme.animation.slideUp}
-    0.3s ease-in-out forwards;
+    0.4s ease-in-out forwards;
 `;
 
 export const TitleWrapper = styled.div`

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
@@ -1,28 +1,47 @@
+import { useState } from 'react';
 import Modal from '~/components/common/Modal/Modal';
 import Text from '~/components/common/Text/Text';
 import * as S from './ThreadAddBottomSheet.styled';
 import Button from '~/components/common/Button/Button';
 import useBottomSheet from '~/hooks/useBottomSheet';
+import type { ChangeEventHandler, FormEventHandler } from 'react';
 
 const ThreadAddBottomSheet = () => {
+  const [content, setContent] = useState('');
   const { handleClose, isClosing } = useBottomSheet();
+
+  const handleChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+    const { target } = e;
+
+    setContent(() => target.value);
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    alert(content);
+  };
 
   return (
     <Modal>
       <S.Backdrop onClick={handleClose} />
-      <S.Container isClosing={isClosing}>
-        <Text as="h3" css={S.title}>
-          팀 피드 작성하기
-        </Text>
-        <S.Textarea
-          placeholder="내용을 입력해주세요."
-          maxLength={1500}
-          required
-        />
-        <S.ButtonWrapper>
-          <Button css={S.button}>등록</Button>
-        </S.ButtonWrapper>
-      </S.Container>
+      <form onSubmit={handleSubmit}>
+        <S.Container isClosing={isClosing}>
+          <Text as="h3" css={S.title}>
+            팀 피드 작성하기
+          </Text>
+          <S.Textarea
+            placeholder="내용을 입력해주세요."
+            maxLength={1500}
+            value={content}
+            onChange={handleChange}
+            required
+          />
+          <S.ButtonWrapper>
+            <Button css={S.button}>등록</Button>
+          </S.ButtonWrapper>
+        </S.Container>
+      </form>
     </Modal>
   );
 };

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
@@ -5,12 +5,14 @@ import * as S from './ThreadAddBottomSheet.styled';
 import Button from '~/components/common/Button/Button';
 import useBottomSheet from '~/hooks/useBottomSheet';
 import type { ChangeEventHandler, FormEventHandler } from 'react';
+import Checkbox from '~/components/common/Checkbox/Checkbox';
 
 const ThreadAddBottomSheet = () => {
   const [content, setContent] = useState('');
+  const [isNotice, setIsNotice] = useState(false);
   const { handleClose, isClosing } = useBottomSheet();
 
-  const handleChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+  const handleContentChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
     const { target } = e;
 
     setContent(() => target.value);
@@ -22,22 +24,47 @@ const ThreadAddBottomSheet = () => {
     alert(content);
   };
 
+  const handleIsNoticeChange = () => {
+    setIsNotice((prev) => !prev);
+  };
+
+  const handleCancelButtonClick = () => {
+    handleClose();
+    setContent(() => '');
+    setIsNotice(() => false);
+  };
+
   return (
     <Modal>
       <S.Backdrop onClick={handleClose} />
       <form onSubmit={handleSubmit}>
         <S.Container isClosing={isClosing}>
-          <Text as="h3" css={S.title}>
-            팀 피드 작성하기
-          </Text>
+          <S.TitleWrapper>
+            <Text as="h3" css={S.title}>
+              팀 피드 작성하기
+            </Text>
+            <S.NoticeWrapper>
+              <Text as="span" css={S.notice}>
+                공지로 등록
+              </Text>
+              <Checkbox isChecked={isNotice} onChange={handleIsNoticeChange} />
+            </S.NoticeWrapper>
+          </S.TitleWrapper>
           <S.Textarea
             placeholder="내용을 입력해주세요."
             maxLength={1500}
             value={content}
-            onChange={handleChange}
+            onChange={handleContentChange}
             required
           />
           <S.ButtonWrapper>
+            <Button
+              type="button"
+              css={S.cancelButton}
+              onClick={handleCancelButtonClick}
+            >
+              취소
+            </Button>
             <Button css={S.button}>등록</Button>
           </S.ButtonWrapper>
         </S.Container>

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
@@ -65,7 +65,7 @@ const ThreadAddBottomSheet = () => {
             >
               취소
             </Button>
-            <Button css={S.button}>등록</Button>
+            <Button css={S.submitButton}>등록</Button>
           </S.ButtonWrapper>
         </S.Container>
       </form>

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
@@ -1,0 +1,30 @@
+import Modal from '~/components/common/Modal/Modal';
+import Text from '~/components/common/Text/Text';
+import * as S from './ThreadAddBottomSheet.styled';
+import Button from '~/components/common/Button/Button';
+import useBottomSheet from '~/hooks/useBottomSheet';
+
+const ThreadAddBottomSheet = () => {
+  const { handleClose, isClosing } = useBottomSheet();
+
+  return (
+    <Modal>
+      <S.Backdrop onClick={handleClose} />
+      <S.Container isClosing={isClosing}>
+        <Text as="h3" css={S.title}>
+          팀 피드 작성하기
+        </Text>
+        <S.Textarea
+          placeholder="내용을 입력해주세요."
+          maxLength={1500}
+          required
+        />
+        <S.ButtonWrapper>
+          <Button css={S.button}>등록</Button>
+        </S.ButtonWrapper>
+      </S.Container>
+    </Modal>
+  );
+};
+
+export default ThreadAddBottomSheet;

--- a/frontend/src/hooks/useBottomSheet.ts
+++ b/frontend/src/hooks/useBottomSheet.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { useModal } from '~/hooks/useModal';
+import theme from '~/styles/theme';
 
 const useBottomSheet = () => {
   const [isClosing, setIsClosing] = useState(false);
@@ -16,7 +17,7 @@ const useBottomSheet = () => {
       if (timerId.current) {
         clearTimeout(timerId.current);
       }
-    }, 300);
+    }, theme.animation.duration);
   };
 
   return {

--- a/frontend/src/hooks/useBottomSheet.ts
+++ b/frontend/src/hooks/useBottomSheet.ts
@@ -1,0 +1,28 @@
+import { useRef, useState } from 'react';
+import { useModal } from '~/hooks/useModal';
+
+const useBottomSheet = () => {
+  const [isClosing, setIsClosing] = useState(false);
+  const timerId = useRef<ReturnType<typeof setTimeout>>();
+  const { closeModal } = useModal();
+
+  const handleClose = () => {
+    setIsClosing(() => true);
+
+    timerId.current = setTimeout(() => {
+      setIsClosing(() => false);
+      closeModal();
+
+      if (timerId.current) {
+        clearTimeout(timerId.current);
+      }
+    }, 300);
+  };
+
+  return {
+    handleClose,
+    isClosing,
+  };
+};
+
+export default useBottomSheet;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import { keyframes } from 'styled-components';
+
 const color = {
   LOGO: '#3145FF',
   PRIMARY: '#516FFF',
@@ -23,9 +25,29 @@ const zIndex = {
   MODAL: 1,
 } as const;
 
+const animation = {
+  slideUp: keyframes`
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  `,
+  slideDown: keyframes`
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(100%);
+    }  
+  `,
+};
+
 export const theme = {
   color,
   zIndex,
+  animation,
 } as const;
 
 export type Theme = typeof theme;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -42,6 +42,7 @@ const animation = {
       transform: translateY(100%);
     }  
   `,
+  duration: 400,
 };
 
 export const theme = {


### PR DESCRIPTION
# [FE] 팀피드 스레드 작성 바텀시트 구현
## 이슈번호
> close #182 

## PR 내용
- 팀피드 스레드 작성 바텀시트 구현
- UI만 구현
- css animation을 theme에 추가

<img width="1250" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/19235163/a43e8d31-bfb1-4d0f-a395-f6514d9bc8de">
