### PR TITLE
[FE] 일정 수정 종일/시간대 선택 구현

### DIFF
--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -7,12 +7,8 @@ import Button from '../common/Button/Button';
 import Input from '../common/Input/Input';
 import useScheduleAddModal from '~/hooks/schedule/useScheduleAddModal';
 import Checkbox from '~/components/common/Checkbox/Checkbox';
-import Menu from '~/components/common/Menu/Menu';
-import MenuButton from '~/components/common/Menu/MenuButton/MenuButton';
-import MenuItem from '~/components/common/Menu/MenuItem/MenuItem';
-import MenuList from '~/components/common/Menu/MenuList/MenuList';
-import { TIME_TABLE } from '~/constants/calendar';
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
+import TimeTableMenu from '~/components/TimeTableMenu/TimeTableMenu';
 
 interface ScheduleAddModalProps {
   teamPlaceName: string;
@@ -81,31 +77,10 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
                 required
               />
               {!isAllDay && (
-                <Menu>
-                  <MenuButton
-                    css={S.timetableButton}
-                    value={times['startTime']}
-                  />
-                  <MenuList
-                    onClick={(e) => {
-                      const { target } = e;
-
-                      if (!(target instanceof HTMLLIElement)) {
-                        return;
-                      }
-
-                      handleStartTimeChange(
-                        (target as HTMLLIElement).textContent ?? '',
-                      );
-                    }}
-                  >
-                    {TIME_TABLE.map((time) => (
-                      <MenuItem key={time} value={time}>
-                        {time}
-                      </MenuItem>
-                    ))}
-                  </MenuList>
-                </Menu>
+                <TimeTableMenu
+                  displayValue={times['startTime']}
+                  onClickMenu={handleStartTimeChange}
+                />
               )}
             </S.InputWrapper>
           </S.TimeSelectContainer>
@@ -126,31 +101,10 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
                 required
               />
               {!isAllDay && (
-                <Menu>
-                  <MenuButton
-                    css={S.timetableButton}
-                    value={times['endTime']}
-                  />
-                  <MenuList
-                    onClick={(e) => {
-                      const { target } = e;
-
-                      if (!(target instanceof HTMLLIElement)) {
-                        return;
-                      }
-
-                      handleEndTimeChange(
-                        (target as HTMLLIElement).textContent ?? '',
-                      );
-                    }}
-                  >
-                    {TIME_TABLE.map((time) => (
-                      <MenuItem key={time} value={time}>
-                        {time}
-                      </MenuItem>
-                    ))}
-                  </MenuList>
-                </Menu>
+                <TimeTableMenu
+                  displayValue={times['endTime']}
+                  onClickMenu={handleEndTimeChange}
+                />
               )}
             </S.InputWrapper>
           </S.TimeSelectContainer>

--- a/frontend/src/components/ScheduleEditModal/ScheduleEditModal.styled.ts
+++ b/frontend/src/components/ScheduleEditModal/ScheduleEditModal.styled.ts
@@ -17,7 +17,7 @@ export const Container = styled.div`
   flex-direction: column;
 
   width: 496px;
-  height: 386px;
+  min-height: 400px;
   padding: 20px 30px;
 
   border-radius: 10px;
@@ -26,6 +26,13 @@ export const Container = styled.div`
     0 15px 25px #1b1d1f33,
     0 5px 10px #1b1d1f1f;
   background-color: ${({ theme }) => theme.color.WHITE};
+
+  & > form {
+    display: flex;
+    flex-direction: column;
+
+    row-gap: 24px;
+  }
 `;
 
 export const Header = styled.div`
@@ -42,7 +49,21 @@ export const Header = styled.div`
 export const TitleWrapper = styled.div`
   width: 100%;
   height: 51px;
-  margin-bottom: 28px;
+`;
+
+export const InnerContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 100%;
+`;
+
+export const CheckboxContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  column-gap: 8px;
 `;
 
 export const TimeSelectContainer = styled.div`
@@ -51,18 +72,27 @@ export const TimeSelectContainer = styled.div`
 
   width: 100%;
   height: 40px;
-  margin-bottom: 28px;
 
   column-gap: 10px;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: calc(100% - 100px);
+
+  margin-left: auto;
 `;
 
 export const TeamNameContainer = styled.div`
   display: flex;
   align-items: center;
-  gap: 5px;
 
-  width: 100%;
   height: 23px;
+
+  gap: 5px;
 `;
 
 export const ControlButtonWrapper = styled.div`
@@ -71,12 +101,6 @@ export const ControlButtonWrapper = styled.div`
 
   width: 100%;
   height: 40px;
-`;
-
-/* TODO: 체크박스 공통 컴포넌트 구현 후 이 컴포넌트를 교체 */
-export const CheckBox = styled.input`
-  width: 25px;
-  height: 25px;
 `;
 
 export const title = css`
@@ -96,7 +120,7 @@ export const closeButton = css`
 `;
 
 export const dateTimeLocalInput = css`
-  margin-right: 30px;
+  border-radius: 4px;
 
   text-align: center;
 `;
@@ -108,4 +132,8 @@ export const teamPlaceName = css`
 
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+export const submitButton = css`
+  width: 90px;
 `;

--- a/frontend/src/components/ScheduleEditModal/ScheduleEditModal.tsx
+++ b/frontend/src/components/ScheduleEditModal/ScheduleEditModal.tsx
@@ -8,6 +8,8 @@ import Text from '~/components/common/Text/Text';
 import useScheduleEditModal from '~/hooks/schedule/useScheduleEditModal';
 import type { Schedule } from '~/types/schedule';
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
+import TimeTableMenu from '~/components/TimeTableMenu/TimeTableMenu';
+import Checkbox from '~/components/common/Checkbox/Checkbox';
 
 interface ScheduleEditModalProps {
   teamPlaceName: string;
@@ -20,7 +22,16 @@ const ScheduleEditModal = (props: ScheduleEditModalProps) => {
   const { closeModal } = useModal();
   const {
     schedule,
-    handlers: { handleScheduleChange, handleScheduleSubmit },
+    times,
+    isAllDay,
+
+    handlers: {
+      handleScheduleChange,
+      handleScheduleSubmit,
+      handleStartTimeChange,
+      handleEndTimeChange,
+      handleIsAllDayChange,
+    },
   } = useScheduleEditModal(scheduleId, initialSchedule);
 
   if (initialSchedule === undefined) {
@@ -42,61 +53,84 @@ const ScheduleEditModal = (props: ScheduleEditModalProps) => {
             <CloseIcon />
           </Button>
         </S.Header>
-        <S.TitleWrapper>
-          <Input
-            width="100%"
-            height="100%"
-            placeholder="일정 제목"
-            css={S.title}
-            name="title"
-            value={schedule['title']}
-            required
-            onChange={handleScheduleChange}
-          />
-        </S.TitleWrapper>
-
         <form onSubmit={handleScheduleSubmit}>
+          <S.TitleWrapper>
+            <Input
+              width="100%"
+              height="100%"
+              placeholder="일정 제목"
+              css={S.title}
+              name="title"
+              value={schedule['title']}
+              required
+              onChange={handleScheduleChange}
+            />
+          </S.TitleWrapper>
+
           <S.TimeSelectContainer>
-            <Text size="xxl" weight="bold">
+            <Text size="xl" weight="bold">
               일정 시작
             </Text>
-            <Input
-              width="220px"
-              height="40px"
-              type="datetime-local"
-              css={S.dateTimeLocalInput}
-              name="startDateTime"
-              value={schedule['startDateTime']}
-              onChange={handleScheduleChange}
-              required
-            />
-            <Text size="xxl" weight="bold">
-              종일
-            </Text>
-            <S.CheckBox type="checkbox" />
+            <S.InputWrapper>
+              <Input
+                width={isAllDay ? '100%' : '50%'}
+                height="40px"
+                type="date"
+                css={S.dateTimeLocalInput}
+                name="startDate"
+                value={schedule['startDate']}
+                onChange={handleScheduleChange}
+                required
+              />
+              {!isAllDay && (
+                <TimeTableMenu
+                  displayValue={times['startTime']}
+                  onClickMenu={handleStartTimeChange}
+                />
+              )}
+            </S.InputWrapper>
           </S.TimeSelectContainer>
           <S.TimeSelectContainer>
             <Text size="xxl" weight="bold">
               일정 마감
             </Text>
-            <Input
-              width="220px"
-              height="40px"
-              type="datetime-local"
-              css={S.dateTimeLocalInput}
-              name="endDateTime"
-              value={schedule['endDateTime']}
-              onChange={handleScheduleChange}
-              required
-            />
+            <S.InputWrapper>
+              <Input
+                width={isAllDay ? '100%' : '50%'}
+                height="40px"
+                type="date"
+                css={S.dateTimeLocalInput}
+                name="endDate"
+                value={schedule['endDate']}
+                min={schedule['startDate']}
+                onChange={handleScheduleChange}
+                required
+              />
+              {!isAllDay && (
+                <TimeTableMenu
+                  displayValue={times['endTime']}
+                  onClickMenu={handleEndTimeChange}
+                />
+              )}
+            </S.InputWrapper>
           </S.TimeSelectContainer>
-          <S.TeamNameContainer title={teamPlaceName}>
-            <TeamBadge teamPlaceColor={0} size="lg" />
-            <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
-          </S.TeamNameContainer>
-          <S.ControlButtonWrapper>
-            <Button variant="primary">수정</Button>
-          </S.ControlButtonWrapper>
+          <S.CheckboxContainer>
+            <Text size="xl" weight="bold">
+              종일
+            </Text>
+            <Checkbox isChecked={isAllDay} onChange={handleIsAllDayChange} />
+          </S.CheckboxContainer>
+          <S.InnerContainer>
+            <S.TeamNameContainer title={teamPlaceName}>
+              <TeamBadge teamPlaceColor={0} size="lg" />
+              <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
+            </S.TeamNameContainer>
+            <S.ControlButtonWrapper>
+              <Button variant="primary" css={S.submitButton}>
+                수정
+              </Button>
+            </S.ControlButtonWrapper>
+          </S.InnerContainer>
         </form>
       </S.Container>
     </Modal>

--- a/frontend/src/components/TimeTableMenu/TimeTableMenu.stories.tsx
+++ b/frontend/src/components/TimeTableMenu/TimeTableMenu.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TimeTableMenu from '~/components/TimeTableMenu/TimeTableMenu';
+
+const meta = {
+  title: 'Calendar/TimeTableMenu',
+  component: TimeTableMenu,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TimeTableMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    displayValue: '00:00',
+    onClickMenu: () => {
+      alert('Clicked!');
+    },
+  },
+};

--- a/frontend/src/components/TimeTableMenu/TimeTableMenu.styled.ts
+++ b/frontend/src/components/TimeTableMenu/TimeTableMenu.styled.ts
@@ -1,0 +1,9 @@
+import { css } from 'styled-components';
+
+export const timeTableButton = css`
+  width: 150px;
+  height: 40px;
+
+  border: 1px solid ${({ theme }) => theme.color.GRAY200};
+  border-radius: 4px;
+`;

--- a/frontend/src/components/TimeTableMenu/TimeTableMenu.tsx
+++ b/frontend/src/components/TimeTableMenu/TimeTableMenu.tsx
@@ -1,0 +1,38 @@
+import Menu from '~/components/common/Menu/Menu';
+import * as S from './TimeTableMenu.styled';
+import { TIME_TABLE } from '~/constants/calendar';
+import type { MouseEventHandler } from 'react';
+
+interface TimeTableMenuProps {
+  displayValue: string;
+  onClickMenu: (value: string) => void;
+}
+
+const TimeTableMenu = (props: TimeTableMenuProps) => {
+  const { displayValue, onClickMenu } = props;
+
+  const handleMenuClick: MouseEventHandler<HTMLUListElement> = (e) => {
+    const { target } = e;
+
+    if (!(target instanceof HTMLLIElement)) {
+      return;
+    }
+
+    onClickMenu(target.textContent ?? '');
+  };
+
+  return (
+    <Menu>
+      <Menu.Button css={S.timeTableButton} value={displayValue} />
+      <Menu.List onClick={handleMenuClick}>
+        {TIME_TABLE.map((time) => (
+          <Menu.Item key={time} value={time}>
+            {time}
+          </Menu.Item>
+        ))}
+      </Menu.List>
+    </Menu>
+  );
+};
+
+export default TimeTableMenu;

--- a/frontend/src/components/common/Menu/Menu.stories.tsx
+++ b/frontend/src/components/common/Menu/Menu.stories.tsx
@@ -19,7 +19,7 @@ export const Default: Story = {
   render: () => {
     return (
       <Menu>
-        <MenuButton
+        <Menu.Button
           css={css`
             background-color: #516fff;
             width: 100px;
@@ -29,12 +29,12 @@ export const Default: Story = {
           `}
         >
           메뉴 열기
-        </MenuButton>
-        <MenuList>
-          <MenuItem value="메뉴 1">메뉴 1</MenuItem>
-          <MenuItem value="메뉴 2">메뉴 2</MenuItem>
-          <MenuItem value="메뉴 3">메뉴 3</MenuItem>
-        </MenuList>
+        </Menu.Button>
+        <Menu.List>
+          <Menu.Item value="메뉴 1">메뉴 1</Menu.Item>
+          <Menu.Item value="메뉴 2">메뉴 2</Menu.Item>
+          <Menu.Item value="메뉴 3">메뉴 3</Menu.Item>
+        </Menu.List>
       </Menu>
     );
   },

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,6 +1,9 @@
+import type { PropsWithChildren } from 'react';
 import { MenuProvider } from '~/components/common/Menu/MenuContext';
 import * as S from './Menu.styled';
-import type { PropsWithChildren } from 'react';
+import MenuButton from '~/components/common/Menu/MenuButton/MenuButton';
+import MenuList from '~/components/common/Menu/MenuList/MenuList';
+import MenuItem from '~/components/common/Menu/MenuItem/MenuItem';
 
 const Menu = (props: PropsWithChildren) => {
   const { children } = props;
@@ -11,5 +14,9 @@ const Menu = (props: PropsWithChildren) => {
     </MenuProvider>
   );
 };
+
+Menu.Button = MenuButton;
+Menu.List = MenuList;
+Menu.Item = MenuItem;
 
 export default Menu;

--- a/frontend/src/hooks/schedule/useScheduleEditModal.ts
+++ b/frontend/src/hooks/schedule/useScheduleEditModal.ts
@@ -3,20 +3,32 @@ import { useState } from 'react';
 import { useModifySchedule } from '~/hooks/queries/useModifySchedule';
 import { useModal } from '~/hooks/useModal';
 import { isYYYYMMDDHHMM } from '~/types/typeGuard';
-import { formatISOString } from '~/utils/formatISOString';
 import type { Schedule } from '~/types/schedule';
 
 const useScheduleEditModal = (
   scheduleId: Schedule['id'],
   initialSchedule?: Schedule,
 ) => {
+  const [startDate, startTime] = initialSchedule?.startDateTime.split(' ') ?? [
+    '',
+  ];
+  const [endDate, endTime] = initialSchedule?.endDateTime.split(' ') ?? [''];
   const [schedule, setSchedule] = useState({
     title: initialSchedule?.title,
-    startDateTime: initialSchedule?.startDateTime,
-    endDateTime: initialSchedule?.endDateTime,
+    startDate,
+    endDate,
   });
+  const [times, setTimes] = useState({
+    startTime,
+    endTime: endTime === '23:59' ? '23:30' : endTime,
+  });
+  const [isAllDay, setIsAllDay] = useState(endTime === '23:59');
   const { closeModal } = useModal();
   const { mutateModifySchedule } = useModifySchedule(1, scheduleId);
+
+  const handleIsAllDayChange = () => {
+    setIsAllDay((prev) => !prev);
+  };
 
   const handleScheduleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { name, value } = e.target;
@@ -24,20 +36,71 @@ const useScheduleEditModal = (
     setSchedule((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleStartTimeChange = (value: string) => {
+    if (!isValidEndTime(value, times['endTime'])) {
+      setTimes((prev) => {
+        return {
+          ...prev,
+          ['startTime']: value,
+          ['endTime']: value,
+        };
+      });
+
+      return;
+    }
+
+    setTimes((prev) => {
+      return {
+        ...prev,
+        ['startTime']: value,
+      };
+    });
+  };
+
+  const handleEndTimeChange = (value: string) => {
+    if (!isValidEndTime(times['startTime'], value)) {
+      setTimes((prev) => {
+        return {
+          ...prev,
+          ['endTime']: prev['startTime'],
+        };
+      });
+
+      return;
+    }
+
+    setTimes((prev) => {
+      return {
+        ...prev,
+        ['endTime']: value,
+      };
+    });
+  };
+
+  const isValidEndTime = (startTime: string, endTime: string) => {
+    const { startDate, endDate } = schedule;
+    const start = new Date(`${startDate} ${startTime}`);
+    const end = new Date(`${endDate} ${endTime}`);
+
+    return start < end;
+  };
+
   const handleScheduleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
 
-    const { title, startDateTime, endDateTime } = schedule;
-
+    const { title, startDate, endDate } = schedule;
+    const { startTime, endTime } = times;
     if (
       typeof title !== 'string' ||
-      typeof startDateTime !== 'string' ||
-      typeof endDateTime !== 'string'
+      typeof startDate !== 'string' ||
+      typeof endDate !== 'string'
     )
       return;
 
-    const formattedStartDateTime = formatISOString(startDateTime);
-    const formattedEndDateTime = formatISOString(endDateTime);
+    const formattedStartDateTime = `${startDate} ${
+      isAllDay ? '00:00' : startTime
+    }`;
+    const formattedEndDateTime = `${endDate} ${isAllDay ? '23:59' : endTime}`;
 
     if (
       !isYYYYMMDDHHMM(formattedStartDateTime) ||
@@ -60,10 +123,15 @@ const useScheduleEditModal = (
 
   return {
     schedule,
+    times,
+    isAllDay,
 
     handlers: {
       handleScheduleChange,
       handleScheduleSubmit,
+      handleStartTimeChange,
+      handleEndTimeChange,
+      handleIsAllDayChange,
     },
   };
 };


### PR DESCRIPTION
# [FE] 일정 수정 종일/시간대 선택 구현
## 이슈번호
> close #168

## PR 내용
- 일정 수정 종일/시간대 선택 구현
- 일정 등록과 로직이 유사함
- 종일 일정인 경우 체크된 상태로 보여주고, 체크 해제 시 마감 시간은 23:30
- 시간대 선택 메뉴를 TimeTableMenu 컴포넌트로 분리
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/19235163/922de96f-6392-422d-a5c7-6045834038c9)
