### PR TITLE
[FE]통합캘린더 스케줄 렌더링

### DIFF
--- a/frontend/src/components/MyCalendar/MyCalendar.styled.ts
+++ b/frontend/src/components/MyCalendar/MyCalendar.styled.ts
@@ -24,8 +24,10 @@ export const DaysOfWeek = styled.div`
 
 export const ScheduleCircleWrapper = styled.div`
   display: flex;
-  justify-content: space-evenly;
+  justify-content: center;
+
   padding-top: 2px;
+  column-gap: 2px;
 `;
 
 export const DateView = styled.div`

--- a/frontend/src/components/MyCalendar/MyCalendar.styled.ts
+++ b/frontend/src/components/MyCalendar/MyCalendar.styled.ts
@@ -24,6 +24,8 @@ export const DaysOfWeek = styled.div`
 
 export const ScheduleCircleWrapper = styled.div`
   display: flex;
+  justify-content: space-evenly;
+  padding-top: 2px;
 `;
 
 export const DateView = styled.div`

--- a/frontend/src/components/MyCalendar/MyCalendar.tsx
+++ b/frontend/src/components/MyCalendar/MyCalendar.tsx
@@ -8,6 +8,9 @@ import { ArrowLeftIcon, ArrowRightIcon } from '~/assets/svg';
 import { DAYS_OF_WEEK } from '~/constants/calendar';
 import { useFetchMySchedules } from '~/hooks/queries/useFetchMySchedules';
 import { parseDate } from '~/utils/parseDate';
+import { generateScheduleCirclesMatrix } from '~/utils/generateScheduleCirclesMatrix';
+import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
+import type { TeamPlaceColor } from '~/types/team';
 
 const MyCalendar = () => {
   const {
@@ -16,14 +19,15 @@ const MyCalendar = () => {
     calendar,
     handlers: { handlePrevButtonClick, handleNextButtonClick },
   } = useCalendar();
-
-  const schedules = useFetchMySchedules(year, month);
   const {
     year: currentYear,
     month: currentMonth,
     date: currentDate,
   } = parseDate(new Date());
 
+  const schedules = useFetchMySchedules(year, month);
+  const scheduleCircles = generateScheduleCirclesMatrix(year, month, schedules);
+  console.log(schedules);
   return (
     <S.Container>
       <S.CalendarHeader>
@@ -58,12 +62,11 @@ const MyCalendar = () => {
           })}
         </S.DaysOfWeek>
         <div>
-          {calendar.map((week, index) => {
+          {calendar.map((week, rowIndex) => {
             return (
-              <Fragment key={index}>
-                <S.ScheduleCircleWrapper></S.ScheduleCircleWrapper>
+              <Fragment key={rowIndex}>
                 <S.DateView>
-                  {week.map((day) => {
+                  {week.map((day, colIndex) => {
                     const {
                       year: renderYear,
                       month: renderMonth,
@@ -74,15 +77,27 @@ const MyCalendar = () => {
                       currentYear === renderYear &&
                       currentMonth === renderMonth &&
                       currentDate === renderDate;
-
+                    console.log(scheduleCircles[rowIndex][colIndex]);
                     return (
-                      <DateCell
-                        key={day.toISOString()}
-                        rawDate={day}
-                        currentMonth={month}
-                        isToday={isToday}
-                        size="sm"
-                      />
+                      <div key={day.toISOString()}>
+                        <DateCell
+                          rawDate={day}
+                          currentMonth={month}
+                          isToday={isToday}
+                          size="sm"
+                        />
+                        <S.ScheduleCircleWrapper>
+                          {scheduleCircles[rowIndex][colIndex].teamPlaceIds.map(
+                            (teamPlaceId) => (
+                              <TeamBadge
+                                key={`${rowIndex},${colIndex}`}
+                                size="sm"
+                                teamPlaceColor={teamPlaceId as TeamPlaceColor} //팀 조회 로직 나오면 바꿀 임시 색상 로직
+                              />
+                            ),
+                          )}
+                        </S.ScheduleCircleWrapper>
+                      </div>
                     );
                   })}
                 </S.DateView>

--- a/frontend/src/components/MyCalendar/MyCalendar.tsx
+++ b/frontend/src/components/MyCalendar/MyCalendar.tsx
@@ -27,7 +27,7 @@ const MyCalendar = () => {
 
   const schedules = useFetchMySchedules(year, month);
   const scheduleCircles = generateScheduleCirclesMatrix(year, month, schedules);
-  console.log(schedules);
+
   return (
     <S.Container>
       <S.CalendarHeader>
@@ -40,7 +40,7 @@ const MyCalendar = () => {
           <ArrowLeftIcon />
         </Button>
         <Text size="xxl">
-          {year}-{month + 1}
+          {year}년 {month + 1}월
         </Text>
         <Button
           variant="plain"
@@ -77,7 +77,7 @@ const MyCalendar = () => {
                       currentYear === renderYear &&
                       currentMonth === renderMonth &&
                       currentDate === renderDate;
-                    console.log(scheduleCircles[rowIndex][colIndex]);
+
                     return (
                       <div key={day.toISOString()}>
                         <DateCell

--- a/frontend/src/components/common/TeamBadge/TeamBadge.styled.ts
+++ b/frontend/src/components/common/TeamBadge/TeamBadge.styled.ts
@@ -5,8 +5,8 @@ export const Wrapper = styled.div<TeamBadgeProps>`
   ${({ size }) => {
     if (size === 'sm')
       return css`
-        width: 8px;
-        height: 8px;
+        width: 6px;
+        height: 6px;
       `;
     if (size === 'lg')
       return css`

--- a/frontend/src/hooks/queries/useDeleteSchedule.ts
+++ b/frontend/src/hooks/queries/useDeleteSchedule.ts
@@ -9,6 +9,8 @@ export const useDeleteSchedule = (teamPlaceId: number, scheduleId: number) => {
       onSuccess: () => {
         queryClient.invalidateQueries(['schedules', teamPlaceId]);
         queryClient.removeQueries(['schedule', teamPlaceId, scheduleId]);
+        queryClient.invalidateQueries(['mySchedules']);
+        queryClient.invalidateQueries(['myDailySchedules']);
       },
       onError: () => {
         alert('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');

--- a/frontend/src/hooks/queries/useModifySchedule.ts
+++ b/frontend/src/hooks/queries/useModifySchedule.ts
@@ -13,6 +13,8 @@ export const useModifySchedule = (
       onSuccess: () => {
         queryClient.invalidateQueries(['schedules', teamPlaceId]);
         queryClient.invalidateQueries(['schedule', teamPlaceId, scheduleId]);
+        queryClient.invalidateQueries(['mySchedules']);
+        queryClient.invalidateQueries(['myDailySchedules']);
       },
     },
   );

--- a/frontend/src/hooks/queries/useSendSchedule.ts
+++ b/frontend/src/hooks/queries/useSendSchedule.ts
@@ -9,6 +9,8 @@ export const useSendSchedule = (teamPlaceId: number) => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['schedules', teamPlaceId]);
+        queryClient.invalidateQueries(['mySchedules']);
+        queryClient.invalidateQueries(['myDailySchedules']);
       },
     },
   );

--- a/frontend/src/mocks/handlers/calendar.ts
+++ b/frontend/src/mocks/handlers/calendar.ts
@@ -1,10 +1,11 @@
 import { rest } from 'msw';
 import {
   schedules as scheduleData,
-  mySchedules,
+  mySchedules as myScheduleData,
 } from '~/mocks/fixtures/schedules';
 
 let schedules = [...scheduleData];
+let mySchedules = [...myScheduleData];
 
 export const calendarHandlers = [
   //통합캘린더 일정 기간 조회
@@ -53,6 +54,7 @@ export const calendarHandlers = [
       const teamPlaceId = Number(req.params.teamPlaceId);
 
       schedules.push(newSchedule);
+      mySchedules.push({ ...newSchedule, teamPlaceId: 1 });
 
       return res(
         ctx.status(201),
@@ -74,10 +76,22 @@ export const calendarHandlers = [
         (schedule) => schedule.id === scheduleId,
       );
 
+      const myIndex = mySchedules.findIndex(
+        (schedule) => schedule.id === scheduleId,
+      );
+
       if (index === -1) return res(ctx.status(404));
 
       schedules[index] = {
         id: scheduleId,
+        title,
+        startDateTime,
+        endDateTime,
+      };
+
+      mySchedules[myIndex] = {
+        id: scheduleId,
+        teamPlaceId: mySchedules[myIndex].teamPlaceId,
         title,
         startDateTime,
         endDateTime,
@@ -95,11 +109,12 @@ export const calendarHandlers = [
       const index = schedules.findIndex(
         (schedule) => schedule.id === scheduleId,
       );
-
       if (index === -1) return res(ctx.status(404));
 
       schedules = schedules.filter((schedule) => schedule.id !== scheduleId);
-
+      mySchedules = mySchedules.filter(
+        (schedule) => schedule.id !== scheduleId,
+      );
       return res(ctx.status(204));
     },
   ),


### PR DESCRIPTION
[FE]통합캘린더 스케줄 렌더링 
## 이슈번호
> close #274 

## PR 내용
<img width="194" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/49e15c20-6b3b-43c7-b551-7a3aabd43d4f">

스케줄 등록/수정/삭제에 의존성 추가
스케줄 msw에 야매로 통합도 반영되도록 함. 
통합이랑 스케줄이랑 data가 달라서 안에 있는지 없는지는 검사안하고 있음-> 새로 등록 하고 삭제 하는 것에 대해서만 msw통해서 통합 캘린더 볼 수 있음

