### PR TITLE
[FE] 빌드 실패 시 action이 실패하도록 CI 스크립트 수정

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - frontend/**
 
+defaults:
+  run:
+    working-directory: frontend
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -15,8 +19,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      working-directory: ./frontend
 
     steps:
       - name: Checkout
@@ -31,8 +33,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-        working-directory: ${{ env.working-directory }}
+
+      - name: Run build
+        run: npm run build
 
       - name: Run unit test
         run: npm run test:ci
-        working-directory: ${{ env.working-directory }}


### PR DESCRIPTION
# [FE] 빌드 실패 시 action이 실패하도록 CI 스크립트 수정

## PR 내용
- 빌드 실패 시 action이 실패하도록 CI 스크립트 수정
- 배포 직전에 확인하는 과정이 불편하여, CI 과정에 추가
