### PR TITLE
[BE] 공지 조회 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -51,13 +51,12 @@ public class NoticeService {
         return !teamPlaceRepository.existsById(teamPlaceId);
     }
 
+    @Transactional(readOnly = true)
     public Optional<NoticeResponse> findMostRecentNotice(final Long teamPlaceId) {
         checkTeamPlaceExist(teamPlaceId);
 
         return noticeRepository.findMostRecentByTeamPlaceId(teamPlaceId)
-                .flatMap(findNotice -> {
-                    return memberRepository.findById(findNotice.getAuthorId())
-                            .map(findAuthor -> NoticeResponse.of(findNotice, findAuthor));
-                });
+                .flatMap(findNotice -> memberRepository.findById(findNotice.getAuthorId())
+                        .map(findAuthor -> NoticeResponse.of(findNotice, findAuthor)));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/dto/NoticeResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/dto/NoticeResponse.java
@@ -1,0 +1,32 @@
+package team.teamby.teambyteam.notice.application.dto;
+
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.notice.domain.Notice;
+
+import java.time.format.DateTimeFormatter;
+
+public record NoticeResponse(
+        Long id,
+        String content,
+        Long authorId,
+        String authorName,
+        String profileImageUrl,
+        String createdAt
+) {
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
+
+    public static NoticeResponse of(final Notice notice, final Member member) {
+        final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
+        final String noticeCreatedAt = dateTimeFormatter.format(notice.getCreatedAt());
+
+        return new NoticeResponse(
+                notice.getId(),
+                notice.getContent().getValue(),
+                member.getId(),
+                member.getName().getValue(),
+                member.getProfileImageUrl().getValue(),
+                noticeCreatedAt
+        );
+    }
+}
+

--- a/backend/src/main/java/team/teamby/teambyteam/notice/domain/NoticeRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/domain/NoticeRepository.java
@@ -1,10 +1,19 @@
 package team.teamby.teambyteam.notice.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     List<Notice> findAllByTeamPlaceId(Long teamPlaceId);
+
+    @Query("SELECT n FROM Notice n " +
+            "WHERE n.teamPlaceId = :teamPlaceId " +
+            "ORDER BY n.id DESC " +
+            "LIMIT 1"
+    )
+    Optional<Notice> findMostRecentByTeamPlaceId(Long teamPlaceId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.notice.presentation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import team.teamby.teambyteam.member.configuration.AuthPrincipal;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.notice.application.NoticeService;
 import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
+import team.teamby.teambyteam.notice.application.dto.NoticeResponse;
 
 import java.net.URI;
 
@@ -23,7 +25,7 @@ public class NoticeController {
     private final NoticeService noticeService;
 
     @PostMapping("/{teamPlaceId}/feed/notice")
-    public ResponseEntity<Void> register(
+    public ResponseEntity<Void> registerNotice(
             @RequestBody @Valid final NoticeRegisterRequest reqeust,
             @PathVariable final Long teamPlaceId,
             @AuthPrincipal final MemberEmailDto memberEmailDto
@@ -32,5 +34,15 @@ public class NoticeController {
         final URI location = URI.create("/api/team-place/" + teamPlaceId + "/feed/threads/notice/" + registeredId);
 
         return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping("/{teamPlaceId}/feed/notice/recent")
+    public ResponseEntity<Object> findNotice(@PathVariable final Long teamPlaceId) {
+        final NoticeResponse noticeResponse = noticeService.findMostRecentNotice(teamPlaceId);
+
+        if (noticeResponse == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(noticeResponse);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
@@ -16,6 +16,7 @@ import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
 import team.teamby.teambyteam.notice.application.dto.NoticeResponse;
 
 import java.net.URI;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,12 +38,11 @@ public class NoticeController {
     }
 
     @GetMapping("/{teamPlaceId}/feed/notice/recent")
-    public ResponseEntity<Object> findNotice(@PathVariable final Long teamPlaceId) {
-        final NoticeResponse noticeResponse = noticeService.findMostRecentNotice(teamPlaceId);
+    public ResponseEntity<NoticeResponse> findNotice(@PathVariable final Long teamPlaceId) {
+        final Optional<NoticeResponse> noticeResponseOptional = noticeService.findMostRecentNotice(teamPlaceId);
 
-        if (noticeResponse == null) {
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity.ok(noticeResponse);
+        return noticeResponseOptional
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.noContent().build());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
@@ -41,8 +41,10 @@ public class NoticeController {
     public ResponseEntity<NoticeResponse> findNotice(@PathVariable final Long teamPlaceId) {
         final Optional<NoticeResponse> noticeResponseOptional = noticeService.findMostRecentNotice(teamPlaceId);
 
-        return noticeResponseOptional
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.noContent().build());
+        if (noticeResponseOptional.isEmpty()) {
+            return ResponseEntity.ok().build();
+        }
+
+        return ResponseEntity.ok(noticeResponseOptional.get());
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/NoticeFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/NoticeFixtures.java
@@ -11,6 +11,7 @@ public class NoticeFixtures {
      */
     public static final String FIRST_CONTENT = "1stNotice";
     public static final String SECOND_CONTENT = "2ndNotice";
+    public static final String THIRD_CONTENT = "3rdNotice";
 
     /**
      * REQUEST
@@ -27,5 +28,9 @@ public class NoticeFixtures {
 
     public static Notice NOTICE_2ND(final Long teamPlaceId, final Long authorId) {
         return new Notice(new Content(SECOND_CONTENT), teamPlaceId, authorId);
+    }
+
+    public static Notice NOTICE_3RD(final Long teamPlaceId, final Long authorId) {
+        return new Notice(new Content(THIRD_CONTENT), teamPlaceId, authorId);
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/NoticeAcceptanceFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/NoticeAcceptanceFixtures.java
@@ -24,4 +24,16 @@ public class NoticeAcceptanceFixtures {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> GET_NOTICE_REQUEST(
+            final String authToken,
+            final Long teamPlaceId
+    ) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + authToken)
+                .when().log().all()
+                .get("/api/team-place/{teamPlaceId}/feed/notice/recent", teamPlaceId)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
@@ -199,7 +199,7 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(StringUtils.isBlank(response.body().asString())).isTrue();
             });
         }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.commons.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -17,13 +18,19 @@ import team.teamby.teambyteam.common.fixtures.NoticeFixtures;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
+import team.teamby.teambyteam.notice.domain.Notice;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
+import static team.teamby.teambyteam.common.fixtures.NoticeFixtures.*;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.acceptance.NoticeAcceptanceFixtures.GET_NOTICE_REQUEST;
 import static team.teamby.teambyteam.common.fixtures.acceptance.NoticeAcceptanceFixtures.POST_NOTICE_REQUEST;
 
 public class NoticeAcceptanceTest extends AcceptanceTest {
@@ -129,6 +136,104 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
             assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
                 softly.assertThat(response.body().asString()).contains("조회한 멤버가 존재하지 않습니다.");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("공지 조회 시")
+    class FindNotice {
+
+        public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+        private Member authedMember;
+        private TeamPlace participatedTeamPlace;
+        private MemberTeamPlace participatedMemberTeamPlace;
+        private String authToken;
+        private List<Notice> registeredNotices;
+
+        @BeforeEach
+        void setup() {
+            authedMember = testFixtureBuilder.buildMember(PHILIP());
+            participatedTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            participatedMemberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(authedMember, participatedTeamPlace);
+            authToken = jwtTokenProvider.generateToken(authedMember.getEmail().getValue());
+            Notice notice1 = NOTICE_1ST(participatedMemberTeamPlace.getId(), authedMember.getId());
+            Notice notice2 = NOTICE_2ND(participatedMemberTeamPlace.getId(), authedMember.getId());
+            Notice notice3 = NOTICE_3RD(participatedMemberTeamPlace.getId(), authedMember.getId());
+            registeredNotices = testFixtureBuilder.buildNotices(List.of(notice1, notice2, notice3));
+        }
+
+        @Test
+        @DisplayName("가장 최근에 등록된 공지가 조회된다.")
+        void successFindingNotice() {
+            //given
+            final Notice recentRegisteredNotice = registeredNotices.get(registeredNotices.size() - 1);
+
+            // when
+            final ExtractableResponse<Response> response = GET_NOTICE_REQUEST(authToken, participatedTeamPlace.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(response.jsonPath().getLong("id")).isEqualTo(recentRegisteredNotice.getId());
+                softly.assertThat(response.jsonPath().getString("content")).isEqualTo(recentRegisteredNotice.getContent().getValue());
+                softly.assertThat(response.jsonPath().getLong("authorId")).isEqualTo(authedMember.getId());
+                softly.assertThat(response.jsonPath().getString("authorName")).isEqualTo(authedMember.getName().getValue());
+                softly.assertThat(response.jsonPath().getString("profileImageUrl")).isEqualTo(authedMember.getProfileImageUrl().getValue());
+                softly.assertThat(response.jsonPath().getString("createdAt")).isEqualTo(DATE_TIME_FORMATTER.format(recentRegisteredNotice.getCreatedAt()));
+            });
+        }
+
+        @Test
+        @DisplayName("팀플레이스에 등록 된 공지가 없을 경우 빈 값이 반환된다.")
+        void successFindingEmptyNotice() {
+            // given
+            final Member additionalMember = testFixtureBuilder.buildMember(ROY());
+            final TeamPlace additionalTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());
+            final MemberTeamPlace additionalMemberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(additionalMember, additionalTeamPlace);
+            final String additionalToken = jwtTokenProvider.generateToken(additionalMember.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = GET_NOTICE_REQUEST(additionalToken, additionalTeamPlace.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+                softly.assertThat(StringUtils.isBlank(response.body().asString())).isTrue();
+            });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팀플레이스로 공지 조회 요청 시 예외가 발생한다.")
+        void failWithNonExistTeamPlace() {
+            // given
+            final Long nonExistTeamPlaceId = -1L;
+
+            // when
+            final ExtractableResponse<Response> response = GET_NOTICE_REQUEST(authToken, nonExistTeamPlaceId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(response.body().asString()).contains("접근할 수 없는 팀플레이스입니다.");
+            });
+        }
+
+        @Test
+        @DisplayName("사용자가 소속되지 않은 팀플레이스 Id로 공지 조회 요청 시 예외가 발생한다.")
+        void failWithForbiddenTeamPlace() {
+            // given
+            final Member forbiddenMember = testFixtureBuilder.buildMember(ROY());
+            final String forbiddenToken = jwtTokenProvider.generateToken(forbiddenMember.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = GET_NOTICE_REQUEST(forbiddenToken, participatedTeamPlace.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(response.body().asString()).contains("접근할 수 없는 팀플레이스입니다.");
             });
         }
     }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.notice.application;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +18,7 @@ import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException.NotFoundException;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -111,10 +113,13 @@ class NoticeServiceTest extends ServiceTest {
         @DisplayName("공지 조회 시 가장 최근에 등록된 공지가 조회된다.")
         void successFindNotice() {
             // when
-            final NoticeResponse noticeResponse = noticeService.findMostRecentNotice(teamPlace.getId());
+            final Optional<NoticeResponse> noticeResponse = noticeService.findMostRecentNotice(teamPlace.getId());
 
             // then
-            assertThat(noticeResponse.content()).isEqualTo("3rdNotice");
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(noticeResponse).isPresent();
+                softly.assertThat(noticeResponse.get().content()).isEqualTo("3rdNotice");
+            });
         }
 
         @Test
@@ -136,23 +141,10 @@ class NoticeServiceTest extends ServiceTest {
             final TeamPlace additionalTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());
 
             // when
-            final NoticeResponse noticeResponse = noticeService.findMostRecentNotice(additionalTeamPlace.getId());
+            Optional<NoticeResponse> noticeResponse = noticeService.findMostRecentNotice(additionalTeamPlace.getId());
 
             //then
-            assertThat(noticeResponse).isNull();
-        }
-
-        @Test
-        @DisplayName("조회할 공지를 작성한 Member의 Id값이 존재하지 않을 경우 예외가 발생한다.")
-        void failMemberNotExistByIdFindingNotice() {
-            // given
-            final Long nonExistMemberId = -1L;
-            testFixtureBuilder.buildNotice(NOTICE_1ST(teamPlace.getId(), nonExistMemberId));
-
-            // when & then
-            assertThatThrownBy(() -> noticeService.findMostRecentNotice(teamPlace.getId()))
-                    .isInstanceOf(MemberNotFoundException.class)
-                    .hasMessage("조회한 멤버가 존재하지 않습니다.");
+            assertThat(noticeResponse).isEmpty();
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -8,17 +8,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
-import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.member.exception.MemberException.MemberNotFoundException;
 import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
+import team.teamby.teambyteam.notice.application.dto.NoticeResponse;
+import team.teamby.teambyteam.notice.domain.Notice;
 import team.teamby.teambyteam.notice.domain.NoticeRepository;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException.NotFoundException;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.*;
-import static team.teamby.teambyteam.common.fixtures.NoticeFixtures.FIRST_NOTICE_REGISTER_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.NoticeFixtures.*;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
 
 class NoticeServiceTest extends ServiceTest {
 
@@ -63,7 +68,7 @@ class NoticeServiceTest extends ServiceTest {
 
             // when & then
             assertThatThrownBy(() -> noticeService.register(request, notExistTeamPlaceId, ROY_MEMBER_EMAIL_REQUEST))
-                    .isInstanceOf(TeamPlaceException.NotFoundException.class)
+                    .isInstanceOf(NotFoundException.class)
                     .hasMessage("조회한 팀 플레이스가 존재하지 않습니다.");
         }
 
@@ -75,7 +80,78 @@ class NoticeServiceTest extends ServiceTest {
 
             // when & then
             assertThatThrownBy(() -> noticeService.register(request, teamPlace.getId(), new MemberEmailDto(nonExistMember.getEmail().getValue())))
-                    .isInstanceOf(MemberException.MemberNotFoundException.class)
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage("조회한 멤버가 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("공지 조회 시")
+    class findNotice {
+
+        private Member member;
+        private TeamPlace teamPlace;
+        private NoticeRegisterRequest request;
+        private List<Notice> notices;
+
+        @BeforeEach
+        void setUP() {
+            member = testFixtureBuilder.buildMember(ROY());
+            teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            request = FIRST_NOTICE_REGISTER_REQUEST;
+            notices = testFixtureBuilder.buildNotices(
+                    List.of(
+                            NOTICE_1ST(teamPlace.getId(), member.getId()),
+                            NOTICE_2ND(teamPlace.getId(), member.getId()),
+                            NOTICE_3RD(teamPlace.getId(), member.getId()))
+            );
+        }
+
+        @Test
+        @DisplayName("공지 조회 시 가장 최근에 등록된 공지가 조회된다.")
+        void successFindNotice() {
+            // when
+            final NoticeResponse noticeResponse = noticeService.findMostRecentNotice(teamPlace.getId());
+
+            // then
+            assertThat(noticeResponse.content()).isEqualTo("3rdNotice");
+        }
+
+        @Test
+        @DisplayName("공지 조회 시 팀 플레이스 ID에 해당하는 팀 플레이스가 존재하지 않으면 예외가 발생한다.")
+        void failTeamPlaceNotExistByIdFindingNotice() {
+            // given
+            final Long notExistTeamPlaceId = -1L;
+
+            // when & then
+            assertThatThrownBy(() -> noticeService.findMostRecentNotice(notExistTeamPlaceId))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("조회한 팀 플레이스가 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("조회할 공지가 없으면 null값을 반환한다.")
+        void succeedFindEmptyNotice() {
+            // given
+            final TeamPlace additionalTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());
+
+            // when
+            final NoticeResponse noticeResponse = noticeService.findMostRecentNotice(additionalTeamPlace.getId());
+
+            //then
+            assertThat(noticeResponse).isNull();
+        }
+
+        @Test
+        @DisplayName("조회할 공지를 작성한 Member의 Id값이 존재하지 않을 경우 예외가 발생한다.")
+        void failMemberNotExistByIdFindingNotice() {
+            // given
+            final Long nonExistMemberId = -1L;
+            testFixtureBuilder.buildNotice(NOTICE_1ST(teamPlace.getId(), nonExistMemberId));
+
+            // when & then
+            assertThatThrownBy(() -> noticeService.findMostRecentNotice(teamPlace.getId()))
+                    .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage("조회한 멤버가 존재하지 않습니다.");
         }
     }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -139,9 +139,10 @@ class NoticeServiceTest extends ServiceTest {
         void succeedFindEmptyNotice() {
             // given
             final TeamPlace additionalTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());
+            final TeamPlace registerdTeamplace = testFixtureBuilder.buildTeamPlace(additionalTeamPlace);
 
             // when
-            Optional<NoticeResponse> noticeResponse = noticeService.findMostRecentNotice(additionalTeamPlace.getId());
+            Optional<NoticeResponse> noticeResponse = noticeService.findMostRecentNotice(registerdTeamplace.getId());
 
             //then
             assertThat(noticeResponse).isEmpty();

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -135,7 +135,7 @@ class NoticeServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("조회할 공지가 없으면 null값을 반환한다.")
+        @DisplayName("조회할 공지가 없으면 빈 Optional 객체를 반환한다.")
         void succeedFindEmptyNotice() {
             // given
             final TeamPlace additionalTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());

--- a/backend/src/test/java/team/teamby/teambyteam/notice/domain/NoticeRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/domain/NoticeRepositoryTest.java
@@ -7,10 +7,11 @@ import team.teamby.teambyteam.common.RepositoryTest;
 import team.teamby.teambyteam.notice.domain.vo.Content;
 
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static team.teamby.teambyteam.common.fixtures.NoticeFixtures.NOTICE_1ST;
-import static team.teamby.teambyteam.common.fixtures.NoticeFixtures.NOTICE_2ND;
+import static team.teamby.teambyteam.common.fixtures.NoticeFixtures.*;
 
 class NoticeRepositoryTest extends RepositoryTest {
 
@@ -37,5 +38,39 @@ class NoticeRepositoryTest extends RepositoryTest {
             softly.assertThat(notices.get(1)).isInstanceOf(Notice.class);
             softly.assertThat(notices.get(1).getContent()).isEqualTo(new Content("2ndNotice"));
         });
+    }
+
+    @Test
+    @DisplayName("공지를 조회할 때 가장 최근에 등록된 공지가 반환된다.")
+    void findMostRecentNoticeByTeamPlaceId() {
+        // given
+        final Long teamPlaceId = 1L;
+        final Long authorId = 1L;
+        final Notice firstNotice = testFixtureBuilder.buildNotice(NOTICE_1ST(teamPlaceId, authorId));
+        final Notice secondNotice = testFixtureBuilder.buildNotice(NOTICE_2ND(teamPlaceId, authorId));
+        final Notice thirdNotice = testFixtureBuilder.buildNotice(NOTICE_3RD(teamPlaceId, authorId));
+
+        // when
+        final Optional<Notice> findNotice = noticeRepository.findMostRecentByTeamPlaceId(1L);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(findNotice).isPresent();
+            softly.assertThat(findNotice.get().getId()).isEqualTo(thirdNotice.getId());
+            softly.assertThat(findNotice.get().getContent().getValue()).isEqualTo(thirdNotice.getContent().getValue());
+        });
+    }
+
+    @Test
+    @DisplayName("공지를 조회할 때 등록된 공지가 없을 경우 null을 반환한다.")
+    void findEmptyNoticeByTeamPlaceId() {
+        // given
+        final Long nonExistTeamPlaceId = -1L;
+
+        // when
+        final Optional<Notice> nonExistNotice = noticeRepository.findMostRecentByTeamPlaceId(nonExistTeamPlaceId);
+
+        // then
+        assertThat(nonExistNotice).isEmpty();
     }
 }


### PR DESCRIPTION
## 이슈번호
> #218 

## PR 내용
- 공지 조회 기능 구현
    - (공지 기등록 시) 가장 최근에 등록된 공지 조회
    - (공지 미등록 시) 빈값 반한
- 공지 조회 기능 관련 레포지토리, 서비스, 인수 테스트 구현

## 참고자료

## 의논할 거리
