### PR TITLE
[BE] 팀플래이스 생성 api. 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
@@ -10,6 +10,7 @@ import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
@@ -24,12 +25,12 @@ public class TeamPlaceService {
     private final TeamPlaceRepository teamPlaceRepository;
     private final MemberTeamPlaceRepository memberTeamPlaceRepository;
 
-    public TeamPlaceCreateResponse create(final MemberEmailDto memberEmailDto, final String teamPlaceName) {
+    public TeamPlaceCreateResponse create(final MemberEmailDto memberEmailDto, final TeamPlaceCreateRequest request) {
 
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(MemberException.MemberNotFoundException::new);
 
-        final TeamPlace createdTeamPlace = teamPlaceRepository.save(new TeamPlace(new Name(teamPlaceName)));
+        final TeamPlace createdTeamPlace = teamPlaceRepository.save(new TeamPlace(new Name(request.name())));
         final MemberTeamPlace participatedMemberTeamPlace = member.participate(createdTeamPlace);
 
         memberTeamPlaceRepository.save(participatedMemberTeamPlace);

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
@@ -1,0 +1,40 @@
+package team.teamby.teambyteam.teamplace.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
+import team.teamby.teambyteam.member.domain.vo.Email;
+import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
+import team.teamby.teambyteam.teamplace.domain.vo.Name;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TeamPlaceService {
+
+    private final MemberRepository memberRepository;
+    private final TeamPlaceRepository teamPlaceRepository;
+    private final MemberTeamPlaceRepository memberTeamPlaceRepository;
+
+    public TeamPlaceCreateResponse create(final MemberEmailDto memberEmailDto, final String teamPlaceName) {
+
+        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+
+        final TeamPlace createdTeamPlace = teamPlaceRepository.save(new TeamPlace(new Name(teamPlaceName)));
+        final MemberTeamPlace participatedMemberTeamPlace = member.participate(createdTeamPlace);
+
+        memberTeamPlaceRepository.save(participatedMemberTeamPlace);
+
+        return new TeamPlaceCreateResponse(createdTeamPlace.getId());
+    }
+
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceCreateRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceCreateRequest.java
@@ -1,0 +1,4 @@
+package team.teamby.teambyteam.teamplace.application.dto;
+
+public record TeamPlaceCreateRequest(String name) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceCreateResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceCreateResponse.java
@@ -1,0 +1,4 @@
+package team.teamby.teambyteam.teamplace.application.dto;
+
+public record TeamPlaceCreateResponse(Long teamPlaceId) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
@@ -1,0 +1,32 @@
+package team.teamby.teambyteam.teamplace.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.teamby.teambyteam.member.configuration.AuthPrincipal;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.teamplace.application.TeamPlaceService;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
+
+@RestController
+@RequestMapping("/api/team-places")
+@RequiredArgsConstructor
+public class TeamPlaceController {
+
+    private final TeamPlaceService teamPlaceService;
+
+    @PostMapping
+    public ResponseEntity<TeamPlaceCreateResponse> createTeamPlace(
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
+            @RequestBody final TeamPlaceCreateRequest teamPlaceCreateRequest
+    ) {
+        final TeamPlaceCreateResponse response = teamPlaceService.create(memberEmailDto, teamPlaceCreateRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamPlaceAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamPlaceAcceptanceFixture.java
@@ -1,0 +1,23 @@
+package team.teamby.teambyteam.common.fixtures.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
+
+public class TeamPlaceAcceptanceFixture {
+
+    private static final String JWT_PREFIX = "Bearer ";
+
+    public static ExtractableResponse<Response> CREATE_TEAM_PLACE(final String token, final TeamPlaceCreateRequest request) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/api/team-places")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -1,0 +1,48 @@
+package team.teamby.teambyteam.teamplace.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import team.teamby.teambyteam.common.AcceptanceTest;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
+
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamPlaceAcceptanceFixture.CREATE_TEAM_PLACE;
+
+public class TeamPlaceAcceptanceTest extends AcceptanceTest {
+
+    @Nested
+    @DisplayName("팀플레이스 생성시")
+    public class CreateTeamPlaceTest {
+
+        @Test
+        @DisplayName("생성에 성공하고, 요청한 사용자가 생성된 팀플레이스에 소속된다.")
+        void success() {
+            // given
+            final Member ENDL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final String ENDL_TOKEN = jwtTokenProvider.generateToken(ENDL.getEmail().getValue());
+            final String NEW_TEAM_PLACE_NAME = "새로운 팀플레이스";
+            final TeamPlaceCreateRequest request = new TeamPlaceCreateRequest(NEW_TEAM_PLACE_NAME);
+
+            // when
+            final ExtractableResponse<Response> createResponse = CREATE_TEAM_PLACE(ENDL_TOKEN, request);
+
+            //then
+            final ExtractableResponse<Response> response = GET_PARTICIPATED_TEAM_PLACES(ENDL_TOKEN);
+            TeamPlacesResponse teamPlacesResponse = response.body().as(TeamPlacesResponse.class);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+                softly.assertThat(createResponse.jsonPath().getLong("teamPlaceId")).isNotNull();
+                softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(1);
+                softly.assertThat(teamPlacesResponse.teamPlaces().get(0).displayName()).isEqualTo(NEW_TEAM_PLACE_NAME);
+            });
+        }
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -13,6 +13,7 @@ import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
 import static team.teamby.teambyteam.common.fixtures.acceptance.TeamPlaceAcceptanceFixture.CREATE_TEAM_PLACE;
 
@@ -42,6 +43,24 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
                 softly.assertThat(createResponse.jsonPath().getLong("teamPlaceId")).isNotNull();
                 softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(1);
                 softly.assertThat(teamPlacesResponse.teamPlaces().get(0).displayName()).isEqualTo(NEW_TEAM_PLACE_NAME);
+            });
+        }
+
+        @Test
+        @DisplayName("잘못된 인증 토큰으로 요청시 실패한다.")
+        void failWithWrongToken() {
+            // given
+            final String WRONG_TOKEN = "12j40jf390.0we9ru2i3hr8.912jrkejfi23j";
+            final String NEW_TEAM_PLACE_NAME = "새로운 팀플레이스";
+            final TeamPlaceCreateRequest request = new TeamPlaceCreateRequest(NEW_TEAM_PLACE_NAME);
+
+            // when
+            final ExtractableResponse<Response> response = CREATE_TEAM_PLACE(WRONG_TOKEN, request);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
         }
     }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
@@ -15,6 +15,7 @@ import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.DisplayTeamPlaceName;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
@@ -45,7 +46,7 @@ class TeamPlaceServiceTest extends ServiceTest {
             final String TEAM_PLACE_NAME = "새로운 팀플레이스";
 
             // when
-            final TeamPlaceCreateResponse response = teamPlaceService.create(new MemberEmailDto(PHILIP.getEmail().getValue()), TEAM_PLACE_NAME);
+            final TeamPlaceCreateResponse response = teamPlaceService.create(new MemberEmailDto(PHILIP.getEmail().getValue()), new TeamPlaceCreateRequest(TEAM_PLACE_NAME));
 
             //then
             Optional<TeamPlace> createdTeamPlace = teamPlaceRepository.findById(response.teamPlaceId());
@@ -68,7 +69,7 @@ class TeamPlaceServiceTest extends ServiceTest {
             final String TEAM_PLACE_NAME = "새로운 팀플레이스";
 
             // when & then
-            Assertions.assertThatThrownBy(() -> teamPlaceService.create(new MemberEmailDto(PHILIP.getEmail().getValue()), TEAM_PLACE_NAME))
+            Assertions.assertThatThrownBy(() -> teamPlaceService.create(new MemberEmailDto(PHILIP.getEmail().getValue()), new TeamPlaceCreateRequest(TEAM_PLACE_NAME)))
                     .isInstanceOf(MemberException.MemberNotFoundException.class)
                     .hasMessage("조회한 멤버가 존재하지 않습니다.");
         }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
@@ -1,0 +1,74 @@
+package team.teamby.teambyteam.teamplace.application;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import team.teamby.teambyteam.common.ServiceTest;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberIdAndDisplayNameOnly;
+import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
+import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
+import team.teamby.teambyteam.teamplace.domain.vo.Name;
+
+import java.util.Optional;
+
+class TeamPlaceServiceTest extends ServiceTest {
+
+    @Autowired
+    private TeamPlaceService teamPlaceService;
+
+    @Autowired
+    private TeamPlaceRepository teamPlaceRepository;
+
+    @Autowired
+    private MemberTeamPlaceRepository memberTeamPlaceRepository;
+
+    @Nested
+    @DisplayName("팀플레이스 생성시")
+    class CreateTeamPlaceTest {
+
+        @Test
+        @DisplayName("생성에 성공한다.")
+        void success() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final String TEAM_PLACE_NAME = "새로운 팀플레이스";
+
+            // when
+            final TeamPlaceCreateResponse response = teamPlaceService.create(new MemberEmailDto(PHILIP.getEmail().getValue()), TEAM_PLACE_NAME);
+
+            //then
+            Optional<TeamPlace> createdTeamPlace = teamPlaceRepository.findById(response.teamPlaceId());
+            Optional<MemberIdAndDisplayNameOnly> memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(response.teamPlaceId(), PHILIP.getId());
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.teamPlaceId()).isNotNull();
+                softly.assertThat(createdTeamPlace).isNotEmpty();
+                softly.assertThat(createdTeamPlace.get().getName()).isEqualTo(new Name(TEAM_PLACE_NAME));
+                softly.assertThat(memberTeamPlace).isNotEmpty();
+                softly.assertThat(memberTeamPlace.get().displayMemberName()).isEqualTo(new DisplayMemberName(PHILIP.getName().getValue()));
+            });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자 아이디로 요청시 실패한다.")
+        void failWithUnauthorizedEmail() {
+            // given
+            final Member PHILIP = MemberFixtures.PHILIP();
+            final String TEAM_PLACE_NAME = "새로운 팀플레이스";
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> teamPlaceService.create(new MemberEmailDto(PHILIP.getEmail().getValue()), TEAM_PLACE_NAME))
+                    .isInstanceOf(MemberException.MemberNotFoundException.class)
+                    .hasMessage("조회한 멤버가 존재하지 않습니다.");
+        }
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
@@ -10,9 +10,10 @@ import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
-import team.teamby.teambyteam.member.domain.MemberIdAndDisplayNameOnly;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
+import team.teamby.teambyteam.member.domain.vo.DisplayTeamPlaceName;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
@@ -48,13 +49,14 @@ class TeamPlaceServiceTest extends ServiceTest {
 
             //then
             Optional<TeamPlace> createdTeamPlace = teamPlaceRepository.findById(response.teamPlaceId());
-            Optional<MemberIdAndDisplayNameOnly> memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(response.teamPlaceId(), PHILIP.getId());
+            Optional<MemberTeamPlace> memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(response.teamPlaceId(), PHILIP.getId());
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(response.teamPlaceId()).isNotNull();
                 softly.assertThat(createdTeamPlace).isNotEmpty();
                 softly.assertThat(createdTeamPlace.get().getName()).isEqualTo(new Name(TEAM_PLACE_NAME));
                 softly.assertThat(memberTeamPlace).isNotEmpty();
-                softly.assertThat(memberTeamPlace.get().displayMemberName()).isEqualTo(new DisplayMemberName(PHILIP.getName().getValue()));
+                softly.assertThat(memberTeamPlace.get().getDisplayMemberName()).isEqualTo(new DisplayMemberName(PHILIP.getName().getValue()));
+                softly.assertThat(memberTeamPlace.get().getDisplayTeamPlaceName()).isEqualTo(new DisplayTeamPlaceName(TEAM_PLACE_NAME));
             });
         }
 


### PR DESCRIPTION
## 이슈번호
> close #321

## PR 내용

- 팀플레이스 생성 api 구현
- 팀플레이스 생성시 요청한 멤버는 해당 팀플레이스에 자동 소속

## 참고자료

## 의논할 거리
