### PR TITLE
[FE] 스케줄 서클 유틸함수 중복반환 해결

### DIFF
--- a/frontend/src/utils/generateScheduleCirclesMatrix.test.ts
+++ b/frontend/src/utils/generateScheduleCirclesMatrix.test.ts
@@ -253,3 +253,66 @@ describe('Test #2 - 범위를 벗어나는 일정 테스트', () => {
     );
   });
 });
+
+describe('Test #3 - 중복 방지 테스트', () => {
+  test('팀플레이스 아이디 목록을 반환할 때, 같은 아이디는 한 번만 반환해야 한다.', () => {
+    const schedules: ScheduleWithTeamPlaceId[] = [
+      {
+        id: 1223,
+        teamPlaceId: 2,
+        title: '내 일정',
+        startDateTime: '2023-08-01 00:00',
+        endDateTime: '2023-08-01 02:00',
+      },
+      {
+        id: 4535,
+        teamPlaceId: 7,
+        title: '내 일정',
+        startDateTime: '2023-08-01 01:00',
+        endDateTime: '2023-08-01 03:59',
+      },
+      {
+        id: 1342,
+        teamPlaceId: 1,
+        title: '내 일정',
+        startDateTime: '2023-08-01 02:00',
+        endDateTime: '2023-08-01 03:59',
+      },
+      {
+        id: 3465,
+        teamPlaceId: 2,
+        title: '내 일정',
+        startDateTime: '2023-08-01 06:00',
+        endDateTime: '2023-08-01 08:59',
+      },
+      {
+        id: 88542,
+        teamPlaceId: 2,
+        title: '내 일정',
+        startDateTime: '2023-08-01 11:35',
+        endDateTime: '2023-08-01 14:23',
+      },
+      {
+        id: 997,
+        teamPlaceId: 7,
+        title: '내 일정',
+        startDateTime: '2023-08-01 02:00',
+        endDateTime: '2023-08-01 03:59',
+      },
+    ];
+
+    const expectedResult = [
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [1, 2, 7] },
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [] },
+      { teamPlaceIds: [] },
+    ];
+
+    expect(generateScheduleCirclesMatrix(2023, 7, schedules)[0]).toEqual(
+      expectedResult,
+    );
+  });
+});

--- a/frontend/src/utils/generateScheduleCirclesMatrix.ts
+++ b/frontend/src/utils/generateScheduleCirclesMatrix.ts
@@ -44,14 +44,30 @@ export const generateScheduleCirclesMatrix = (
     });
   });
 
-  const sortedScheduleCirclesMatrix = getSortedScheduleCirclesMatrix(
+  const duplicateRemovedCirclesMatrix = removeDuplicatesInMatrix(
     scheduleCirclesMatrix,
+  );
+  const sortedScheduleCirclesMatrix = getSortedScheduleCirclesMatrix(
+    duplicateRemovedCirclesMatrix,
   );
   const slicedScheduleCirclesMatrix = getSlicedScheduleCirclesMatrix(
     sortedScheduleCirclesMatrix,
   );
 
   return slicedScheduleCirclesMatrix;
+};
+
+const removeDuplicatesInMatrix = (
+  scheduleCirclesMatrix: ScheduleCircle[][],
+) => {
+  const duplicateRemovedCirclesMatrix = scheduleCirclesMatrix.map(
+    (scheduleCircles) =>
+      scheduleCircles.map(({ teamPlaceIds }) => ({
+        teamPlaceIds: [...new Set(teamPlaceIds)],
+      })),
+  );
+
+  return duplicateRemovedCirclesMatrix;
 };
 
 const getSortedScheduleCirclesMatrix = (


### PR DESCRIPTION
# [FE] 스케줄 서클 유틸함수 중복반환 해결
## 이슈번호
> close #310 

## PR 내용
본 PR에서는 스케줄 서클을 어떻게 랜더링해야 하는지를 반환하는 유틸 함수에서 캘린더의 각 셀에 여러 개의 팀플레이스 아이디가 잘못 반환되는 현상을 해결하였다.

셀에 랜더링되어야 하는 스케줄 서클의 팀플레이스 아이디들이 `[1, 2, 7, 2, 11, 2, 7]` 인 경우, 실제로는 `[1, 2, 7]` 의 형태로 반환되어 랜더링되어야 하는 것이다 (중복을 제거하고, 오름차순 정렬을 진행한 후, 팀플레이스 아이디를 최대 앞에서부터 세 개까지만 반환)
