### PR TITLE
[BE] 팀 공지 조회 시 member team place의 display name이 조회되도록 기능 변경

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException.MemberNotFoundException;
 import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
@@ -26,6 +27,7 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final TeamPlaceRepository teamPlaceRepository;
     private final MemberRepository memberRepository;
+    private final MemberTeamPlaceRepository memberTeamPlaceRepository;
 
     public Long register(final NoticeRegisterRequest noticeRegisterRequest,
                          final Long teamPlaceId,
@@ -57,6 +59,8 @@ public class NoticeService {
 
         return noticeRepository.findMostRecentByTeamPlaceId(teamPlaceId)
                 .flatMap(findNotice -> memberRepository.findById(findNotice.getAuthorId())
-                        .map(findAuthor -> NoticeResponse.of(findNotice, findAuthor)));
+                        .flatMap(findAuthor -> memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, findAuthor.getId())
+                                .map(findMemberTeamPlace -> NoticeResponse.of(findNotice, findAuthor, findMemberTeamPlace))
+                        ));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/dto/NoticeResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/dto/NoticeResponse.java
@@ -1,6 +1,7 @@
 package team.teamby.teambyteam.notice.application.dto;
 
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberIdAndDisplayNameOnly;
 import team.teamby.teambyteam.notice.domain.Notice;
 
 import java.time.format.DateTimeFormatter;
@@ -15,7 +16,7 @@ public record NoticeResponse(
 ) {
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
 
-    public static NoticeResponse of(final Notice notice, final Member member) {
+    public static NoticeResponse of(final Notice notice, final Member member, final MemberIdAndDisplayNameOnly memberTeamPlace) {
         final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
         final String noticeCreatedAt = dateTimeFormatter.format(notice.getCreatedAt());
 
@@ -23,7 +24,7 @@ public record NoticeResponse(
                 notice.getId(),
                 notice.getContent().getValue(),
                 member.getId(),
-                member.getName().getValue(),
+                memberTeamPlace.displayMemberName().getValue(),
                 member.getProfileImageUrl().getValue(),
                 noticeCreatedAt
         );

--- a/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/presentation/NoticeController.java
@@ -41,10 +41,8 @@ public class NoticeController {
     public ResponseEntity<NoticeResponse> findNotice(@PathVariable final Long teamPlaceId) {
         final Optional<NoticeResponse> noticeResponseOptional = noticeService.findMostRecentNotice(teamPlaceId);
 
-        if (noticeResponseOptional.isEmpty()) {
-            return ResponseEntity.ok().build();
-        }
-
-        return ResponseEntity.ok(noticeResponseOptional.get());
+        return noticeResponseOptional
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok().build());
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
@@ -179,7 +179,7 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
                 softly.assertThat(response.jsonPath().getLong("id")).isEqualTo(recentRegisteredNotice.getId());
                 softly.assertThat(response.jsonPath().getString("content")).isEqualTo(recentRegisteredNotice.getContent().getValue());
                 softly.assertThat(response.jsonPath().getLong("authorId")).isEqualTo(authedMember.getId());
-                softly.assertThat(response.jsonPath().getString("authorName")).isEqualTo(authedMember.getName().getValue());
+                softly.assertThat(response.jsonPath().getString("authorName")).isEqualTo(participatedMemberTeamPlace.getDisplayMemberName().getValue());
                 softly.assertThat(response.jsonPath().getString("profileImageUrl")).isEqualTo(authedMember.getProfileImageUrl().getValue());
                 softly.assertThat(response.jsonPath().getString("createdAt")).isEqualTo(DATE_TIME_FORMATTER.format(recentRegisteredNotice.getCreatedAt()));
             });

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.exception.MemberException.MemberNotFoundException;
 import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
 import team.teamby.teambyteam.notice.application.dto.NoticeResponse;
@@ -93,14 +94,14 @@ class NoticeServiceTest extends ServiceTest {
 
         private Member member;
         private TeamPlace teamPlace;
-        private NoticeRegisterRequest request;
+        private MemberTeamPlace memberTeamPlace;
         private List<Notice> notices;
 
         @BeforeEach
         void setUP() {
             member = testFixtureBuilder.buildMember(ROY());
             teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            request = FIRST_NOTICE_REGISTER_REQUEST;
+            memberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
             notices = testFixtureBuilder.buildNotices(
                     List.of(
                             NOTICE_1ST(teamPlace.getId(), member.getId()),


### PR DESCRIPTION
## 이슈번호
> #324 

## PR 내용
- 공지 조회 시 등록자명 표시 방식 변경(Member의 이름 -> MemberTeamPlace의 DisplayName)
- 관련 테스트 수정
- PostMan Test

## 참고자료

## 의논할 거리
