### PR TITLE
[BE] 사용자가 속한 팀플레이스들 목록 조회 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -1,0 +1,35 @@
+package team.teamby.teambyteam.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.IdOnly;
+import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
+import team.teamby.teambyteam.member.domain.vo.Email;
+import team.teamby.teambyteam.member.exception.MemberException;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberTeamPlaceRepository memberTeamPlaceRepository;
+
+    @Transactional(readOnly = true)
+    public TeamPlacesResponse getParticipatedTeamPlaces(final MemberEmailDto memberEmailDto) {
+        final IdOnly memberId = memberRepository.findIdByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+
+        List<MemberTeamPlace> allByMemberId = memberTeamPlaceRepository.findAllByMemberId(memberId.id());
+
+        return TeamPlacesResponse.of(allByMemberId);
+    }
+
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
         final IdOnly memberId = memberRepository.findIdByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(MemberException.MemberNotFoundException::new);
 
-        List<MemberTeamPlace> allByMemberId = memberTeamPlaceRepository.findAllByMemberId(memberId.id());
+        final List<MemberTeamPlace> allByMemberId = memberTeamPlaceRepository.findAllByMemberId(memberId.id());
 
         return TeamPlacesResponse.of(allByMemberId);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/dto/TeamPlaceResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/dto/TeamPlaceResponse.java
@@ -1,0 +1,17 @@
+package team.teamby.teambyteam.member.application.dto;
+
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+
+public record TeamPlaceResponse(
+        Long id,
+        String displayName,
+        Integer teamPlaceColor
+) {
+    public static TeamPlaceResponse of(MemberTeamPlace memberTeamPlace) {
+        return new TeamPlaceResponse(
+                memberTeamPlace.getId(),
+                memberTeamPlace.getDisplayTeamPlaceName().getValue(),
+                memberTeamPlace.getTeamPlaceColor().getColorNumber()
+        );
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/dto/TeamPlacesResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/dto/TeamPlacesResponse.java
@@ -1,0 +1,13 @@
+package team.teamby.teambyteam.member.application.dto;
+
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+
+import java.util.List;
+
+public record TeamPlacesResponse(List<TeamPlaceResponse> teamPlaces) {
+    public static TeamPlacesResponse of(List<MemberTeamPlace> allByMemberId) {
+        return new TeamPlacesResponse(allByMemberId.stream()
+                .map(TeamPlaceResponse::of)
+                .toList());
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -61,6 +61,15 @@ public class Member extends BaseEntity {
         this(new Name(name), new Email(email), new ProfileImageUrl(profileImageUrl));
     }
 
+    public MemberTeamPlace participate(final TeamPlace teamPlace) {
+
+        final MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+
+        memberTeamPlace.setMemberAndTeamPlace(this, teamPlace);
+
+        return memberTeamPlace;
+    }
+
     public List<TeamPlace> getTeamPlaces() {
         return getMemberTeamPlaces().stream()
                 .map(MemberTeamPlace::getTeamPlace)

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
@@ -10,4 +10,6 @@ public interface MemberTeamPlaceRepository extends JpaRepository<MemberTeamPlace
     Optional<MemberIdAndDisplayNameOnly> findByTeamPlaceIdAndMemberId(Long teamPlaceId, Long memberId);
 
     List<MemberIdAndDisplayNameOnly> findAllByTeamPlaceId(Long teamPlaceId);
+
+    List<MemberTeamPlace> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/TeamPlaceColor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/TeamPlaceColor.java
@@ -1,0 +1,22 @@
+package team.teamby.teambyteam.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamPlaceColor {
+
+    A(0),
+    B(1),
+    C(2),
+    D(3),
+    E(4),
+    F(5),
+    G(6),
+    H(7),
+    I(8),
+    J(9);
+
+    private final int colorNumber;
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -1,0 +1,27 @@
+package team.teamby.teambyteam.member.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.teamby.teambyteam.member.application.MemberService;
+import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.configuration.AuthPrincipal;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+
+@RestController
+@RequestMapping("/api/me")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/team-places")
+    public ResponseEntity<TeamPlacesResponse> getParticipatedTeamPlaces(@AuthPrincipal MemberEmailDto memberEmailDto) {
+        final TeamPlacesResponse participatedTeamPlaces = memberService.getParticipatedTeamPlaces(memberEmailDto);
+
+        return ResponseEntity.ok(participatedTeamPlaces);
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/TeamPlaceFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/TeamPlaceFixtures.java
@@ -7,6 +7,11 @@ public class TeamPlaceFixtures {
 
     public static final String ENGLISH_TEAM_PLACE_NAME = "영어 팀플";
     public static final String JAPANESE_TEAM_PLACE_NAME = "일본어 팀플";
+    public static final String FLUID_TEAM_PLACE_NAME = "유체역학 팀플";
+    public static final String STATICS_TEAM_PLACE_NAME = "정역학 팀플";
+    public static final String DYNAMICS_TEAM_PLACE_NAME = "동역학 팀플";
+    public static final String CONTROLS_TEAM_PLACE_NAME = "제어공학 팀플";
+    public static final String MATERIALS_TEAM_PLACE_NAME = "제료공학 팀플";
 
     public static TeamPlace ENGLISH_TEAM_PLACE() {
         return new TeamPlace(new Name(ENGLISH_TEAM_PLACE_NAME));
@@ -14,5 +19,25 @@ public class TeamPlaceFixtures {
 
     public static TeamPlace JAPANESE_TEAM_PLACE() {
         return new TeamPlace(new Name(JAPANESE_TEAM_PLACE_NAME));
+    }
+
+    public static TeamPlace FLUID_TEAM_PLACE() {
+        return new TeamPlace(new Name(FLUID_TEAM_PLACE_NAME));
+    }
+
+    public static TeamPlace STATICS_TEAM_PLACE() {
+        return new TeamPlace(new Name(STATICS_TEAM_PLACE_NAME));
+    }
+
+    public static TeamPlace DYNAMICS_TEAM_PLACE() {
+        return new TeamPlace(new Name(DYNAMICS_TEAM_PLACE_NAME));
+    }
+
+    public static TeamPlace CONTROLS_TEAM_PLACE() {
+        return new TeamPlace(new Name(CONTROLS_TEAM_PLACE_NAME));
+    }
+
+    public static TeamPlace MATERIALS_TEAM_PLACE() {
+        return new TeamPlace(new Name(MATERIALS_TEAM_PLACE_NAME));
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -1,0 +1,21 @@
+package team.teamby.teambyteam.common.fixtures.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+
+public class MemberAcceptanceFixture {
+
+    private static final String JWT_PREFIX = "Bearer ";
+
+    public static ExtractableResponse<Response> GET_PARTICIPATED_TEAM_PLACES(final String token) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .when().log().all()
+                .get("/api/me/team-places")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,81 @@
+package team.teamby.teambyteam.member.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import team.teamby.teambyteam.common.AcceptanceTest;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
+
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Nested
+    @DisplayName("사용자가 소속된 팀플레이스들의 정보를 조회시")
+    class GetParticipatedTeamPlaces {
+
+        @Test
+        @DisplayName("조회에 성공한다.")
+        void success() {
+            // given
+            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
+            final TeamPlace STATICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.STATICS_TEAM_PLACE());
+
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, JAPANESE_TEAM_PLACE);
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, STATICS_TEAM_PLACE);
+
+            final String ENDEL_TOKEN = jwtTokenProvider.generateToken(ENDEL.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = GET_PARTICIPATED_TEAM_PLACES(ENDEL_TOKEN);
+
+            //then
+            final TeamPlacesResponse teamPlacesResponse = response.body().as(TeamPlacesResponse.class);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(3);
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(0).id()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(0).displayName()).isEqualTo(ENGLISH_TEAM_PLACE.getName().getValue());
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(1).id()).isEqualTo(JAPANESE_TEAM_PLACE.getId());
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(1).displayName()).isEqualTo(JAPANESE_TEAM_PLACE.getName().getValue());
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(2).id()).isEqualTo(STATICS_TEAM_PLACE.getId());
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(2).displayName()).isEqualTo(STATICS_TEAM_PLACE.getName().getValue());
+            });
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 사용자로 요청시 실패한다.")
+        void failWithUnAuthorizedMember() {
+            // given
+            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
+            final TeamPlace STATICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.STATICS_TEAM_PLACE());
+
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, JAPANESE_TEAM_PLACE);
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, STATICS_TEAM_PLACE);
+
+            final Member unAuthorizedMember = MemberFixtures.PHILIP();
+            final String UNAUTHORIZED_TOKEN = jwtTokenProvider.generateToken(unAuthorizedMember.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = GET_PARTICIPATED_TEAM_PLACES(UNAUTHORIZED_TOKEN);
+
+            //then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -1,0 +1,74 @@
+package team.teamby.teambyteam.member.application;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import team.teamby.teambyteam.common.ServiceTest;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.member.application.dto.TeamPlaceResponse;
+import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberServiceTest extends ServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Nested
+    @DisplayName("사용자가 속한 팀플레이스들의 정보 조회시")
+    class FindAllParticipatedTeamPlaceInfo {
+
+        @Test
+        @DisplayName("조회에 성공한다.")
+        void success() {
+            // given
+            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
+            final TeamPlace STATICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.STATICS_TEAM_PLACE());
+
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, JAPANESE_TEAM_PLACE);
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, STATICS_TEAM_PLACE);
+
+            // when
+            final TeamPlacesResponse response = memberService.getParticipatedTeamPlaces(new MemberEmailDto(ENDEL.getEmail().getValue()));
+
+            //then
+            final List<TeamPlaceResponse> teamPlaceResponses = response.teamPlaces();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(teamPlaceResponses).hasSize(3);
+                softly.assertThat(teamPlaceResponses.get(0).id()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
+                softly.assertThat(teamPlaceResponses.get(0).displayName()).isEqualTo(ENGLISH_TEAM_PLACE.getName().getValue());
+                softly.assertThat(teamPlaceResponses.get(1).id()).isEqualTo(JAPANESE_TEAM_PLACE.getId());
+                softly.assertThat(teamPlaceResponses.get(1).displayName()).isEqualTo(JAPANESE_TEAM_PLACE.getName().getValue());
+                softly.assertThat(teamPlaceResponses.get(2).id()).isEqualTo(STATICS_TEAM_PLACE.getId());
+                softly.assertThat(teamPlaceResponses.get(2).displayName()).isEqualTo(STATICS_TEAM_PLACE.getName().getValue());
+            });
+        }
+
+
+        @Test
+        @DisplayName("소속된 팀 플레이스가 없으면 빈배열을 반환한다")
+        void getWithEmptyArray() {
+            // given
+            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+
+            // when
+            final TeamPlacesResponse response = memberService.getParticipatedTeamPlaces(new MemberEmailDto(ENDEL.getEmail().getValue()));
+
+            //then
+            assertThat(response.teamPlaces()).hasSize(0);
+        }
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTest.java
@@ -1,0 +1,83 @@
+package team.teamby.teambyteam.member.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.domain.vo.Name;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.A;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.B;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.C;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.D;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.E;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.F;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.G;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.H;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.I;
+import static team.teamby.teambyteam.member.domain.TeamPlaceColor.J;
+
+class MemberTest {
+
+    @Nested
+    @DisplayName("팀플레이스에 참여한다.")
+    class ParticipateTest {
+
+        @Test
+        @DisplayName("팀플레이스에 등록될 때 색상이 순서대로 들어간다.")
+        void setTeamPlaceColor() {
+            // given
+            final Member philip = MemberFixtures.PHILIP();
+            final TeamPlace englishTeamPlace = TeamPlaceFixtures.ENGLISH_TEAM_PLACE();
+            final TeamPlace japaneseTeamPlace = TeamPlaceFixtures.JAPANESE_TEAM_PLACE();
+            final TeamPlace fluidTeamPlace = TeamPlaceFixtures.FLUID_TEAM_PLACE();
+
+            // when
+            philip.participate(englishTeamPlace);
+            philip.participate(japaneseTeamPlace);
+            philip.participate(fluidTeamPlace);
+
+            //then
+            final List<TeamPlaceColor> actualTeamPlaceColors = philip.getMemberTeamPlaces().stream()
+                    .map(MemberTeamPlace::getTeamPlaceColor)
+                    .toList();
+            assertThat(actualTeamPlaceColors).containsExactly(A, B, C);
+        }
+
+        @Test
+        @DisplayName("정해진 색상코드 수 이상의 팀플레이스에 가입되면 중복을 허용하며 가장 적은 수로 사용된 색상을 배정한다.")
+        void setMinUsedColorIfAllColorsAreUsedFor() {
+            // given
+            final Member roy = MemberFixtures.ROY();
+
+            // when
+            for (int i = 0; i < TeamPlaceColor.values().length * 2; i++) {
+                roy.participate(new TeamPlace(new Name(String.valueOf(i))));
+            }
+
+            //then
+            final List<TeamPlaceColor> actualTeamColors = roy.getMemberTeamPlaces()
+                    .stream()
+                    .map(MemberTeamPlace::getTeamPlaceColor)
+                    .toList();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == A).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == B).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == C).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == D).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == E).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == F).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == G).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == H).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == I).count()).isEqualTo(2);
+                softly.assertThat(actualTeamColors.stream().filter(color -> color == J).count()).isEqualTo(2);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## 이슈번호
> close #287


## PR 내용

- Member가 TeamPlace에 소속되는 domain 기능 구현
- 사용자가 속한 팀플레이스들의 목록 조회 기능 구현
  - 소속된 팀플레이스가 없을 경우 빈 리스트 반환

## 참고자료

## 의논할 거리

# 중요사항

meerge전에 db서버 table 스키마 변경 ( member_team_palce table -> team_place_coler 추가 : 노션 ddl참고)
