### PR TITLE
[FE] 팀 정보를 조회해오는 API 로직 구현

### DIFF
--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -1,0 +1,8 @@
+import { http } from '~/apis/http';
+import type { TeamPlace } from '~/types/team';
+
+export const fetchTeamPlaces = () => {
+  return http.get<{
+    teamPlaces: TeamPlace[];
+  }>('/api/me/team-places');
+};

--- a/frontend/src/hooks/queries/useFetchTeamPlaces.ts
+++ b/frontend/src/hooks/queries/useFetchTeamPlaces.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchTeamPlaces } from '~/apis/team';
+
+export const useFetchTeamPlaces = () => {
+  const { data } = useQuery(['teamPlaces'], () => fetchTeamPlaces());
+
+  if (data === undefined) return [];
+
+  const { teamPlaces } = data;
+
+  return { teamPlaces };
+};

--- a/frontend/src/mocks/fixtures/team.ts
+++ b/frontend/src/mocks/fixtures/team.ts
@@ -1,0 +1,56 @@
+import type { TeamPlace } from '~/types/team';
+
+export const teamPlaces = {
+  teamPlaces: [
+    {
+      id: 1,
+      displayName: '인공지능 신비주의자들',
+      teamPlaceColor: 0,
+    },
+    {
+      id: 2,
+      displayName: '[3조] 환경 구원 대작전',
+      teamPlaceColor: 1,
+    },
+    {
+      id: 3,
+      displayName: '윤리와 인간관계 2조',
+      teamPlaceColor: 2,
+    },
+    {
+      id: 4,
+      displayName: '문화 다양성과 소통 1조 팀플레이스입니다.',
+      teamPlaceColor: 3,
+    },
+    {
+      id: 5,
+      displayName: '그냥 저희 빨리 하고 끝내죠',
+      teamPlaceColor: 4,
+    },
+    {
+      id: 6,
+      displayName: '!! 게임 동아리',
+      teamPlaceColor: 5,
+    },
+    {
+      id: 7,
+      displayName: '북클럽 스터디 7기',
+      teamPlaceColor: 6,
+    },
+    {
+      id: 8,
+      displayName: '우아한테크코스 팀바팀',
+      teamPlaceColor: 7,
+    },
+    {
+      id: 9,
+      displayName: 'English II',
+      teamPlaceColor: 8,
+    },
+    {
+      id: 10,
+      displayName: '현대사회와 범죄 5조',
+      teamPlaceColor: 9,
+    },
+  ],
+};

--- a/frontend/src/mocks/fixtures/team.ts
+++ b/frontend/src/mocks/fixtures/team.ts
@@ -1,56 +1,54 @@
 import type { TeamPlace } from '~/types/team';
 
-export const teamPlaces = {
-  teamPlaces: [
-    {
-      id: 1,
-      displayName: '인공지능 신비주의자들',
-      teamPlaceColor: 0,
-    },
-    {
-      id: 2,
-      displayName: '[3조] 환경 구원 대작전',
-      teamPlaceColor: 1,
-    },
-    {
-      id: 3,
-      displayName: '윤리와 인간관계 2조',
-      teamPlaceColor: 2,
-    },
-    {
-      id: 4,
-      displayName: '문화 다양성과 소통 1조 팀플레이스입니다.',
-      teamPlaceColor: 3,
-    },
-    {
-      id: 5,
-      displayName: '그냥 저희 빨리 하고 끝내죠',
-      teamPlaceColor: 4,
-    },
-    {
-      id: 6,
-      displayName: '!! 게임 동아리',
-      teamPlaceColor: 5,
-    },
-    {
-      id: 7,
-      displayName: '북클럽 스터디 7기',
-      teamPlaceColor: 6,
-    },
-    {
-      id: 8,
-      displayName: '우아한테크코스 팀바팀',
-      teamPlaceColor: 7,
-    },
-    {
-      id: 9,
-      displayName: 'English II',
-      teamPlaceColor: 8,
-    },
-    {
-      id: 10,
-      displayName: '현대사회와 범죄 5조',
-      teamPlaceColor: 9,
-    },
-  ],
-};
+export const teamPlaces: TeamPlace[] = [
+  {
+    id: 1,
+    displayName: '인공지능 신비주의자들',
+    teamPlaceColor: 0,
+  },
+  {
+    id: 2,
+    displayName: '[3조] 환경 구원 대작전',
+    teamPlaceColor: 1,
+  },
+  {
+    id: 3,
+    displayName: '윤리와 인간관계 2조',
+    teamPlaceColor: 2,
+  },
+  {
+    id: 4,
+    displayName: '문화 다양성과 소통 1조 팀플레이스입니다.',
+    teamPlaceColor: 3,
+  },
+  {
+    id: 5,
+    displayName: '그냥 저희 빨리 하고 끝내죠',
+    teamPlaceColor: 4,
+  },
+  {
+    id: 6,
+    displayName: '!! 게임 동아리',
+    teamPlaceColor: 5,
+  },
+  {
+    id: 7,
+    displayName: '북클럽 스터디 7기',
+    teamPlaceColor: 6,
+  },
+  {
+    id: 8,
+    displayName: '우아한테크코스 팀바팀',
+    teamPlaceColor: 7,
+  },
+  {
+    id: 9,
+    displayName: 'English II',
+    teamPlaceColor: 8,
+  },
+  {
+    id: 10,
+    displayName: '현대사회와 범죄 5조',
+    teamPlaceColor: 9,
+  },
+];

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,5 +1,5 @@
 import { calendarHandlers } from '~/mocks/handlers/calendar';
 import { feedHandlers } from '~/mocks/handlers/feed';
-import { teamHandlers } from './team';
+import { teamHandlers } from '~/mocks/handlers/team';
 
 export const handlers = [...calendarHandlers, ...feedHandlers, ...teamHandlers];

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { calendarHandlers } from '~/mocks/handlers/calendar';
 import { feedHandlers } from '~/mocks/handlers/feed';
+import { teamHandlers } from './team';
 
-export const handlers = [...calendarHandlers, ...feedHandlers];
+export const handlers = [...calendarHandlers, ...feedHandlers, ...teamHandlers];

--- a/frontend/src/mocks/handlers/team.ts
+++ b/frontend/src/mocks/handlers/team.ts
@@ -1,0 +1,11 @@
+import { rest } from 'msw';
+import { teamPlaces as teamPlaceData } from '~/mocks/fixtures/team';
+
+const teamPlaces = { ...teamPlaceData };
+
+export const teamHandlers = [
+  // 팀플레이스 목록 조회
+  rest.get('/api/me/team-places', async (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(teamPlaces));
+  }),
+];

--- a/frontend/src/mocks/handlers/team.ts
+++ b/frontend/src/mocks/handlers/team.ts
@@ -1,11 +1,9 @@
 import { rest } from 'msw';
-import { teamPlaces as teamPlaceData } from '~/mocks/fixtures/team';
-
-const teamPlaces = { teamPlaceData };
+import { teamPlaces } from '~/mocks/fixtures/team';
 
 export const teamHandlers = [
   // 팀플레이스 목록 조회
   rest.get('/api/me/team-places', async (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(teamPlaces));
+    return res(ctx.status(200), ctx.json({ teamPlaces }));
   }),
 ];

--- a/frontend/src/mocks/handlers/team.ts
+++ b/frontend/src/mocks/handlers/team.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { teamPlaces as teamPlaceData } from '~/mocks/fixtures/team';
 
-const teamPlaces = { ...teamPlaceData };
+const teamPlaces = { teamPlaceData };
 
 export const teamHandlers = [
   // 팀플레이스 목록 조회

--- a/frontend/src/types/team.ts
+++ b/frontend/src/types/team.ts
@@ -1,1 +1,7 @@
 export type TeamPlaceColor = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+export interface TeamPlace {
+  id: number;
+  displayName: string;
+  teamPlaceColor: TeamPlaceColor;
+}


### PR DESCRIPTION
# [FE] 팀 정보를 조회해오는 API 로직 구현
## 이슈번호
> close #275 

## PR 내용
본 PR에서는 팀 정보를 조회해 올 수 있도록 비동기 로직을 구현하였다. 팀 정보 조회에 대한 msw 모킹이 포함되어 있다.

## 참고자료
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/bfb0cad5-1c50-4ded-bb70-e6f9f2dac413)
