### PR TITLE
[BE] feed thread 조회 시 MemberTeamPlace의 DisplayMemberName으로 조회되도록 변경

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -17,9 +17,12 @@ import team.teamby.teambyteam.feed.domain.vo.Content;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberIdAndDisplayNameOnly;
 import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.List;
 
@@ -34,6 +37,7 @@ public class FeedThreadService {
 
     private final FeedRepository feedRepository;
     private final MemberRepository memberRepository;
+    private final MemberTeamPlaceRepository memberTeamPlaceRepository;
 
     public Long write(
             final FeedThreadWritingRequest feedThreadWritingRequest,
@@ -81,7 +85,9 @@ public class FeedThreadService {
         if (FeedType.THREAD == feed.getType()) {
             final Member member = memberRepository.findById(feed.getAuthorId())
                     .orElseThrow(MemberException.MemberNotFoundException::new);
-            return FeedResponse.from(feed, member.getName().getValue(), member.getProfileImageUrl().getValue());
+            MemberIdAndDisplayNameOnly memberIdAndDisplayName = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(feed.getTeamPlaceId(), member.getId())
+                    .orElseThrow(TeamPlaceException.TeamPlaceAccessForbidden::new);
+            return FeedResponse.from(feed, memberIdAndDisplayName.displayMemberName().getValue(), member.getProfileImageUrl().getValue());
         }
         if (FeedType.NOTIFICATION == feed.getType()) {
             return FeedResponse.from(feed, "schedule", "");

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -86,4 +86,8 @@ public class MemberTeamPlace extends BaseEntity {
                 .map(Map.Entry::getKey)
                 .get();
     }
+
+    public void changeDisplayMemberName(final DisplayMemberName displayMemberName) {
+        this.displayMemberName = displayMemberName;
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
@@ -98,9 +98,7 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
-            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
             final List<Feed> feeds = new ArrayList<>();
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello1"), member.getId()));
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello2"), member.getId()));
@@ -151,9 +149,7 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
-            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
             final List<Feed> feeds = new ArrayList<>();
             final int size = 3;
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello"), member.getId()));
@@ -180,9 +176,7 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
-            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
             final List<Feed> feeds = new ArrayList<>();
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello1"), member.getId()));
             testFixtureBuilder.buildFeeds(feeds);
@@ -224,9 +218,7 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
-            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
             final List<Feed> feeds = new ArrayList<>();
             feeds.add(new FeedThread(1L, new Content("테스트 스레드"), member.getId()));
             feeds.add(ScheduleNotification.from(new ScheduleCreateEvent(1L, 1L, new Title("테스트 알림"), new Span(LocalDateTime.now(), LocalDateTime.now()))));
@@ -257,9 +249,7 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
-            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
             final List<Feed> feeds = new ArrayList<>();
             final int size = 3;
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello"), member.getId()));
@@ -288,12 +278,8 @@ class FeedThreadServiceTest extends ServiceTest {
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace englishTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             final TeamPlace japaneseTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());
-            MemberTeamPlace memberTeamPlace1 = new MemberTeamPlace();
-            memberTeamPlace1.setMemberAndTeamPlace(member, englishTeamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace1);
-            MemberTeamPlace memberTeamPlace2 = new MemberTeamPlace();
-            memberTeamPlace2.setMemberAndTeamPlace(member, japaneseTeamPlace);
-            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace2);
+            testFixtureBuilder.buildMemberTeamPlace(member, englishTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(member, japaneseTeamPlace);
             final int size = 2;
 
             final List<Feed> feeds = new ArrayList<>();

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
@@ -15,6 +15,8 @@ import team.teamby.teambyteam.feed.domain.notification.ScheduleNotification;
 import team.teamby.teambyteam.feed.domain.vo.Content;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.schedule.application.event.ScheduleCreateEvent;
 import team.teamby.teambyteam.schedule.domain.vo.Span;
@@ -29,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.HELLO_WRITING_REQUEST;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
+import static team.teamby.teambyteam.common.fixtures.MemberTeamPlaceFixtures.PHILIP_ENGLISH_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
 
@@ -95,6 +98,9 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
             final List<Feed> feeds = new ArrayList<>();
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello1"), member.getId()));
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello2"), member.getId()));
@@ -114,11 +120,40 @@ class FeedThreadServiceTest extends ServiceTest {
         }
 
         @Test
+        @DisplayName("피드의 스레드조회 시 팀플레이스의 이름이 나온다.")
+        void threadReadTeamPlaceMemberName() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            final MemberTeamPlace PHILIP_ENGLISH_TEAM_PLACE = PHILIP_ENGLISH_TEAM_PLACE();
+            PHILIP_ENGLISH_TEAM_PLACE.setMemberAndTeamPlace(PHILIP, ENGLISH_TEAM_PLACE);
+            DisplayMemberName displayMemberName = new DisplayMemberName("changedName");
+            PHILIP_ENGLISH_TEAM_PLACE.changeDisplayMemberName(displayMemberName);
+            testFixtureBuilder.buildMemberTeamPlace(PHILIP_ENGLISH_TEAM_PLACE);
+            final List<Feed> feeds = new ArrayList<>();
+            feeds.add(new FeedThread(ENGLISH_TEAM_PLACE.getId(), new Content("Hello1"), PHILIP.getId()));
+            testFixtureBuilder.buildFeeds(feeds);
+            final int size = 10;
+
+            // when
+            final FeedsResponse feedsResponse = feedThreadService.firstRead(PHILIP_ENGLISH_TEAM_PLACE.getId(), size);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(feedsResponse.threads().get(0).authorName()).isEqualTo(displayMemberName.getValue());
+                softly.assertThat(feedsResponse.threads().get(0).authorName()).isNotEqualTo(PHILIP.getName().getValue());
+            });
+        }
+
+        @Test
         @DisplayName("피드의 스레드를 사이즈 초과인 경우 처음 조회한다.")
         void firstThreadReadOverSizeSuccess() {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
             final List<Feed> feeds = new ArrayList<>();
             final int size = 3;
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello"), member.getId()));
@@ -145,6 +180,9 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
             final List<Feed> feeds = new ArrayList<>();
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello1"), member.getId()));
             testFixtureBuilder.buildFeeds(feeds);
@@ -186,6 +224,9 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
             final List<Feed> feeds = new ArrayList<>();
             feeds.add(new FeedThread(1L, new Content("테스트 스레드"), member.getId()));
             feeds.add(ScheduleNotification.from(new ScheduleCreateEvent(1L, 1L, new Title("테스트 알림"), new Span(LocalDateTime.now(), LocalDateTime.now()))));
@@ -216,6 +257,9 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            MemberTeamPlace memberTeamPlace = new MemberTeamPlace();
+            memberTeamPlace.setMemberAndTeamPlace(member, teamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace);
             final List<Feed> feeds = new ArrayList<>();
             final int size = 3;
             feeds.add(new FeedThread(teamPlace.getId(), new Content("Hello"), member.getId()));
@@ -244,6 +288,12 @@ class FeedThreadServiceTest extends ServiceTest {
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace englishTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             final TeamPlace japaneseTeamPlace = testFixtureBuilder.buildTeamPlace(JAPANESE_TEAM_PLACE());
+            MemberTeamPlace memberTeamPlace1 = new MemberTeamPlace();
+            memberTeamPlace1.setMemberAndTeamPlace(member, englishTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace1);
+            MemberTeamPlace memberTeamPlace2 = new MemberTeamPlace();
+            memberTeamPlace2.setMemberAndTeamPlace(member, japaneseTeamPlace);
+            testFixtureBuilder.buildMemberTeamPlace(memberTeamPlace2);
             final int size = 2;
 
             final List<Feed> feeds = new ArrayList<>();


### PR DESCRIPTION
## 이슈번호
#317

## PR 내용
스레드 조회 시 소속 팀플레이스의 이름으로 조회되도록 변경
## 참고자료

## 의논할 거리
