### PR TITLE
[BE] MemberArgumentResolver에서 JwtTokenProvider 사용하도록 리팩토링

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebMvcConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
 import team.teamby.teambyteam.auth.presentation.MemberInterceptor;
 import team.teamby.teambyteam.auth.presentation.TeamPlaceParticipationInterceptor;
 import team.teamby.teambyteam.member.configuration.MemberArgumentResolver;
@@ -17,10 +18,11 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     private final MemberInterceptor memberInterceptor;
     private final TeamPlaceParticipationInterceptor teamPlaceParticipationInterceptor;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new MemberArgumentResolver());
+        resolvers.add(new MemberArgumentResolver(jwtTokenProvider));
     }
 
     @Override

--- a/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberArgumentResolver.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/configuration/MemberArgumentResolver.java
@@ -1,21 +1,23 @@
 package team.teamby.teambyteam.member.configuration;
 
-import org.springframework.boot.json.JacksonJsonParser;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 
-import java.util.Base64;
-
+@Component
+@RequiredArgsConstructor
 public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private static final String EMAIL_KEY = "email";
-    private static final int PAYLOAD_INDEX = 1;
     private static final int TOKEN_INDEX = 1;
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -26,15 +28,7 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final String authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
         final String jwtToken = authorization.split(" ")[TOKEN_INDEX];
-        final String email = extractEmailFromToken(jwtToken);
+        String email = jwtTokenProvider.extractEmailFromToken(jwtToken);
         return new MemberEmailDto(email);
-    }
-
-    private String extractEmailFromToken(final String jwtToken) {
-        final String payLoad = jwtToken.split("\\.")[PAYLOAD_INDEX];
-        final String decodedPayLoad = new String(Base64.getDecoder().decode(payLoad));
-        final JacksonJsonParser jacksonJsonParser = new JacksonJsonParser();
-        return (String) jacksonJsonParser.parseMap(decodedPayLoad)
-                .get(EMAIL_KEY);
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/TeamCalendarScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/TeamCalendarScheduleApiDocsTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
 import team.teamby.teambyteam.auth.presentation.MemberInterceptor;
 import team.teamby.teambyteam.auth.presentation.TeamPlaceParticipationInterceptor;
 import team.teamby.teambyteam.schedule.application.TeamCalendarScheduleService;
@@ -31,18 +32,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -50,10 +46,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE;
-import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_REGISTER_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_TITLE;
-import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_UPDATE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.ScheduleFixtures.*;
 
 @AutoConfigureRestDocs
 @WebMvcTest(TeamCalendarScheduleController.class)
@@ -82,6 +75,9 @@ public class TeamCalendarScheduleApiDocsTest {
 
     @MockBean
     private TeamPlaceParticipationInterceptor teamPlaceParticipationInterceptor;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
 
     @BeforeEach
     void setup() throws Exception {


### PR DESCRIPTION
 ## 이슈번호
> #364 

## PR 내용

- MemberArgumentResolver에서 JwtTokenProvider 사용하도록 리팩토링
- 기존 JsonParser 사용 시 RestDocsTest에서 MockBean이 제대로 안되는 문제가 발생함.
  - 이미 있는 로직인 JwtTokenProvider의 extractEmailFromToken을 재사용하고, RestDocs에서 jwtTokenProvider를 MockBean하기 위해 리팩토링

## 참고자료

## 의논할 거리
