### PR TITLE
[BE] 스레드 조회 타입 수정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -83,7 +83,7 @@ public class FeedThreadService {
                     .orElseThrow(MemberException.MemberNotFoundException::new);
             return FeedResponse.from(feed, member.getName().getValue(), member.getProfileImageUrl().getValue());
         }
-        if (FeedType.SCHEDULE_NOTIFICATION == feed.getType()) {
+        if (FeedType.NOTIFICATION == feed.getType()) {
             return FeedResponse.from(feed, "schedule", "");
         }
         throw new IllegalArgumentException("지원하지 않는 타입입니다.");

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -21,7 +21,7 @@ public record FeedResponse(
 
         return new FeedResponse(
                 feed.getId(),
-                feed.getType().name(),
+                feed.getType().name().toLowerCase(),
                 feed.getAuthorId(),
                 authorName,
                 profileImageUrl,

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/FeedType.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/FeedType.java
@@ -1,5 +1,5 @@
 package team.teamby.teambyteam.feed.domain;
 
 public enum FeedType {
-    THREAD, SCHEDULE_NOTIFICATION
+    THREAD, NOTIFICATION
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/notification/ScheduleNotification.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/notification/ScheduleNotification.java
@@ -26,7 +26,7 @@ public class ScheduleNotification extends Notification {
 
     @Override
     public FeedType getType() {
-        return FeedType.SCHEDULE_NOTIFICATION;
+        return FeedType.NOTIFICATION;
     }
 
     @Override

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/NotificationServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/NotificationServiceTest.java
@@ -32,7 +32,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("일정 등록 시 일정 등록 알림 생성")
-    class createScheduleNotificationWhenCreateSchedule {
+    class CreateScheduleNotificationWhenCreateSchedule {
 
         @Test
         @DisplayName("정상적으로 성공한다.")
@@ -56,7 +56,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("일정 수정 시 일정 수정 알림 생성")
-    class createScheduleNotificationWhenUpdateSchedule {
+    class CreateScheduleNotificationWhenUpdateSchedule {
 
         @Test
         @DisplayName("정상적으로 성공한다.")
@@ -80,7 +80,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("일정 삭제 시 일정 삭제 알림 생성")
-    class createScheduleNotificationWhenDeleteSchedule {
+    class CreateScheduleNotificationWhenDeleteSchedule {
 
         @Test
         @DisplayName("정상적으로 성공한다.")


### PR DESCRIPTION
## 이슈번호
#307

## PR 내용
조회 타입을 SCHEDULE_NOTIFICATION->NOTIFICATION으로 변경하고 반환 타입을 전부 소문자로 하도록 변경

## 참고자료

## 의논할 거리
