### PR TITLE
[FE] 스케줄바 타이틀 표시 구현

### DIFF
--- a/frontend/src/components/ScheduleBar/ScheduleBar.styled.ts
+++ b/frontend/src/components/ScheduleBar/ScheduleBar.styled.ts
@@ -3,7 +3,6 @@ import type { ScheduleBarProps } from '~/components/ScheduleBar/ScheduleBar';
 
 export const Wrapper = styled.div<ScheduleBarProps>`
   position: absolute;
-
   top: ${({ level }) => level * 18 + 36}px;
   left: ${({ column }) => (column * 100) / 7}%;
 
@@ -18,7 +17,6 @@ export const Inner = styled.div<Pick<ScheduleBarProps, 'color' | 'level'>>`
   align-items: center;
 
   height: 100%;
-
   padding-left: 6px;
 
   background-color: ${({ color }) => color};
@@ -27,6 +25,7 @@ export const Inner = styled.div<Pick<ScheduleBarProps, 'color' | 'level'>>`
   filter: brightness(${({ level }) => 1 + level * 0.5});
 
   cursor: pointer;
+
   &:hover {
     opacity: 0.8;
   }
@@ -34,6 +33,5 @@ export const Inner = styled.div<Pick<ScheduleBarProps, 'color' | 'level'>>`
 
 export const scheduleBarTitle = css`
   font-size: 13px;
-
   color: ${({ theme }) => theme.color.WHITE};
 `;

--- a/frontend/src/components/ScheduleBar/ScheduleBar.styled.ts
+++ b/frontend/src/components/ScheduleBar/ScheduleBar.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import type { ScheduleBarProps } from '~/components/ScheduleBar/ScheduleBar';
 
 export const Wrapper = styled.div<ScheduleBarProps>`
@@ -14,7 +14,12 @@ export const Wrapper = styled.div<ScheduleBarProps>`
 `;
 
 export const Inner = styled.div<Pick<ScheduleBarProps, 'color' | 'level'>>`
+  display: flex;
+  align-items: center;
+
   height: 100%;
+
+  padding-left: 6px;
 
   background-color: ${({ color }) => color};
   border-radius: 4px;
@@ -25,4 +30,10 @@ export const Inner = styled.div<Pick<ScheduleBarProps, 'color' | 'level'>>`
   &:hover {
     opacity: 0.8;
   }
+`;
+
+export const scheduleBarTitle = css`
+  font-size: 13px;
+
+  color: ${({ theme }) => theme.color.WHITE};
 `;

--- a/frontend/src/components/ScheduleBar/ScheduleBar.tsx
+++ b/frontend/src/components/ScheduleBar/ScheduleBar.tsx
@@ -1,3 +1,4 @@
+import Text from '~/components/common/Text/Text';
 import * as S from './ScheduleBar.styled';
 
 export interface ScheduleBarProps {
@@ -17,7 +18,11 @@ const ScheduleBar = (props: ScheduleBarProps) => {
 
   return (
     <S.Wrapper color={color} title={title} onClick={onClick} {...rest}>
-      <S.Inner color={color} {...rest} />
+      <S.Inner color={color} {...rest}>
+        <Text as="span" css={S.scheduleBarTitle}>
+          {title}
+        </Text>
+      </S.Inner>
     </S.Wrapper>
   );
 };


### PR DESCRIPTION
# [FE] 스케줄바 타이틀 표시 구현
## 이슈번호
> close #180 

## PR 내용
- 스케줄바 타이틀 표시 구현 
<img width="1482" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/19235163/3031a2ac-1c1f-4383-855d-54edc9b4ce23">
