### PR TITLE
[BE] 팀플레이스 탈퇴 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.teamby.teambyteam.auth.exception.AuthenticationException;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
@@ -42,7 +43,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {
             MemberException.MemberNotFoundException.class,
             TeamPlaceException.NotFoundException.class,
-            ScheduleException.ScheduleNotFoundException.class
+            ScheduleException.ScheduleNotFoundException.class,
+            MemberTeamPlaceException.NotFoundException.class
     })
     public ResponseEntity<String> handleNotFoundException(final RuntimeException exception) {
         final String message = exception.getMessage();

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
+import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
@@ -30,6 +31,14 @@ public class MemberService {
         final List<MemberTeamPlace> allByMemberId = memberTeamPlaceRepository.findAllByMemberId(memberId.id());
 
         return TeamPlacesResponse.of(allByMemberId);
+    }
+
+    public void leaveTeamPlace(final MemberEmailDto memberEmailDto, final Long teamPlaceId) {
+        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+
+        final MemberTeamPlace memberTeamPlaceToLeave = member.leaveTeamPlace(teamPlaceId);
+        memberTeamPlaceRepository.delete(memberTeamPlaceToLeave);
     }
 
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -15,8 +15,8 @@ import team.teamby.teambyteam.global.domain.BaseEntity;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.domain.vo.Name;
 import team.teamby.teambyteam.member.domain.vo.ProfileImageUrl;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -87,7 +87,7 @@ public class Member extends BaseEntity {
         final MemberTeamPlace teamPlaceToLeave = memberTeamPlaces.stream()
                 .filter(memberTeamPlace -> memberTeamPlace.getTeamPlace().getId().equals(teamPlaceId))
                 .findAny()
-                .orElseThrow(TeamPlaceException.TeamPlaceAccessForbidden::new);
+                .orElseThrow(MemberTeamPlaceException.NotFoundException::new);
 
         memberTeamPlaces.remove(teamPlaceToLeave);
         return teamPlaceToLeave;

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -16,6 +16,7 @@ import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.domain.vo.Name;
 import team.teamby.teambyteam.member.domain.vo.ProfileImageUrl;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,5 +81,15 @@ public class Member extends BaseEntity {
         return getMemberTeamPlaces().stream()
                 .mapToLong(memberTeamPlace -> memberTeamPlace.getTeamPlace().getId())
                 .anyMatch(teamPlaceId -> teamPlaceId == targetTeamPlaceId);
+    }
+
+    public MemberTeamPlace leaveTeamPlace(final Long teamPlaceId) {
+        final MemberTeamPlace teamPlaceToLeave = memberTeamPlaces.stream()
+                .filter(memberTeamPlace -> memberTeamPlace.getTeamPlace().getId().equals(teamPlaceId))
+                .findAny()
+                .orElseThrow(TeamPlaceException.TeamPlaceAccessForbidden::new);
+
+        memberTeamPlaces.remove(teamPlaceToLeave);
+        return teamPlaceToLeave;
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberTeamPlaceException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberTeamPlaceException.java
@@ -29,4 +29,10 @@ public class MemberTeamPlaceException extends RuntimeException {
             super("팀플레이스의 이름은 공백을 제외한 1자 이상이어야합니다.");
         }
     }
+
+    public static class NotFoundException extends MemberTeamPlaceException {
+        public NotFoundException() {
+            super("가입된 팀플레이스를 찾을 수 없습니다.");
+        }
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -2,7 +2,9 @@ package team.teamby.teambyteam.member.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.application.MemberService;
@@ -18,10 +20,16 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/team-places")
-    public ResponseEntity<TeamPlacesResponse> getParticipatedTeamPlaces(@AuthPrincipal MemberEmailDto memberEmailDto) {
+    public ResponseEntity<TeamPlacesResponse> getParticipatedTeamPlaces(@AuthPrincipal final MemberEmailDto memberEmailDto) {
         final TeamPlacesResponse participatedTeamPlaces = memberService.getParticipatedTeamPlaces(memberEmailDto);
 
         return ResponseEntity.ok(participatedTeamPlaces);
     }
 
+    @DeleteMapping("/team-places/{teamPlaceId}")
+    public ResponseEntity<Void> leaveTeamPlace(@AuthPrincipal final MemberEmailDto memberEmailDto, @PathVariable final Long teamPlaceId) {
+        memberService.leaveTeamPlace(memberEmailDto, teamPlaceId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -18,4 +18,13 @@ public class MemberAcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> DELETE_LEAVE_TEAM_PLACE(final String token, final Long teamPlaceId) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .when().log().all()
+                .delete("/api/me/team-places/{teamPlaceId}", teamPlaceId)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.member.application;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,7 +13,10 @@ import team.teamby.teambyteam.member.application.dto.TeamPlaceResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.List;
 
@@ -22,6 +26,9 @@ class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;
+
+    @Autowired
+    private MemberTeamPlaceRepository memberTeamPlaceRepository;
 
     @Nested
     @DisplayName("사용자가 속한 팀플레이스들의 정보 조회시")
@@ -68,6 +75,42 @@ class MemberServiceTest extends ServiceTest {
 
             //then
             assertThat(response.teamPlaces()).hasSize(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("팀플레이스에서 탈퇴시")
+    class LeaveTeamPlace {
+
+        @Test
+        @DisplayName("팀플레이스 탈퇴에 성공한다.")
+        void success() {
+            // given
+            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
+
+            // when
+            memberService.leaveTeamPlace(new MemberEmailDto(ENDEL.getEmail().getValue()), ENGLISH_TEAM_PLACE.getId());
+
+            //then
+            final List<MemberTeamPlace> allParticipatedTeamPlaces = memberTeamPlaceRepository.findAllByMemberId(ENDEL.getId());
+            assertThat(allParticipatedTeamPlaces).hasSize(0);
+        }
+
+        @Test
+        @DisplayName("소속되지 않은 팀플레이스 탈퇴 시도시 접근할 수 없다는 예외를 발생시킨다.")
+        void failWithUnParticipatedTeamPlace() {
+            // given
+            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> memberService.leaveTeamPlace(new MemberEmailDto(ENDEL.getEmail().getValue()), JAPANESE_TEAM_PLACE.getId()))
+                    .isInstanceOf(TeamPlaceException.TeamPlaceAccessForbidden.class)
+                    .hasMessage("접근할 수 없는 팀플레이스입니다.");
         }
     }
 

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -15,8 +15,8 @@ import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.List;
 
@@ -109,8 +109,8 @@ class MemberServiceTest extends ServiceTest {
 
             // when & then
             Assertions.assertThatThrownBy(() -> memberService.leaveTeamPlace(new MemberEmailDto(ENDEL.getEmail().getValue()), JAPANESE_TEAM_PLACE.getId()))
-                    .isInstanceOf(TeamPlaceException.TeamPlaceAccessForbidden.class)
-                    .hasMessage("접근할 수 없는 팀플레이스입니다.");
+                    .isInstanceOf(MemberTeamPlaceException.NotFoundException.class)
+                    .hasMessage("가입된 팀플레이스를 찾을 수 없습니다.");
         }
     }
 


### PR DESCRIPTION
## 이슈번호
> close #285

## PR 내용

- 팀플레이스 탈퇴 기능 추가
- 팀플레이스 탈퇴 기능 로직 위치 : member domain
- 가입해있지 않은 팀플레이스 아이디로 탈퇴 요청시 404
  - 403아닌 이유 : 해당 아이디의 팀플레이스의 실제 존재 유무에대한 정보를 안주는것이 좋다고 생각
  - 본인이 가입한 팀플레이스 아이디중에서만 확인 후 없으면 바로 404

## 참고자료

## 의논할 거리
