### PR TITLE
[BE] MemberTeamPlaceRepository 반환데이터 변경

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -17,12 +17,11 @@ import team.teamby.teambyteam.feed.domain.vo.Content;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.Member;
-import team.teamby.teambyteam.member.domain.MemberIdAndDisplayNameOnly;
 import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
-import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.List;
 
@@ -81,13 +80,12 @@ public class FeedThreadService {
         return feeds.stream().map(this::mapToResponse).toList();
     }
 
-    private FeedResponse mapToResponse(Feed feed) {
+    private FeedResponse mapToResponse(final Feed feed) {
         if (FeedType.THREAD == feed.getType()) {
-            final Member member = memberRepository.findById(feed.getAuthorId())
+            final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(feed.getTeamPlaceId(), feed.getAuthorId())
                     .orElseThrow(MemberException.MemberNotFoundException::new);
-            MemberIdAndDisplayNameOnly memberIdAndDisplayName = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(feed.getTeamPlaceId(), member.getId())
-                    .orElseThrow(TeamPlaceException.TeamPlaceAccessForbidden::new);
-            return FeedResponse.from(feed, memberIdAndDisplayName.displayMemberName().getValue(), member.getProfileImageUrl().getValue());
+            final Member member = memberTeamPlace.getMember();
+            return FeedResponse.from(feed, memberTeamPlace.getDisplayMemberName().getValue(), member.getProfileImageUrl().getValue());
         }
         if (FeedType.NOTIFICATION == feed.getType()) {
             return FeedResponse.from(feed, "schedule", "");

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberIdAndDisplayNameOnly.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberIdAndDisplayNameOnly.java
@@ -1,9 +1,0 @@
-package team.teamby.teambyteam.member.domain;
-
-import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
-
-public record MemberIdAndDisplayNameOnly(
-        Long id,
-        DisplayMemberName displayMemberName
-) {
-}

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
@@ -9,7 +9,5 @@ public interface MemberTeamPlaceRepository extends JpaRepository<MemberTeamPlace
 
     Optional<MemberTeamPlace> findByTeamPlaceIdAndMemberId(Long teamPlaceId, Long memberId);
 
-    List<MemberIdAndDisplayNameOnly> findAllByTeamPlaceId(Long teamPlaceId);
-
     List<MemberTeamPlace> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface MemberTeamPlaceRepository extends JpaRepository<MemberTeamPlace, Long> {
 
-    Optional<MemberIdAndDisplayNameOnly> findByTeamPlaceIdAndMemberId(Long teamPlaceId, Long memberId);
+    Optional<MemberTeamPlace> findByTeamPlaceIdAndMemberId(Long teamPlaceId, Long memberId);
 
     List<MemberIdAndDisplayNameOnly> findAllByTeamPlaceId(Long teamPlaceId);
 

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -58,9 +58,9 @@ public class NoticeService {
         checkTeamPlaceExist(teamPlaceId);
 
         return noticeRepository.findMostRecentByTeamPlaceId(teamPlaceId)
-                .flatMap(findNotice -> memberRepository.findById(findNotice.getAuthorId())
-                        .flatMap(findAuthor -> memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, findAuthor.getId())
-                                .map(findMemberTeamPlace -> NoticeResponse.of(findNotice, findAuthor, findMemberTeamPlace))
-                        ));
+                .flatMap(findNotice ->
+                        memberTeamPlaceRepository.findById(findNotice.getAuthorId())
+                                .map(memberTeamPlace -> NoticeResponse.of(findNotice, memberTeamPlace))
+                );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/dto/NoticeResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/dto/NoticeResponse.java
@@ -1,7 +1,6 @@
 package team.teamby.teambyteam.notice.application.dto;
 
-import team.teamby.teambyteam.member.domain.Member;
-import team.teamby.teambyteam.member.domain.MemberIdAndDisplayNameOnly;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.notice.domain.Notice;
 
 import java.time.format.DateTimeFormatter;
@@ -16,16 +15,16 @@ public record NoticeResponse(
 ) {
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
 
-    public static NoticeResponse of(final Notice notice, final Member member, final MemberIdAndDisplayNameOnly memberTeamPlace) {
+    public static NoticeResponse of(final Notice notice, final MemberTeamPlace memberTeamPlace) {
         final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
         final String noticeCreatedAt = dateTimeFormatter.format(notice.getCreatedAt());
 
         return new NoticeResponse(
                 notice.getId(),
                 notice.getContent().getValue(),
-                member.getId(),
-                memberTeamPlace.displayMemberName().getValue(),
-                member.getProfileImageUrl().getValue(),
+                memberTeamPlace.getMember().getId(),
+                memberTeamPlace.getDisplayMemberName().getValue(),
+                memberTeamPlace.getMember().getProfileImageUrl().getValue(),
                 noticeCreatedAt
         );
     }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
@@ -7,10 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import team.teamby.teambyteam.common.RepositoryTest;
 import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
-import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-
-import java.util.List;
 
 class MemberTeamPlaceRepositoryTest extends RepositoryTest {
 
@@ -33,30 +30,6 @@ class MemberTeamPlaceRepositoryTest extends RepositoryTest {
             softly.assertThat(actual.getMember().getId()).isEqualTo(PHILIP.getId());
             softly.assertThat(actual.getDisplayMemberName().getValue()).isEqualTo(PHILIP.getName().getValue());
             softly.assertThat(actual.getDisplayTeamPlaceName().getValue()).isEqualTo(ENGLISH_TEAM_PLACE.getName().getValue());
-        });
-    }
-
-    @Test
-    @DisplayName("팀플레이스에 소속된 모든 멤버들의 아이디와 해당 팀에서의 사용자 이름을 조회한다.")
-    void findAllMemberIdAndDisplayNameByTeamPlace() {
-        // given
-        final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
-        final Member ENDLE = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
-        final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
-        testFixtureBuilder.buildMemberTeamPlace(PHILIP, ENGLISH_TEAM_PLACE);
-        testFixtureBuilder.buildMemberTeamPlace(ENDLE, ENGLISH_TEAM_PLACE);
-
-        // when
-        final List<MemberIdAndDisplayNameOnly> actual = memberTeamPlaceRepository.findAllByTeamPlaceId(ENGLISH_TEAM_PLACE.getId());
-        final List<String> displayNames = actual.stream()
-                .map(MemberIdAndDisplayNameOnly::displayMemberName)
-                .map(DisplayMemberName::getValue)
-                .toList();
-
-        //then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(actual).hasSize(2);
-            softly.assertThat(displayNames).containsExactlyInAnyOrder(PHILIP.getName().getValue(), ENDLE.getName().getValue());
         });
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepositoryTest.java
@@ -18,7 +18,7 @@ class MemberTeamPlaceRepositoryTest extends RepositoryTest {
     private MemberTeamPlaceRepository memberTeamPlaceRepository;
 
     @Test
-    @DisplayName("멤버아이디와 소속된 팀의 아이디로 해당 팀에서의 사용자 이름을 조회한다.")
+    @DisplayName("멤버아이디와 소속된 팀의 아이디로 해당 팀에서의 사용자 정보를 조회한다.")
     void findMemberIdAndDisplayNameByTeamPlaceIdAndMemberId() {
         // given
         final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
@@ -26,12 +26,13 @@ class MemberTeamPlaceRepositoryTest extends RepositoryTest {
         testFixtureBuilder.buildMemberTeamPlace(PHILIP, ENGLISH_TEAM_PLACE);
 
         // when
-        final MemberIdAndDisplayNameOnly actual = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(ENGLISH_TEAM_PLACE.getId(), PHILIP.getId()).get();
+        final MemberTeamPlace actual = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(ENGLISH_TEAM_PLACE.getId(), PHILIP.getId()).get();
 
         //then
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(actual.id()).isEqualTo(PHILIP.getId());
-            softly.assertThat(actual.displayMemberName().getValue()).isEqualTo(PHILIP.getName().getValue());
+            softly.assertThat(actual.getMember().getId()).isEqualTo(PHILIP.getId());
+            softly.assertThat(actual.getDisplayMemberName().getValue()).isEqualTo(PHILIP.getName().getValue());
+            softly.assertThat(actual.getDisplayTeamPlaceName().getValue()).isEqualTo(ENGLISH_TEAM_PLACE.getName().getValue());
         });
     }
 


### PR DESCRIPTION
## 이슈번호
> close #367 

## PR 내용

- MemberTeamPlace에서 Projection 제거
- 제거 이유
  - 기존에는 사용자의 displayname과 id만 가져옴
  - 피드등의 조회 api에서 diplayNmae, id 뿐만 아니라 profile image url도 필요
  - 해당 필드는 member entity에만 있음
  - projection사용시 member는 memberRepository를 통해 다시 가져와야함
  - entity를 가져와서 memberTeamPlace에서 member를 가져와 사용할 수 있도록 변경

## 참고자료

## 의논할 거리
