### PR TITLE
[FE] 통합 캘린더 스케줄 서클 구현을 위한 유틸 함수 작성

### DIFF
--- a/frontend/src/constants/calendar.ts
+++ b/frontend/src/constants/calendar.ts
@@ -16,6 +16,8 @@ export const TIME_TABLE = arrayOf(48).map((_, i) => {
   return `${hour}:${minute}`;
 });
 
+export const SCHEDULE_CIRCLE_MAX_COUNT = 3;
+
 export const MODAL_OPEN_TYPE = {
   ADD: 'add',
   VIEW: 'view',

--- a/frontend/src/types/schedule.ts
+++ b/frontend/src/types/schedule.ts
@@ -26,3 +26,7 @@ export interface ScheduleCircle {
 
 export type ModalOpenType =
   (typeof MODAL_OPEN_TYPE)[keyof typeof MODAL_OPEN_TYPE];
+
+export interface ScheduleWithTeamPlaceId extends Schedule {
+  teamPlaceId: number;
+}

--- a/frontend/src/types/schedule.ts
+++ b/frontend/src/types/schedule.ts
@@ -20,5 +20,9 @@ export interface SchedulePosition extends Position {
   level: number;
 }
 
+export interface ScheduleCircle {
+  teamPlaceIds: number[];
+}
+
 export type ModalOpenType =
   (typeof MODAL_OPEN_TYPE)[keyof typeof MODAL_OPEN_TYPE];

--- a/frontend/src/utils/generateScheduleCirclesMatrix.test.ts
+++ b/frontend/src/utils/generateScheduleCirclesMatrix.test.ts
@@ -1,0 +1,255 @@
+import { generateScheduleCirclesMatrix } from './generateScheduleCirclesMatrix';
+import type { ScheduleWithTeamPlaceId } from '~/types/schedule';
+
+describe('Test #1 - 스케줄 서클 기본 기능 테스트', () => {
+  test('하나의 스케줄 정보와 연/월에 대한 정보가 주어지면, 주어진 정보에 해당하는 스케줄 서클 분포를 2차원 배열로 반환해야 한다.', () => {
+    const schedules: ScheduleWithTeamPlaceId[] = [
+      {
+        id: 20,
+        teamPlaceId: 0,
+        title: '내 일정',
+        startDateTime: '2023-07-24 00:00',
+        endDateTime: '2023-07-26 23:59',
+      },
+    ];
+
+    const expectedResult = [
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [0] },
+      { teamPlaceIds: [0] },
+      { teamPlaceIds: [0] },
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [] },
+    ];
+
+    expect(generateScheduleCirclesMatrix(2023, 6, schedules)[4]).toEqual(
+      expectedResult,
+    );
+  });
+
+  test('여러 개의 스케줄 정보가 서로 겹치더라도, 올바른 결과를 반환해야 한다. 반환 시에는 아이디를 오름차순 정렬하여 반환하고, 한계 랜더링 개수를 넘기지 않도록 반환한다.', () => {
+    const schedules: ScheduleWithTeamPlaceId[] = [
+      {
+        id: 116,
+        teamPlaceId: 0,
+        title: '엔델',
+        startDateTime: '2023-07-31 00:00',
+        endDateTime: '2023-08-03 23:59',
+      },
+      {
+        id: 23,
+        teamPlaceId: 4,
+        title: '유스',
+        startDateTime: '2023-08-08 23:58',
+        endDateTime: '2023-08-28 23:59',
+      },
+      {
+        id: 394,
+        teamPlaceId: 9,
+        title: '제임스',
+        startDateTime: '2023-08-26 12:34',
+        endDateTime: '2023-09-08 12:34',
+      },
+      {
+        id: 890,
+        teamPlaceId: 16,
+        title: '브리',
+        startDateTime: '2023-08-07 08:10',
+        endDateTime: '2023-08-14 10:20',
+      },
+      {
+        id: 225,
+        teamPlaceId: 1,
+        title: '필립',
+        startDateTime: '2023-08-12 12:00',
+        endDateTime: '2023-08-18 13:59',
+      },
+      {
+        id: 320,
+        teamPlaceId: 11,
+        title: '요술토끼',
+        startDateTime: '2023-08-13 11:00',
+        endDateTime: '2023-08-13 15:20',
+      },
+      {
+        id: 243,
+        teamPlaceId: 5,
+        title: '루루',
+        startDateTime: '2023-08-24 11:02',
+        endDateTime: '2023-09-08 14:03',
+      },
+      {
+        id: 932,
+        teamPlaceId: 3,
+        title: '로이',
+        startDateTime: '2023-08-30 23:58',
+        endDateTime: '2023-09-05 23:59',
+      },
+      {
+        id: 1108,
+        teamPlaceId: 2,
+        title: '성하',
+        startDateTime: '2023-08-28 23:58',
+        endDateTime: '2023-08-28 23:59',
+      },
+    ];
+
+    const expectedResult = [
+      [
+        { teamPlaceIds: [] },
+        { teamPlaceIds: [0] },
+        { teamPlaceIds: [0] },
+        { teamPlaceIds: [0] },
+        { teamPlaceIds: [0] },
+        { teamPlaceIds: [] },
+        { teamPlaceIds: [] },
+      ],
+      [
+        { teamPlaceIds: [] },
+        { teamPlaceIds: [16] },
+        { teamPlaceIds: [4, 16] },
+        { teamPlaceIds: [4, 16] },
+        { teamPlaceIds: [4, 16] },
+        { teamPlaceIds: [4, 16] },
+        { teamPlaceIds: [1, 4, 16] },
+      ],
+      [
+        { teamPlaceIds: [1, 4, 11] },
+        { teamPlaceIds: [1, 4, 16] },
+        { teamPlaceIds: [1, 4] },
+        { teamPlaceIds: [1, 4] },
+        { teamPlaceIds: [1, 4] },
+        { teamPlaceIds: [1, 4] },
+        { teamPlaceIds: [4] },
+      ],
+      [
+        { teamPlaceIds: [4] },
+        { teamPlaceIds: [4] },
+        { teamPlaceIds: [4] },
+        { teamPlaceIds: [4] },
+        { teamPlaceIds: [4, 5] },
+        { teamPlaceIds: [4, 5] },
+        { teamPlaceIds: [4, 5, 9] },
+      ],
+      [
+        { teamPlaceIds: [4, 5, 9] },
+        { teamPlaceIds: [2, 4, 5] },
+        { teamPlaceIds: [5, 9] },
+        { teamPlaceIds: [3, 5, 9] },
+        { teamPlaceIds: [3, 5, 9] },
+        { teamPlaceIds: [3, 5, 9] },
+        { teamPlaceIds: [3, 5, 9] },
+      ],
+      [
+        { teamPlaceIds: [3, 5, 9] },
+        { teamPlaceIds: [3, 5, 9] },
+        { teamPlaceIds: [3, 5, 9] },
+        { teamPlaceIds: [5, 9] },
+        { teamPlaceIds: [5, 9] },
+        { teamPlaceIds: [5, 9] },
+        { teamPlaceIds: [] },
+      ],
+    ];
+
+    expect(generateScheduleCirclesMatrix(2023, 7, schedules)).toEqual(
+      expectedResult,
+    );
+  });
+});
+
+describe('Test #2 - 범위를 벗어나는 일정 테스트', () => {
+  test('일정이 해당 달력의 범위를 전부 또는 일부를 벗어날 경우, 달력에 해당하는 부분만 반환해야 한다.', () => {
+    const schedules: ScheduleWithTeamPlaceId[] = [
+      {
+        id: 0,
+        teamPlaceId: 0,
+        title: '시작 부분이 잘리는 일정',
+        startDateTime: '2023-07-26 00:00',
+        endDateTime: '2023-08-03 23:59',
+      },
+      {
+        id: 1,
+        teamPlaceId: 1,
+        title: '끝 부분이 잘리는 일정',
+        startDateTime: '2023-09-01 00:00',
+        endDateTime: '2023-09-12 23:59',
+      },
+      {
+        id: 2,
+        teamPlaceId: 2,
+        title: '아예 해당 달의 범위 바깥에 있는 일정',
+        startDateTime: '2023-01-12 00:00',
+        endDateTime: '2023-01-13 23:59',
+      },
+      {
+        id: 3,
+        teamPlaceId: 3,
+        title: '일정이 매우 길어 해당 달의 전체를 차지하는 일정',
+        startDateTime: '2023-01-01 00:00',
+        endDateTime: '2023-12-31 23:59',
+      },
+    ];
+
+    const expectedResult = [
+      [
+        { teamPlaceIds: [0, 3] },
+        { teamPlaceIds: [0, 3] },
+        { teamPlaceIds: [0, 3] },
+        { teamPlaceIds: [0, 3] },
+        { teamPlaceIds: [0, 3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+      ],
+      [
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+      ],
+      [
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+      ],
+      [
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+      ],
+      [
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [3] },
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+      ],
+      [
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+        { teamPlaceIds: [1, 3] },
+      ],
+    ];
+
+    expect(generateScheduleCirclesMatrix(2023, 7, schedules)).toEqual(
+      expectedResult,
+    );
+  });
+});

--- a/frontend/src/utils/generateScheduleCirclesMatrix.ts
+++ b/frontend/src/utils/generateScheduleCirclesMatrix.ts
@@ -1,0 +1,89 @@
+import type { ScheduleWithTeamPlaceId } from '~/types/schedule';
+import { getDateByPosition } from './getDateByPosition';
+import type { ScheduleCircle } from '~/types/schedule';
+import { arrayOf } from './arrayOf';
+import { CALENDAR, SCHEDULE_CIRCLE_MAX_COUNT } from '~/constants/calendar';
+
+/**
+ * 《generateScheduleCirclesMatrix》
+ * 이 유틸 함수는 가공 전의 팀플레이스 아이디가 포함된 스케줄 데이터를 받고, 이를 즉시 랜더링이 가능한 서클 형태로 내보내는 역할을 수행합니다.
+ * - 일정의 기간에 상관없이 현재 달력에 표시되어야 하는 부분만 결과로 반환됩니다.
+ * - 각 일자에 서클을 표시할 때, 팀플레이스 하나 당 하나의 서클만 반환됩니다.
+ * - 잘리는 일정이나 잘못된 일정이 있는 경우도 처리가 가능합니다.
+ *
+ * @param year - 스케줄 바를 표시할 연도
+ * @param month - 스케줄 바를 표시할 월
+ * @param schedules - 팀플레이스의 아이디가 포함된 스케줄들
+ * @returns leveledScheduleBars - ScheduleBarProps 타입의 형태로 결과물을 반환합니다
+ */
+export const generateScheduleCirclesMatrix = (
+  year: number,
+  month: number,
+  schedules: ScheduleWithTeamPlaceId[],
+) => {
+  const scheduleCirclesMatrix: ScheduleCircle[][] = arrayOf(
+    CALENDAR.ROW_SIZE,
+  ).map(() =>
+    arrayOf(CALENDAR.COLUMN_SIZE).map(() => {
+      const emptyScheduleIds: ScheduleCircle = { teamPlaceIds: [] };
+      return emptyScheduleIds;
+    }),
+  );
+
+  arrayOf(CALENDAR.ROW_SIZE).forEach((row) => {
+    arrayOf(CALENDAR.COLUMN_SIZE).forEach((column) => {
+      const currentDate = getDateByPosition(year, month, row, column);
+
+      schedules.forEach((schedule) => {
+        if (isDateInPeriod(currentDate, schedule)) {
+          scheduleCirclesMatrix[row][column].teamPlaceIds.push(
+            schedule.teamPlaceId,
+          );
+        }
+      });
+    });
+  });
+
+  const sortedScheduleCirclesMatrix = getSortedScheduleCirclesMatrix(
+    scheduleCirclesMatrix,
+  );
+  const slicedScheduleCirclesMatrix = getSlicedScheduleCirclesMatrix(
+    sortedScheduleCirclesMatrix,
+  );
+
+  return slicedScheduleCirclesMatrix;
+};
+
+const getSortedScheduleCirclesMatrix = (
+  scheduleCirclesMatrix: ScheduleCircle[][],
+) => {
+  const sortedScheduleCirclesMatrix = scheduleCirclesMatrix.map(
+    (scheduleCircles) =>
+      scheduleCircles.map(({ teamPlaceIds }) => ({
+        teamPlaceIds: [...teamPlaceIds.sort((a, b) => a - b)],
+      })),
+  );
+
+  return sortedScheduleCirclesMatrix;
+};
+
+const getSlicedScheduleCirclesMatrix = (
+  scheduleCirclesMatrix: ScheduleCircle[][],
+) => {
+  const slicedScheduleCirclesMatrix = scheduleCirclesMatrix.map(
+    (scheduleCircles) =>
+      scheduleCircles.map(({ teamPlaceIds }) => ({
+        teamPlaceIds: teamPlaceIds.slice(0, SCHEDULE_CIRCLE_MAX_COUNT),
+      })),
+  );
+
+  return slicedScheduleCirclesMatrix;
+};
+
+const isDateInPeriod = (date: Date, schedule: ScheduleWithTeamPlaceId) => {
+  const { startDateTime, endDateTime } = schedule;
+  const startDateBoundary = new Date(`${startDateTime.split(' ')[0]} 00:00`);
+  const endDateBoundary = new Date(`${endDateTime.split(' ')[0]} 23:59`);
+
+  return date >= startDateBoundary && date <= endDateBoundary;
+};


### PR DESCRIPTION
# [FE] 통합 캘린더 스케줄 서클 구현을 위한 유틸 함수 작성
## 이슈번호
> close #256

## PR 내용
본 PR에서는 통합 캘린더를 랜더링할 때 스케줄 서클을 어디에 랜더링해야 하는지를 알 수 있는 유틸 함수를 구현하였다.
- 스케줄 서클이란, 통합 캘린더에서 여러 팀의 일정을 축약하여 표시하기 위한 원들을 의미한다.

입력으로 `teamPlaceId` 정보가 포함된 `schedule[]` 을 받으며 (`scheduleWithTeamPlaceId[]`), 아래의 형태로 결과를 반환한다.
```tsx
{
  teamPlaceId: number[]
}[][] // 6행 7열의 2차원 배열
```

## 참고자료
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/e1ab798a-bdd3-4221-97ad-26c47913684b)
