### PR TITLE
[FE] 공용 컴포넌트 team badge 구현

### DIFF
--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.styled.ts
@@ -65,14 +65,6 @@ export const TeamNameContainer = styled.div`
   height: 23px;
 `;
 
-export const Circle = styled.div`
-  width: 23px;
-  height: 23px;
-
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.color.PRIMARY};
-`;
-
 export const ControlButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -6,6 +6,7 @@ import Text from '../common/Text/Text';
 import Button from '../common/Button/Button';
 import Input from '../common/Input/Input';
 import useScheduleAddModal from '~/hooks/schedule/useScheduleAddModal';
+import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 
 interface ScheduleAddModalProps {
   teamPlaceName: string;
@@ -85,7 +86,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             />
           </S.TimeSelectContainer>
           <S.TeamNameContainer title={teamPlaceName}>
-            <S.Circle />
+            <TeamBadge teamPlaceColor={0} size="lg" />
             <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
           </S.TeamNameContainer>
           <S.ControlButtonWrapper>

--- a/frontend/src/components/ScheduleEditModal/ScheduleEditModal.styled.ts
+++ b/frontend/src/components/ScheduleEditModal/ScheduleEditModal.styled.ts
@@ -65,14 +65,6 @@ export const TeamNameContainer = styled.div`
   height: 23px;
 `;
 
-export const Circle = styled.div`
-  width: 23px;
-  height: 23px;
-
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.color.PRIMARY};
-`;
-
 export const ControlButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/components/ScheduleEditModal/ScheduleEditModal.tsx
+++ b/frontend/src/components/ScheduleEditModal/ScheduleEditModal.tsx
@@ -7,6 +7,7 @@ import Input from '~/components/common/Input/Input';
 import Text from '~/components/common/Text/Text';
 import useScheduleEditModal from '~/hooks/schedule/useScheduleEditModal';
 import type { Schedule } from '~/types/schedule';
+import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 
 interface ScheduleEditModalProps {
   teamPlaceName: string;
@@ -90,7 +91,7 @@ const ScheduleEditModal = (props: ScheduleEditModalProps) => {
             />
           </S.TimeSelectContainer>
           <S.TeamNameContainer title={teamPlaceName}>
-            <S.Circle />
+            <TeamBadge teamPlaceColor={0} size="lg" />
             <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
           </S.TeamNameContainer>
           <S.ControlButtonWrapper>

--- a/frontend/src/components/ScheduleModal/ScheduleModal.styled.ts
+++ b/frontend/src/components/ScheduleModal/ScheduleModal.styled.ts
@@ -38,14 +38,6 @@ export const TeamWrapper = styled.div`
   gap: 12px;
 `;
 
-export const TeamColor = styled.div`
-  width: 23px;
-  height: 23px;
-
-  border-radius: 100%;
-  background-color: ${({ theme }) => theme.color.PRIMARY};
-`;
-
 export const MenuWrapper = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/components/ScheduleModal/ScheduleModal.tsx
+++ b/frontend/src/components/ScheduleModal/ScheduleModal.tsx
@@ -9,6 +9,7 @@ import { formatDateTime } from '~/utils/formatDateTime';
 import type { SchedulePosition } from '~/types/schedule';
 import { useFetchScheduleById } from '~/hooks/queries/useFetchScheduleById';
 import { useDeleteSchedule } from '~/hooks/queries/useDeleteSchedule';
+import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 
 interface ScheduleModalProps {
   scheduleId: number;
@@ -48,7 +49,7 @@ const ScheduleModal = (props: ScheduleModalProps) => {
       <S.Container style={modalLocation}>
         <S.Header>
           <S.TeamWrapper>
-            <S.TeamColor />
+            <TeamBadge teamPlaceColor={0} size="lg" />
             <div title={'현대사회와 범죄 5조'}>
               <Text css={S.teamName}>현대사회와 범죄 5조</Text>
             </div>

--- a/frontend/src/components/common/Header/Header.styled.ts
+++ b/frontend/src/components/common/Header/Header.styled.ts
@@ -16,13 +16,6 @@ export const Container = styled.div`
   }
 `;
 
-export const TeamColorBadge = styled.div`
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.color.PURPLE};
-`;
-
 export const teamPlaceName = css`
   font-size: 24px;
   font-weight: bold;

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -1,13 +1,14 @@
 import { LogoIcon } from '~/assets/svg';
 import * as S from './Header.styled';
 import Text from '~/components/common/Text/Text';
+import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 
 const Header = () => {
   return (
     <S.Container>
       <LogoIcon />
       <div>
-        <S.TeamColorBadge />
+        <TeamBadge teamPlaceColor={0} />
         <Text as="h1" css={S.teamPlaceName}>
           현대사회와 범죄 5조
         </Text>

--- a/frontend/src/components/common/TeamBadge/TeamBadge.stories.ts
+++ b/frontend/src/components/common/TeamBadge/TeamBadge.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
+
+const meta = {
+  title: 'common/TeamBadge',
+  component: TeamBadge,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TeamBadge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    teamPlaceColor: 0,
+    size: 'md',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    teamPlaceColor: 0,
+    size: 'sm',
+  },
+};
+
+export const Middle: Story = {
+  args: {
+    teamPlaceColor: 0,
+    size: 'md',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    teamPlaceColor: 0,
+    size: 'lg',
+  },
+};

--- a/frontend/src/components/common/TeamBadge/TeamBadge.styled.ts
+++ b/frontend/src/components/common/TeamBadge/TeamBadge.styled.ts
@@ -1,0 +1,25 @@
+import { css, styled } from 'styled-components';
+import type { TeamBadgeProps } from '~/components/common/TeamBadge/TeamBadge';
+
+export const Wrapper = styled.div<TeamBadgeProps>`
+  ${({ size }) => {
+    if (size === 'sm')
+      return css`
+        width: 8px;
+        height: 8px;
+      `;
+    if (size === 'lg')
+      return css`
+        width: 24px;
+        height: 24px;
+      `;
+    return css`
+      width: 20px;
+      height: 20px;
+    `;
+  }}
+
+  border-radius: 50%;
+  background-color: ${({ theme, teamPlaceColor }) =>
+    theme.teamColor[teamPlaceColor]};
+`;

--- a/frontend/src/components/common/TeamBadge/TeamBadge.tsx
+++ b/frontend/src/components/common/TeamBadge/TeamBadge.tsx
@@ -1,0 +1,15 @@
+import type { TeamBadgeSize } from '~/types/size';
+import type { TeamPlaceColor } from '~/types/team';
+import * as S from './TeamBadge.styled';
+
+export interface TeamBadgeProps {
+  teamPlaceColor: TeamPlaceColor;
+  size?: TeamBadgeSize;
+}
+
+const TeamBadge = (props: TeamBadgeProps) => {
+  const { teamPlaceColor, size = 'md' } = props;
+  return <S.Wrapper teamPlaceColor={teamPlaceColor} size={size} />;
+};
+
+export default TeamBadge;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -21,6 +21,19 @@ const color = {
   GRAY900: '#191f28',
 } as const;
 
+const teamColor = {
+  0: '#4886FF',
+  1: '#59DFC7',
+  2: '#8E1DFF',
+  3: '#FF6666',
+  4: '#FF66F9',
+  5: '#FF9051',
+  6: '#FFC451',
+  7: '#FF51B9',
+  8: '#51C0FF',
+  9: '#82FF48',
+};
+
 const zIndex = {
   MODAL: 1,
 } as const;
@@ -47,6 +60,7 @@ const animation = {
 
 export const theme = {
   color,
+  teamColor,
   zIndex,
   animation,
 } as const;

--- a/frontend/src/types/size.ts
+++ b/frontend/src/types/size.ts
@@ -16,3 +16,4 @@ export type NoticeTagSize = Extract<Size, 'sm' | 'md'>;
 
 export type NoticeThreadSize = Extract<Size, 'sm' | 'md'>;
 
+export type TeamBadgeSize = Extract<Size, 'sm' | 'md' | 'lg'>;

--- a/frontend/src/types/team.ts
+++ b/frontend/src/types/team.ts
@@ -1,0 +1,1 @@
+export type TeamPlaceColor = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;


### PR DESCRIPTION
# [FE] 공용 컴포넌트 team badge 구현
## 이슈번호
> close #261 

## PR 내용
<img width="206" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/953d48ff-2fbc-4748-971a-e8700e4425f5">

teamPlaceColor랑 teamColor 는 지금 필요해서 해둔거고 하루일정UI 에 있는거랑 똑같은거에요.. 
## 참고자료

## 의논할 거리
