### PR TITLE
[FE] 팀플레이스 색상과 조회 로직 연결

### DIFF
--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -19,6 +19,8 @@ import ScheduleMoreCell from '~/components/ScheduleMoreCell/ScheduleMoreCell';
 import type { Position, ModalOpenType } from '~/types/schedule';
 import DailyScheduleModal from '~/components/DailyScheduleModal/DailyScheduleModal';
 import { getDateByPosition } from '~/utils/getDateByPosition';
+import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
 
 const Calendar = () => {
   const {
@@ -46,6 +48,9 @@ const Calendar = () => {
     column: 0,
   });
   const scheduleBars = generateScheduleBars(year, month, schedules);
+
+  const { teamPlaces } = useTeamPlace();
+  const { teamPlaceColor } = getInfoByTeamPlaceId(teamPlaces, 1);
 
   const handleModalOpen = (modalOpenType: ModalOpenType) => {
     setModalType(() => modalOpenType);
@@ -157,6 +162,7 @@ const Calendar = () => {
                                 level,
                               });
                             }}
+                            teamPlaceColor={teamPlaceColor}
                             {...scheduleBar}
                           />
                         );
@@ -193,7 +199,7 @@ const Calendar = () => {
         </div>
       </S.Container>
       {isModalOpen && modalType === MODAL_OPEN_TYPE.ADD && (
-        <ScheduleAddModal teamPlaceName="팀바팀" clickedDate={clickedDate} />
+        <ScheduleAddModal clickedDate={clickedDate} />
       )}
       {isModalOpen && modalType === MODAL_OPEN_TYPE.VIEW && (
         <ScheduleModal
@@ -204,7 +210,6 @@ const Calendar = () => {
       )}
       {isModalOpen && modalType === MODAL_OPEN_TYPE.EDIT && (
         <ScheduleEditModal
-          teamPlaceName="팀바팀"
           scheduleId={modalScheduleId}
           initialSchedule={schedules.find(
             (schedule) => schedule.id === modalScheduleId,

--- a/frontend/src/components/MyCalendar/MyCalendar.stories.tsx
+++ b/frontend/src/components/MyCalendar/MyCalendar.stories.tsx
@@ -12,58 +12,5 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    teamPlaces: [
-      {
-        id: 1,
-        displayName: '인공지능 신비주의자들',
-        teamPlaceColor: 0,
-      },
-      {
-        id: 2,
-        displayName: '[3조] 환경 구원 대작전',
-        teamPlaceColor: 1,
-      },
-      {
-        id: 3,
-        displayName: '윤리와 인간관계 2조',
-        teamPlaceColor: 2,
-      },
-      {
-        id: 4,
-        displayName: '문화 다양성과 소통 1조 팀플레이스입니다.',
-        teamPlaceColor: 3,
-      },
-      {
-        id: 5,
-        displayName: '그냥 저희 빨리 하고 끝내죠',
-        teamPlaceColor: 4,
-      },
-      {
-        id: 6,
-        displayName: '!! 게임 동아리',
-        teamPlaceColor: 5,
-      },
-      {
-        id: 7,
-        displayName: '북클럽 스터디 7기',
-        teamPlaceColor: 6,
-      },
-      {
-        id: 8,
-        displayName: '우아한테크코스 팀바팀',
-        teamPlaceColor: 7,
-      },
-      {
-        id: 9,
-        displayName: 'English II',
-        teamPlaceColor: 8,
-      },
-      {
-        id: 10,
-        displayName: '현대사회와 범죄 5조',
-        teamPlaceColor: 9,
-      },
-    ],
-  },
+  args: {},
 };

--- a/frontend/src/components/MyCalendar/MyCalendar.tsx
+++ b/frontend/src/components/MyCalendar/MyCalendar.tsx
@@ -12,14 +12,14 @@ import { generateScheduleCirclesMatrix } from '~/utils/generateScheduleCirclesMa
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 import type { TeamPlace } from '~/types/team';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
 
 interface MyCalendarProps {
-  teamPlaces: TeamPlace[];
   onDailyClick: (date: Date) => void;
 }
 
 const MyCalendar = (props: MyCalendarProps) => {
-  const { teamPlaces, onDailyClick } = props;
+  const { onDailyClick } = props;
   const {
     year,
     month,
@@ -34,6 +34,7 @@ const MyCalendar = (props: MyCalendarProps) => {
 
   const schedules = useFetchMySchedules(year, month);
   const scheduleCircles = generateScheduleCirclesMatrix(year, month, schedules);
+  const { teamPlaces } = useTeamPlace();
 
   return (
     <S.Container>
@@ -99,14 +100,10 @@ const MyCalendar = (props: MyCalendarProps) => {
                         <S.ScheduleCircleWrapper>
                           {scheduleCircles[rowIndex][colIndex].teamPlaceIds.map(
                             (teamPlaceId) => {
-                              const teamInfo = getInfoByTeamPlaceId(
+                              const { teamPlaceColor } = getInfoByTeamPlaceId(
                                 teamPlaces,
                                 teamPlaceId,
                               );
-                              if (teamInfo === undefined) return;
-
-                              const { teamPlaceColor } = teamInfo;
-
                               return (
                                 <TeamBadge
                                   key={`${day.toISOString()}+${teamPlaceId}`}

--- a/frontend/src/components/MyDailyScheduleList/MyDailyScheduleList.stories.ts
+++ b/frontend/src/components/MyDailyScheduleList/MyDailyScheduleList.stories.ts
@@ -13,58 +13,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    teamPlaces: [
-      {
-        id: 1,
-        displayName: '인공지능 신비주의자들',
-        teamPlaceColor: 0,
-      },
-      {
-        id: 2,
-        displayName: '[3조] 환경 구원 대작전',
-        teamPlaceColor: 1,
-      },
-      {
-        id: 3,
-        displayName: '윤리와 인간관계 2조',
-        teamPlaceColor: 2,
-      },
-      {
-        id: 4,
-        displayName: '문화 다양성과 소통 1조 팀플레이스입니다.',
-        teamPlaceColor: 3,
-      },
-      {
-        id: 5,
-        displayName: '그냥 저희 빨리 하고 끝내죠',
-        teamPlaceColor: 4,
-      },
-      {
-        id: 6,
-        displayName: '!! 게임 동아리',
-        teamPlaceColor: 5,
-      },
-      {
-        id: 7,
-        displayName: '북클럽 스터디 7기',
-        teamPlaceColor: 6,
-      },
-      {
-        id: 8,
-        displayName: '우아한테크코스 팀바팀',
-        teamPlaceColor: 7,
-      },
-      {
-        id: 9,
-        displayName: 'English II',
-        teamPlaceColor: 8,
-      },
-      {
-        id: 10,
-        displayName: '현대사회와 범죄 5조',
-        teamPlaceColor: 9,
-      },
-    ],
     rawDate: new Date(),
   },
 };

--- a/frontend/src/components/MyDailyScheduleList/MyDailyScheduleList.tsx
+++ b/frontend/src/components/MyDailyScheduleList/MyDailyScheduleList.tsx
@@ -4,16 +4,17 @@ import * as S from './MyDailyScheduleList.styled';
 import MyDailySchedule from '~/components/MyDailyScheduleList/MyDailySchedule/MyDailySchedule';
 import type { TeamPlace } from '~/types/team';
 import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
 
 interface MyDailyScheduleListProps {
-  teamPlaces: TeamPlace[];
   rawDate: Date;
 }
 
 const MyDailyScheduleList = (props: MyDailyScheduleListProps) => {
-  const { teamPlaces, rawDate } = props;
+  const { rawDate } = props;
   const { year, month, date } = parseDate(rawDate);
   const schedules = useFetchMyDailySchedules(year, month, date);
+  const { teamPlaces } = useTeamPlace();
 
   return (
     <S.ScheduleWrapper>
@@ -21,11 +22,11 @@ const MyDailyScheduleList = (props: MyDailyScheduleListProps) => {
         schedules.map((schedule) => {
           const { id, teamPlaceId, ...rest } = schedule;
 
-          const teamInfo = getInfoByTeamPlaceId(teamPlaces, teamPlaceId);
+          const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(
+            teamPlaces,
+            teamPlaceId,
+          );
 
-          if (teamInfo === undefined) return;
-
-          const { teamPlaceColor, displayName } = teamInfo;
           return (
             <MyDailySchedule
               key={id}

--- a/frontend/src/components/Notification/Notification.stories.ts
+++ b/frontend/src/components/Notification/Notification.stories.ts
@@ -14,12 +14,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    teamPlaceColor: 0,
     content: "'범죄심리학 발표자료..' 일정이 수정되었습니다.",
   },
 };
 
 export const Small: Story = {
   args: {
+    teamPlaceColor: 0,
     content: "'범죄심리학 발표자료..' 일정이 수정되었습니다.",
     size: 'sm',
   },

--- a/frontend/src/components/Notification/Notification.styled.ts
+++ b/frontend/src/components/Notification/Notification.styled.ts
@@ -1,7 +1,9 @@
 import { css, styled } from 'styled-components';
 import type { NotificationProps } from '~/components/Notification/Notification';
 
-export const Wrapper = styled.div<Pick<NotificationProps, 'color' | 'size'>>`
+export const Wrapper = styled.div<
+  Pick<NotificationProps, 'teamPlaceColor' | 'size'>
+>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -12,7 +14,8 @@ export const Wrapper = styled.div<Pick<NotificationProps, 'color' | 'size'>>`
 
   color: ${({ theme }) => theme.color.WHITE};
 
-  background-color: ${({ color }) => color};
+  background-color: ${({ theme, teamPlaceColor = 0 }) =>
+    theme.teamColor[teamPlaceColor]};
   border-radius: 20px;
 
   filter: brightness(1.2);

--- a/frontend/src/components/Notification/Notification.tsx
+++ b/frontend/src/components/Notification/Notification.tsx
@@ -1,19 +1,20 @@
 import Text from '~/components/common/Text/Text';
 import * as S from './Notification.styled';
 import type { NotificationSize, TextSize } from '~/types/size';
+import type { TeamPlaceColor } from '~/types/team';
 
 export interface NotificationProps {
-  color?: string;
+  teamPlaceColor: TeamPlaceColor;
   size?: NotificationSize;
   content: string;
 }
 
 const Notification = (props: NotificationProps) => {
-  const { color = '#516FFF', content, size = 'md' } = props;
+  const { teamPlaceColor, content, size = 'md' } = props;
   const textSize: Extract<TextSize, 'md' | 'xl'> = size === 'md' ? 'xl' : 'md';
 
   return (
-    <S.Wrapper color={color} size={size}>
+    <S.Wrapper teamPlaceColor={teamPlaceColor} size={size}>
       <Text size={textSize} css={S.notification}>
         {content}
       </Text>

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.stories.tsx
@@ -21,10 +21,7 @@ const SampleModal = () => {
   return (
     <>
       <Button onClick={openModal}>모달 열기</Button>
-      <ScheduleAddModal
-        teamPlaceName="Woowacourse TeamByTeam Corporation"
-        clickedDate={new Date()}
-      />
+      <ScheduleAddModal clickedDate={new Date()} />
     </>
   );
 };
@@ -32,7 +29,6 @@ const SampleModal = () => {
 export const Default: Story = {
   render: () => <SampleModal />,
   args: {
-    teamPlaceName: '',
     clickedDate: new Date(),
   },
 };

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -9,20 +9,21 @@ import useScheduleAddModal from '~/hooks/schedule/useScheduleAddModal';
 import Checkbox from '~/components/common/Checkbox/Checkbox';
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 import TimeTableMenu from '~/components/TimeTableMenu/TimeTableMenu';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 
 interface ScheduleAddModalProps {
-  teamPlaceName: string;
   clickedDate: Date;
 }
 
 const ScheduleAddModal = (props: ScheduleAddModalProps) => {
-  const { teamPlaceName, clickedDate } = props;
+  const { clickedDate } = props;
   const { closeModal } = useModal();
+  const { teamPlaces } = useTeamPlace();
   const {
     schedule,
     isAllDay,
     times,
-
     handlers: {
       handleScheduleChange,
       handleIsAllDayChange,
@@ -31,6 +32,8 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
       handleScheduleSubmit,
     },
   } = useScheduleAddModal(clickedDate);
+
+  const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(teamPlaces, 1);
 
   return (
     <Modal>
@@ -115,9 +118,9 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             <Checkbox isChecked={isAllDay} onChange={handleIsAllDayChange} />
           </S.CheckboxContainer>
           <S.InnerContainer>
-            <S.TeamNameContainer title={teamPlaceName}>
-              <TeamBadge teamPlaceColor={0} size="lg" />
-              <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
+            <S.TeamNameContainer title={displayName}>
+              <TeamBadge teamPlaceColor={teamPlaceColor} size="lg" />
+              <Text css={S.teamPlaceName}>{displayName}</Text>
             </S.TeamNameContainer>
             <S.ControlButtonWrapper>
               <Button variant="primary" css={S.submitButton}>

--- a/frontend/src/components/ScheduleBar/ScheduleBar.stories.tsx
+++ b/frontend/src/components/ScheduleBar/ScheduleBar.stories.tsx
@@ -31,6 +31,7 @@ export const Default: Story = {
     level: 0,
     roundedStart: true,
     roundedEnd: true,
+    teamPlaceColor: 0,
     onClick: () => alert('clicked!'),
   },
 };
@@ -52,6 +53,7 @@ export const RoundedStart: Story = {
     level: 0,
     roundedStart: true,
     roundedEnd: false,
+    teamPlaceColor: 0,
     onClick: () => alert('clicked!'),
   },
 };
@@ -73,6 +75,7 @@ export const RoundedEnd: Story = {
     level: 0,
     roundedStart: false,
     roundedEnd: true,
+    teamPlaceColor: 0,
     onClick: () => alert('clicked!'),
   },
 };
@@ -94,6 +97,7 @@ export const NotRounded: Story = {
     level: 0,
     roundedStart: false,
     roundedEnd: false,
+    teamPlaceColor: 0,
     onClick: () => alert('clicked!'),
   },
 };
@@ -116,6 +120,7 @@ export const LongTitle: Story = {
     level: 0,
     roundedStart: true,
     roundedEnd: true,
+    teamPlaceColor: 0,
     onClick: () => alert('clicked!'),
   },
 };

--- a/frontend/src/components/ScheduleBar/ScheduleBar.styled.ts
+++ b/frontend/src/components/ScheduleBar/ScheduleBar.styled.ts
@@ -19,7 +19,10 @@ export const Wrapper = styled.div<
 `;
 
 export const Inner = styled.div<
-  Pick<ScheduleBarProps, 'color' | 'level' | 'roundedStart' | 'roundedEnd'>
+  Pick<
+    ScheduleBarProps,
+    'teamPlaceColor' | 'level' | 'roundedStart' | 'roundedEnd'
+  >
 >`
   display: flex;
   align-items: center;
@@ -28,7 +31,8 @@ export const Inner = styled.div<
   height: 100%;
   padding-left: 6px;
 
-  background-color: ${({ color }) => color};
+  background-color: ${({ theme, teamPlaceColor = 0 }) =>
+    theme.teamColor[teamPlaceColor]};
   border-radius: ${({ roundedStart, roundedEnd }) =>
     `${roundedStart ? '4px' : '0'} ${roundedEnd ? '4px 4px' : '0 0'} ${
       roundedStart ? '4px' : '0'

--- a/frontend/src/components/ScheduleBar/ScheduleBar.tsx
+++ b/frontend/src/components/ScheduleBar/ScheduleBar.tsx
@@ -1,35 +1,29 @@
 import Text from '~/components/common/Text/Text';
 import * as S from './ScheduleBar.styled';
-import type { Schedule } from '~/types/schedule';
+import type { GeneratedScheduleBar } from '~/types/schedule';
 import { DoubleArrowRightIcon } from '~/assets/svg';
+import type { TeamPlaceColor } from '~/types/team';
 
-export interface ScheduleBarProps {
-  id: string;
-  scheduleId: number;
-  schedule: Schedule;
-  title: string;
-  row: number;
-  column: number;
-  duration: number;
-  level: number;
-  color?: string;
-  roundedStart: boolean;
-  roundedEnd: boolean;
+export interface ScheduleBarProps extends GeneratedScheduleBar {
+  teamPlaceColor: TeamPlaceColor;
   onClick?: () => void;
 }
 
 const ScheduleBar = (props: ScheduleBarProps) => {
-  const { color = '#516FFF', title, onClick, roundedEnd, ...rest } = props;
+  const { teamPlaceColor, title, onClick, roundedEnd, ...rest } = props;
 
   return (
     <S.Wrapper
-      color={color}
       title={title}
       onClick={onClick}
       roundedEnd={roundedEnd}
       {...rest}
     >
-      <S.Inner color={color} roundedEnd={roundedEnd} {...rest}>
+      <S.Inner
+        teamPlaceColor={teamPlaceColor}
+        roundedEnd={roundedEnd}
+        {...rest}
+      >
         <Text as="span" css={S.scheduleBarTitle}>
           {title}
         </Text>

--- a/frontend/src/components/ScheduleEditModal/ScheduleEditModal.stories.tsx
+++ b/frontend/src/components/ScheduleEditModal/ScheduleEditModal.stories.tsx
@@ -21,7 +21,6 @@ const SampleModal = () => {
     <>
       <Button onClick={openModal}>모달 열기</Button>
       <ScheduleEditModal
-        teamPlaceName="Woowacourse TeamByTeam Corporation"
         scheduleId={1}
         initialSchedule={{
           id: 1,
@@ -37,7 +36,6 @@ const SampleModal = () => {
 export const Default: Story = {
   render: () => <SampleModal />,
   args: {
-    teamPlaceName: '',
     scheduleId: 1,
     initialSchedule: {
       id: 1,

--- a/frontend/src/components/ScheduleEditModal/ScheduleEditModal.tsx
+++ b/frontend/src/components/ScheduleEditModal/ScheduleEditModal.tsx
@@ -10,21 +10,23 @@ import type { Schedule } from '~/types/schedule';
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 import TimeTableMenu from '~/components/TimeTableMenu/TimeTableMenu';
 import Checkbox from '~/components/common/Checkbox/Checkbox';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 
 interface ScheduleEditModalProps {
-  teamPlaceName: string;
   scheduleId: Schedule['id'];
   initialSchedule?: Schedule;
 }
 
 const ScheduleEditModal = (props: ScheduleEditModalProps) => {
-  const { teamPlaceName, scheduleId, initialSchedule } = props;
+  const { scheduleId, initialSchedule } = props;
   const { closeModal } = useModal();
+  const { teamPlaces } = useTeamPlace();
+  const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(teamPlaces, 1);
   const {
     schedule,
     times,
     isAllDay,
-
     handlers: {
       handleScheduleChange,
       handleScheduleSubmit,
@@ -121,9 +123,9 @@ const ScheduleEditModal = (props: ScheduleEditModalProps) => {
             <Checkbox isChecked={isAllDay} onChange={handleIsAllDayChange} />
           </S.CheckboxContainer>
           <S.InnerContainer>
-            <S.TeamNameContainer title={teamPlaceName}>
-              <TeamBadge teamPlaceColor={0} size="lg" />
-              <Text css={S.teamPlaceName}>{teamPlaceName}</Text>
+            <S.TeamNameContainer title={displayName}>
+              <TeamBadge teamPlaceColor={teamPlaceColor} size="lg" />
+              <Text css={S.teamPlaceName}>{displayName}</Text>
             </S.TeamNameContainer>
             <S.ControlButtonWrapper>
               <Button variant="primary" css={S.submitButton}>

--- a/frontend/src/components/ScheduleModal/ScheduleModal.tsx
+++ b/frontend/src/components/ScheduleModal/ScheduleModal.tsx
@@ -11,6 +11,8 @@ import { useFetchScheduleById } from '~/hooks/queries/useFetchScheduleById';
 import { useDeleteSchedule } from '~/hooks/queries/useDeleteSchedule';
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 import { useToast } from '~/hooks/useToast';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 
 interface ScheduleModalProps {
   scheduleId: number;
@@ -24,10 +26,12 @@ const ScheduleModal = (props: ScheduleModalProps) => {
   const { showToast } = useToast();
   const { scheduleById } = useFetchScheduleById(1, scheduleId);
   const { mutateDeleteSchedule } = useDeleteSchedule(1, scheduleId);
+  const { teamPlaces } = useTeamPlace();
+  const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(teamPlaces, 1);
 
   if (scheduleById === undefined) return;
-
   const { title, startDateTime, endDateTime } = scheduleById;
+
   const { row, column, level } = position;
   const modalLocation: CSSProperties = {
     position: 'absolute',
@@ -54,9 +58,9 @@ const ScheduleModal = (props: ScheduleModalProps) => {
       <S.Container style={modalLocation}>
         <S.Header>
           <S.TeamWrapper>
-            <TeamBadge teamPlaceColor={0} size="lg" />
-            <div title={'현대사회와 범죄 5조'}>
-              <Text css={S.teamName}>현대사회와 범죄 5조</Text>
+            <TeamBadge teamPlaceColor={teamPlaceColor} size="lg" />
+            <div title={displayName}>
+              <Text css={S.teamName}>{displayName}</Text>
             </div>
           </S.TeamWrapper>
           <S.MenuContainer>

--- a/frontend/src/components/ScheduleMoreCell/ScheduleMoreCell.styled.ts
+++ b/frontend/src/components/ScheduleMoreCell/ScheduleMoreCell.styled.ts
@@ -16,6 +16,12 @@ export const Wrapper = styled.div<Pick<Position, 'column'>>`
   &:hover {
     background-color: ${({ theme }) => theme.color.GRAY200};
   }
+
+  @media screen and (max-width: 800px) {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 `;
 
 export const moreText = css`

--- a/frontend/src/components/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/ThreadList/ThreadList.tsx
@@ -9,6 +9,8 @@ import { useRef } from 'react';
 import { useIntersectionObserver } from '~/hooks/useIntersectionObserver';
 import Text from '~/components/common/Text/Text';
 import { useFetchNoticeThread } from '~/hooks/queries/useFetchNoticeThread';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 
 interface ThreadListProps {
   size?: ThreadSize;
@@ -19,6 +21,8 @@ const ThreadList = (props: ThreadListProps) => {
   const { threadPages, hasNextPage, fetchNextPage } = useFetchThreads(1);
   const { noticeThread } = useFetchNoticeThread(1);
   const observeRef = useRef<HTMLDivElement>(null);
+  const { teamPlaces } = useTeamPlace();
+  const { teamPlaceColor } = getInfoByTeamPlaceId(teamPlaces, 1);
 
   const onIntersect: IntersectionObserverCallback = ([entry]) =>
     entry.isIntersecting && fetchNextPage();
@@ -48,7 +52,12 @@ const ThreadList = (props: ThreadListProps) => {
               {...rest}
             />
           ) : (
-            <Notification key={id} size={size} content={content} />
+            <Notification
+              teamPlaceColor={teamPlaceColor}
+              key={id}
+              size={size}
+              content={content}
+            />
           );
         }),
       )}

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -2,15 +2,21 @@ import { LogoIcon } from '~/assets/svg';
 import * as S from './Header.styled';
 import Text from '~/components/common/Text/Text';
 import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 
 const Header = () => {
+  const { teamPlaces } = useTeamPlace();
+
+  const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(teamPlaces, 1);
+
   return (
     <S.Container>
       <LogoIcon />
       <div>
-        <TeamBadge teamPlaceColor={0} />
+        <TeamBadge teamPlaceColor={teamPlaceColor} />
         <Text as="h1" css={S.teamPlaceName}>
-          현대사회와 범죄 5조
+          {displayName}
         </Text>
       </div>
     </S.Container>

--- a/frontend/src/components/common/SideBar/SideBar.tsx
+++ b/frontend/src/components/common/SideBar/SideBar.tsx
@@ -4,12 +4,10 @@ import MyCalendar from '~/components/MyCalendar/MyCalendar';
 import MyDailyScheduleList from '~/components/MyDailyScheduleList/MyDailyScheduleList';
 import { useState } from 'react';
 import { parseDate } from '~/utils/parseDate';
-import { useFetchTeamPlaces } from '~/hooks/queries/useFetchTeamPlaces';
 
 const SideBar = () => {
   const [dailyScheduleDate, setDailyScheduleDate] = useState(new Date());
   const { month, date } = parseDate(dailyScheduleDate);
-  const teamPlaces = useFetchTeamPlaces();
 
   const handleChangeDailySchedule = (date: Date) => {
     setDailyScheduleDate(() => date);
@@ -23,10 +21,7 @@ const SideBar = () => {
             내 일정
           </Text>
         </div>
-        <MyCalendar
-          teamPlaces={teamPlaces}
-          onDailyClick={handleChangeDailySchedule}
-        />
+        <MyCalendar onDailyClick={handleChangeDailySchedule} />
       </S.InnerContainer>
       <S.InnerContainer>
         <div>
@@ -35,10 +30,7 @@ const SideBar = () => {
             {String(date).padStart(2, '0')}일 일정
           </Text>
         </div>
-        <MyDailyScheduleList
-          teamPlaces={teamPlaces}
-          rawDate={dailyScheduleDate}
-        />
+        <MyDailyScheduleList rawDate={dailyScheduleDate} />
       </S.InnerContainer>
     </S.Container>
   );

--- a/frontend/src/components/pages/TeamCalendarPage/TeamCalendarPage.styled.ts
+++ b/frontend/src/components/pages/TeamCalendarPage/TeamCalendarPage.styled.ts
@@ -10,6 +10,18 @@ export const Container = styled.div`
   gap: 10px;
 
   background-color: ${({ theme }) => theme.color.GRAY100};
+
+  @media screen and (max-width: 1320px) {
+    padding: 10px 50px 30px;
+  }
+
+  @media screen and (max-width: 1000px) {
+    padding: 10px 10px 30px;
+  }
+
+  @media screen and (max-width: 660px) {
+    padding: 10px 10px 30px;
+  }
 `;
 
 export const highLight = css`

--- a/frontend/src/components/pages/TeamCalendarPage/TeamCalendarPage.tsx
+++ b/frontend/src/components/pages/TeamCalendarPage/TeamCalendarPage.tsx
@@ -1,6 +1,5 @@
 import Calendar from '~/components/Calendar/Calendar';
 import * as S from './TeamCalendarPage.styled';
-import Text from '~/components/common/Text/Text';
 
 const TeamCalendarPage = () => {
   return (

--- a/frontend/src/contexts/TeamPlaceContext.tsx
+++ b/frontend/src/contexts/TeamPlaceContext.tsx
@@ -1,0 +1,25 @@
+import { createContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { useFetchTeamPlaces } from '~/hooks/queries/useFetchTeamPlaces';
+import type { TeamPlace } from '~/types/team';
+
+interface TeamPlaceContextProps {
+  teamPlaces: TeamPlace[];
+}
+
+export const TeamPlaceContext = createContext<TeamPlaceContextProps>(
+  {} as TeamPlaceContextProps,
+);
+
+export const TeamPlaceProvider = (props: PropsWithChildren) => {
+  const { children } = props;
+  const teamPlaces = useFetchTeamPlaces();
+
+  const value = { teamPlaces } as const;
+
+  return (
+    <TeamPlaceContext.Provider value={value}>
+      {children}
+    </TeamPlaceContext.Provider>
+  );
+};

--- a/frontend/src/hooks/useTeamPlace.ts
+++ b/frontend/src/hooks/useTeamPlace.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { TeamPlaceContext } from '~/contexts/TeamPlaceContext';
+
+export const useTeamPlace = () => {
+  const context = useContext(TeamPlaceContext);
+
+  if (context === undefined) {
+    throw new Error('useTeamPlace must be used within a TeamPlaceContext');
+  }
+
+  return context;
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,6 +12,7 @@ import TeamCalendarPage from '~/components/pages/TeamCalendarPage/TeamCalendarPa
 import { ToastProvider } from '~/components/common/Toast/ToastContext';
 import ToastList from '~/components/common/Toast/ToastList';
 import FeedPage from '~/components/pages/FeedPage/FeedPage';
+import { TeamPlaceProvider } from '~/contexts/TeamPlaceContext';
 
 if (process.env.NODE_ENV === 'development') {
   worker.start();
@@ -42,13 +43,15 @@ root.render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <ToastProvider>
-          <ModalProvider>
-            <GlobalStyle />
-            <RouterProvider router={router} />
-            <ToastList />
-          </ModalProvider>
-        </ToastProvider>
+        <TeamPlaceProvider>
+          <ToastProvider>
+            <ModalProvider>
+              <GlobalStyle />
+              <RouterProvider router={router} />
+              <ToastList />
+            </ModalProvider>
+          </ToastProvider>
+        </TeamPlaceProvider>
       </ThemeProvider>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/types/schedule.ts
+++ b/frontend/src/types/schedule.ts
@@ -34,3 +34,16 @@ export type ModalOpenType =
 export interface ScheduleWithTeamPlaceId extends Schedule {
   teamPlaceId: number;
 }
+
+export interface GeneratedScheduleBar {
+  id: string;
+  scheduleId: number;
+  schedule: Schedule;
+  title: string;
+  row: number;
+  column: number;
+  duration: number;
+  level: number;
+  roundedStart: boolean;
+  roundedEnd: boolean;
+}

--- a/frontend/src/utils/generateScheduleBars.test.ts
+++ b/frontend/src/utils/generateScheduleBars.test.ts
@@ -1,8 +1,7 @@
 import { generateScheduleBars } from './generateScheduleBars';
-import type { Schedule } from '~/types/schedule';
-import type { ScheduleBarProps } from '~/components/ScheduleBar/ScheduleBar';
+import type { GeneratedScheduleBar, Schedule } from '~/types/schedule';
 
-const removeIdFromScheduleBars = (scheduleBars: ScheduleBarProps[]) => {
+const removeIdFromScheduleBars = (scheduleBars: GeneratedScheduleBar[]) => {
   /* eslint-disable-next-line */
   const scheduleBarsWithoutId = scheduleBars.map(({ id, ...rest }) => {
     return rest;

--- a/frontend/src/utils/generateScheduleBars.ts
+++ b/frontend/src/utils/generateScheduleBars.ts
@@ -1,6 +1,9 @@
-import type { ScheduleBarProps } from '~/components/ScheduleBar/ScheduleBar';
 import { CALENDAR, ONE_DAY } from '~/constants/calendar';
-import type { Position, Schedule } from '~/types/schedule';
+import type {
+  GeneratedScheduleBar,
+  Position,
+  Schedule,
+} from '~/types/schedule';
 import { parseDate } from '~/utils/parseDate';
 import { generateUuid } from '~/utils/generateUuid';
 
@@ -90,7 +93,7 @@ const generateRawScheduleBars = (
   schedules: Schedule[],
   calendarObject: CalendarObject,
 ) => {
-  const rawScheduleBars: ScheduleBarProps[] = [];
+  const rawScheduleBars: GeneratedScheduleBar[] = [];
 
   schedules.forEach((schedule) => {
     const { startDateTime, endDateTime, id: scheduleId, title } = schedule;
@@ -141,7 +144,7 @@ const calcDuration = (start: Date, end: Date) => {
   return Math.abs(diff / ONE_DAY) + 1;
 };
 
-const sortScheduleBars = (scheduleBars: ScheduleBarProps[]) => {
+const sortScheduleBars = (scheduleBars: GeneratedScheduleBar[]) => {
   return [...scheduleBars].sort((a, b) => {
     if (a.row !== b.row) {
       return a.row - b.row;
@@ -158,9 +161,9 @@ const sortScheduleBars = (scheduleBars: ScheduleBarProps[]) => {
 const sliceScheduleBars = (
   year: number,
   month: number,
-  rawScheduleBars: ScheduleBarProps[],
+  rawScheduleBars: GeneratedScheduleBar[],
 ) => {
-  const slicedScheduleBars: ScheduleBarProps[] = [];
+  const slicedScheduleBars: GeneratedScheduleBar[] = [];
   const { firstDateOfCalendar, lastDateOfCalendar } =
     getFirstLastDateOfCalendar(year, month);
 
@@ -203,8 +206,8 @@ const sliceScheduleBars = (
   return slicedScheduleBars;
 };
 
-const giveLevelToScheduleBars = (scheduleBars: ScheduleBarProps[]) => {
-  const leveledScheduleBars: ScheduleBarProps[] = [];
+const giveLevelToScheduleBars = (scheduleBars: GeneratedScheduleBar[]) => {
+  const leveledScheduleBars: GeneratedScheduleBar[] = [];
   const lastIndexes: number[] = [];
   const sortedScheduleBars = sortScheduleBars(scheduleBars);
 

--- a/frontend/src/utils/getInfoByTeamPlaceId.ts
+++ b/frontend/src/utils/getInfoByTeamPlaceId.ts
@@ -1,4 +1,4 @@
-import type { TeamPlace } from '~/types/team';
+import type { TeamPlace, TeamPlaceColor } from '~/types/team';
 
 export const getInfoByTeamPlaceId = (
   teamPlaces: TeamPlace[],
@@ -8,7 +8,11 @@ export const getInfoByTeamPlaceId = (
     (teamPlace) => teamPlace.id === teamPlaceId,
   );
 
-  if (teamPlace === undefined) return;
+  if (teamPlace === undefined)
+    return {
+      teamPlaceColor: 0 as TeamPlaceColor,
+      displayName: '',
+    };
 
   return {
     teamPlaceColor: teamPlace.teamPlaceColor,


### PR DESCRIPTION
# [FE] 팀플레이스 색상과 조회 로직 연결
## 이슈번호
>close #308 #114 

## PR 내용
캘린더 페이지 간단한 반응형 적용 (paading)
일정 더보기 간단한 반응형 적용

팀플레이스 아이디에 따라 보여주는 정보 다르게 함
- 스케줄바
- 스케줄 모달, 추가모달, 수정모달
- 헤더의 팀 정보
- 스레드의 일정알림 색상
- 통합 캘린더

계속 teamplace 정보 fetch하는게 불안정하다고 생각 + 어차피 한번에 보여줘야하는 부분
의 이유로 context로 만들어 감쌌습니다. 
나중에 페이지 param으로 팀플레이스 id 추출할 수 있게된다면 로직을 합칠 수 있을 것 같습니다. 

## 참고자료

## 의논할 거리
