### PR TITLE
[FE] 일정 등록 접근성 개선

### DIFF
--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -108,6 +108,7 @@ const Calendar = () => {
           <Button
             css={S.scheduleAddButton}
             onClick={handleScheduleAddButtonClick}
+            aria-label="새로운 일정 등록하기"
           >
             <PlusIcon />
           </Button>

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -45,7 +45,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             type="button"
             onClick={closeModal}
             css={S.closeButton}
-            aria-label="닫기"
+            aria-label="일정 등록 모달 닫기"
           >
             <CloseIcon />
           </Button>
@@ -55,10 +55,11 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
             <Input
               width="100%"
               height="100%"
-              placeholder="일정 제목"
+              placeholder="일정 제목을 입력해주세요."
               css={S.title}
               name="title"
               value={schedule['title']}
+              ref={titleInputRef}
               required
               onChange={handleScheduleChange}
             />
@@ -77,6 +78,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
                 name="startDateTime"
                 value={schedule['startDateTime']}
                 onChange={handleScheduleChange}
+                aria-label={`일정 시작 일자는 ${schedule['startDateTime']} 입니다`}
                 required
               />
               {!isAllDay && (
@@ -99,7 +101,8 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
                 css={S.dateTimeLocalInput}
                 name="endDateTime"
                 value={schedule['endDateTime']}
-                min={schedule['startDateTime']}
+                min={schedule['endDateTime']}
+                aria-label={`일정 마감 일자는 ${schedule['endDateTime']} 입니다`}
                 onChange={handleScheduleChange}
                 required
               />
@@ -116,6 +119,16 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
               종일
             </Text>
             <Checkbox isChecked={isAllDay} onChange={handleIsAllDayChange} />
+
+            <p
+              className="hidden"
+              aria-live="assertive"
+              aria-relevant="additions"
+            >
+              {isAllDay
+                ? '종일 일정이 선택되었습니다.'
+                : '종일 일정이 해제되었습니다.'}
+            </p>
           </S.CheckboxContainer>
           <S.InnerContainer>
             <S.TeamNameContainer title={displayName}>

--- a/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/ScheduleAddModal/ScheduleAddModal.tsx
@@ -11,6 +11,7 @@ import TeamBadge from '~/components/common/TeamBadge/TeamBadge';
 import TimeTableMenu from '~/components/TimeTableMenu/TimeTableMenu';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
+import { useRef, useEffect } from 'react';
 
 interface ScheduleAddModalProps {
   clickedDate: Date;
@@ -34,6 +35,12 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
   } = useScheduleAddModal(clickedDate);
 
   const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(teamPlaces, 1);
+
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    titleInputRef.current?.focus();
+  }, []);
 
   return (
     <Modal>

--- a/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
+++ b/frontend/src/components/ThreadAddBottomSheet/ThreadAddBottomSheet.tsx
@@ -3,6 +3,7 @@ import * as S from './ThreadAddBottomSheet.styled';
 import Button from '~/components/common/Button/Button';
 import Checkbox from '~/components/common/Checkbox/Checkbox';
 import { useThreadAddBottomSheet } from '~/hooks/thread/useThreadAddBottomSheet';
+import { useRef, useEffect } from 'react';
 
 const ThreadAddBottomSheet = () => {
   const {
@@ -18,6 +19,12 @@ const ThreadAddBottomSheet = () => {
       handleSubmit,
     },
   } = useThreadAddBottomSheet();
+
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textAreaRef.current?.focus();
+  }, []);
 
   return (
     <>
@@ -40,6 +47,7 @@ const ThreadAddBottomSheet = () => {
             maxLength={1500}
             value={content}
             onChange={handleContentChange}
+            ref={textAreaRef}
             required
           />
           <S.ButtonWrapper>

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -11,7 +11,7 @@ const Header = () => {
   const { teamPlaceColor, displayName } = getInfoByTeamPlaceId(teamPlaces, 1);
 
   return (
-    <S.Container>
+    <S.Container tabIndex={0}>
       <LogoIcon />
       <div>
         <TeamBadge teamPlaceColor={teamPlaceColor} />

--- a/frontend/src/components/common/Input/Input.tsx
+++ b/frontend/src/components/common/Input/Input.tsx
@@ -1,14 +1,15 @@
 import * as S from './Input.styled';
 import type { CSSProp } from 'styled-components';
-import type { InputHTMLAttributes } from 'react';
+import type { ComponentPropsWithRef } from 'react';
+import { forwardRef } from 'react';
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends ComponentPropsWithRef<'input'> {
   width: string;
   height: string;
   css?: CSSProp;
 }
 
-const Input = (props: InputProps) => {
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const { width, height, css, ...rest } = props;
 
   return (
@@ -16,9 +17,12 @@ const Input = (props: InputProps) => {
       width={width}
       height={height}
       css={css}
+      ref={ref}
       {...rest}
     ></S.InputWrapper>
   );
-};
+});
+
+Input.displayName = 'Input';
 
 export default Input;

--- a/frontend/src/components/common/Menu/MenuList/MenuList.tsx
+++ b/frontend/src/components/common/Menu/MenuList/MenuList.tsx
@@ -16,7 +16,6 @@ const MenuList = (props: PropsWithChildren<MenuListProps>) => {
     handleMenuOpen,
     handleSelectedValueChange,
   } = useMenu();
-  const offsetRef = useRef(0);
   const ref = useRef<HTMLUListElement>(null);
 
   useClickOutside(ref, (e: Event) => {

--- a/frontend/src/components/common/NavigationBar/NavigationBar.styled.ts
+++ b/frontend/src/components/common/NavigationBar/NavigationBar.styled.ts
@@ -1,4 +1,5 @@
-import { styled, css } from 'styled-components';
+import { styled } from 'styled-components';
+import { Link } from 'react-router-dom';
 
 export const Container = styled.div`
   display: flex;
@@ -17,7 +18,7 @@ export const MenuContainer = styled.div`
   gap: 30px;
 `;
 
-export const menuIcon = css`
+export const MenuLink = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -28,7 +29,8 @@ export const menuIcon = css`
 
   border-radius: 50%;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: ${({ theme }) => theme.color.GRAY200};
   }
 `;

--- a/frontend/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/frontend/src/components/common/NavigationBar/NavigationBar.tsx
@@ -1,21 +1,19 @@
 import { CalendarIcon, FeedIcon, HomeIcon } from '~/assets/svg';
 import * as S from './NavigationBar.styled';
-import Button from '~/components/common/Button/Button';
-import { Link } from 'react-router-dom';
 
 const NavigationBar = () => {
   return (
     <S.Container>
       <S.MenuContainer>
-        <Link to="/" aria-label="홈 페이지로 이동하기 버튼">
+        <S.MenuLink to="/" aria-label="홈 페이지로 이동하기 버튼">
           <HomeIcon />
-        </Link>
-        <Link to="/" aria-label="팀 캘린더 페이지로 이동하기 버튼">
+        </S.MenuLink>
+        <S.MenuLink to="/" aria-label="팀 캘린더 페이지로 이동하기 버튼">
           <CalendarIcon />
-        </Link>
-        <Link to="/threads" aria-label="팀 피드 페이지로 이동하기 버튼">
+        </S.MenuLink>
+        <S.MenuLink to="/threads" aria-label="팀 피드 페이지로 이동하기 버튼">
           <FeedIcon />
-        </Link>
+        </S.MenuLink>
       </S.MenuContainer>
     </S.Container>
   );

--- a/frontend/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/frontend/src/components/common/NavigationBar/NavigationBar.tsx
@@ -7,20 +7,14 @@ const NavigationBar = () => {
   return (
     <S.Container>
       <S.MenuContainer>
-        <Link to="/">
-          <Button type="button" variant="plain" css={S.menuIcon}>
-            <HomeIcon />
-          </Button>
+        <Link to="/" aria-label="홈 페이지로 이동하기 버튼">
+          <HomeIcon />
         </Link>
-        <Link to="/">
-          <Button type="button" variant="plain" css={S.menuIcon}>
-            <CalendarIcon />
-          </Button>
+        <Link to="/" aria-label="팀 캘린더 페이지로 이동하기 버튼">
+          <CalendarIcon />
         </Link>
-        <Link to="/threads">
-          <Button type="button" variant="plain" css={S.menuIcon}>
-            <FeedIcon />
-          </Button>
+        <Link to="/threads" aria-label="팀 피드 페이지로 이동하기 버튼">
+          <FeedIcon />
         </Link>
       </S.MenuContainer>
     </S.Container>

--- a/frontend/src/components/common/Toast/Toast.tsx
+++ b/frontend/src/components/common/Toast/Toast.tsx
@@ -28,6 +28,9 @@ const Toast = (props: ToastProps) => {
   return (
     <S.Wrapper id={id} ref={ref} status={status} isActive={isActive}>
       <Text as="span">{message}</Text>
+      <p className="hidden" aria-live="assertive">
+        {message}
+      </p>
     </S.Wrapper>
   );
 };

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -53,6 +53,20 @@ const GlobalStyle = createGlobalStyle`
   button:disabled {
     cursor: not-allowed;
   }
+
+  *.hidden {
+    overflow: hidden;
+    white-space: nowrap;
+    clip: rect(1px, 1px, 1px, 1px);
+    -webkit-clip-path: inset(50%);
+    clip-path: inset(50%);
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
 `;
 
 export default GlobalStyle;

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -55,17 +55,21 @@ const GlobalStyle = createGlobalStyle`
   }
 
   *.hidden {
-    overflow: hidden;
-    white-space: nowrap;
-    clip: rect(1px, 1px, 1px, 1px);
-    -webkit-clip-path: inset(50%);
-    clip-path: inset(50%);
     position: absolute;
+    overflow: hidden;
+
     width: 1px;
     height: 1px;
     margin: 0;
     padding: 0;
+    
     border: 0;
+    
+    white-space: nowrap;
+    
+    clip: rect(1px, 1px, 1px, 1px);
+    -webkit-clip-path: inset(50%);
+    clip-path: inset(50%);
   }
 `;
 


### PR DESCRIPTION
# [FE] 일정 등록 접근성 개선
## 이슈번호
> close #322

## PR 내용
본 PR에서는 사용자가 팀 캘린더 페이지에 접속하고, 새로운 일정을 생성하기까지의 과정의 웹 접근성을 개선하였다.
- 키보드만을 이용하여 메뉴를 자유로이 이동하고, 새로운 일정을 생성할 수 있다.
- 일정 등록 메뉴 / 팀 피드 메뉴를 편리하게 이용할 수 있도록, 모달을 열었을 때 자동으로 인풋에 포커스를 준다.
- 스크린 리더만으로 어떠한 작업이 진행되는지를 충분히 알 수 있도록 구현하였다. 다만 커스텀 메뉴 컴포넌트 (시간 선택 인풋)에 한해서는 이를 개선하지 못했다.
