### PR TITLE
[BE] 팀플레이스 가입 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/presentation/TeamPlaceParticipationInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/presentation/TeamPlaceParticipationInterceptor.java
@@ -14,11 +14,13 @@ import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
 public final class TeamPlaceParticipationInterceptor implements HandlerInterceptor {
 
+    private static final String PATH_VARIABLE_KEY = "teamPlaceId";
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
@@ -28,7 +30,10 @@ public final class TeamPlaceParticipationInterceptor implements HandlerIntercept
         final String token = jwtTokenExtractor.extractToken(request);
         final String email = jwtTokenProvider.extractEmailFromToken(token);
         final Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        final Long teamPlaceId = Long.parseLong(pathVariables.get("teamPlaceId"));
+        if (Objects.isNull(pathVariables.get(PATH_VARIABLE_KEY))) {
+            return true;
+        }
+        final Long teamPlaceId = Long.parseLong(pathVariables.get(PATH_VARIABLE_KEY));
 
         if (hasNotMemberInTeamPlace(teamPlaceId, email)) {
             throw new TeamPlaceException.TeamPlaceAccessForbidden();

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -77,7 +77,10 @@ public class GlobalExceptionHandler {
                 .body(message);
     }
 
-    @ExceptionHandler(value = {ScheduleException.SpanWrongOrderException.class})
+    @ExceptionHandler(value = {
+            ScheduleException.SpanWrongOrderException.class,
+            TeamPlaceInviteCodeException.LengthException.class
+    })
     public ResponseEntity<String> handleCustomBadRequestException(final RuntimeException exception) {
         final String message = exception.getMessage();
         log.warn(message, exception);

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import team.teamby.teambyteam.auth.exception.AuthenticationException;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceInviteCodeException;
 
 import java.time.DateTimeException;
 import java.time.format.DateTimeParseException;
@@ -42,7 +43,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {
             MemberException.MemberNotFoundException.class,
             TeamPlaceException.NotFoundException.class,
-            ScheduleException.ScheduleNotFoundException.class
+            ScheduleException.ScheduleNotFoundException.class,
+            TeamPlaceInviteCodeException.NotFoundException.class
     })
     public ResponseEntity<String> handleNotFoundException(final RuntimeException exception) {
         final String message = exception.getMessage();

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -43,7 +43,9 @@ public class MemberService {
     public TeamPlaceParticipantResponse participateTeamPlace(final MemberEmailDto memberEmailDto, final String inviteCode) {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(MemberException.MemberNotFoundException::new);
-        final TeamPlaceInviteCode teamPlaceInviteCode = teamPlaceInviteCodeRepository.findByInviteCode(new InviteCode(inviteCode))
+
+        final InviteCode inviteCodeVo = validteInviteCode(inviteCode);
+        final TeamPlaceInviteCode teamPlaceInviteCode = teamPlaceInviteCodeRepository.findByInviteCode(inviteCodeVo)
                 .orElseThrow(TeamPlaceInviteCodeException.NotFoundException::new);
         final TeamPlace teamPlace = teamPlaceInviteCode.getTeamPlace();
         if (member.isMemberOf(teamPlace.getId())) {
@@ -54,5 +56,15 @@ public class MemberService {
         memberTeamPlaceRepository.save(participatedMemberTeamPlace);
 
         return new TeamPlaceParticipantResponse(teamPlace.getId());
+    }
+
+    private InviteCode validteInviteCode(final String inviteCode) {
+        InviteCode inviteCodeVo;
+        try {
+            inviteCodeVo = new InviteCode(inviteCode);
+        } catch (IllegalArgumentException e) {
+            throw new TeamPlaceInviteCodeException.LengthException();
+        }
+        return inviteCodeVo;
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -6,11 +6,18 @@ import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
+import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.domain.TeamPlaceInviteCode;
+import team.teamby.teambyteam.teamplace.domain.TeamPlaceInviteCodeRepository;
+import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
+import team.teamby.teambyteam.teamplace.exception.TeamPlaceInviteCodeException;
 
 import java.util.List;
 
@@ -21,6 +28,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberTeamPlaceRepository memberTeamPlaceRepository;
+    private final TeamPlaceInviteCodeRepository teamPlaceInviteCodeRepository;
 
     @Transactional(readOnly = true)
     public TeamPlacesResponse getParticipatedTeamPlaces(final MemberEmailDto memberEmailDto) {
@@ -32,4 +40,19 @@ public class MemberService {
         return TeamPlacesResponse.of(allByMemberId);
     }
 
+    public TeamPlaceParticipantResponse participateTeamPlace(final MemberEmailDto memberEmailDto, final String inviteCode) {
+        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+        final TeamPlaceInviteCode teamPlaceInviteCode = teamPlaceInviteCodeRepository.findByInviteCode(new InviteCode(inviteCode))
+                .orElseThrow(TeamPlaceInviteCodeException.NotFoundException::new);
+        final TeamPlace teamPlace = teamPlaceInviteCode.getTeamPlace();
+        if (member.isMemberOf(teamPlace.getId())) {
+            return new TeamPlaceParticipantResponse(teamPlace.getId());
+        }
+
+        final MemberTeamPlace participatedMemberTeamPlace = member.participate(teamPlace);
+        memberTeamPlaceRepository.save(participatedMemberTeamPlace);
+
+        return new TeamPlaceParticipantResponse(teamPlace.getId());
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -1,14 +1,18 @@
 package team.teamby.teambyteam.member.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.application.MemberService;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
 
 @RestController
 @RequestMapping("/api/me")
@@ -24,4 +28,13 @@ public class MemberController {
         return ResponseEntity.ok(participatedTeamPlaces);
     }
 
+    @PostMapping("/team-places/{inviteCode}")
+    public ResponseEntity<TeamPlaceParticipantResponse> getParticipatedTeamPlaces(
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
+            @PathVariable final String inviteCode
+    ) {
+        final TeamPlaceParticipantResponse response = memberService.participateTeamPlace(memberEmailDto, inviteCode);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceParticipantResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceParticipantResponse.java
@@ -1,0 +1,4 @@
+package team.teamby.teambyteam.teamplace.application.dto;
+
+public record TeamPlaceParticipantResponse(Long teamPlaceId) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceInviteCodeRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceInviteCodeRepository.java
@@ -9,6 +9,8 @@ public interface TeamPlaceInviteCodeRepository extends JpaRepository<TeamPlaceIn
 
     Optional<TeamPlaceInviteCode> findByTeamPlaceId(final Long teamPlaceId);
 
+    Optional<TeamPlaceInviteCode> findByInviteCode(final InviteCode inviteCode);
+
     boolean existsByTeamPlaceId(final Long teamPlaceId);
 
     boolean existsByInviteCode(final InviteCode inviteCode);

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/vo/InviteCode.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/vo/InviteCode.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.teamplace.exception.TeamPlaceInviteCodeException;
 
 import java.util.Objects;
 
@@ -16,9 +15,9 @@ import java.util.Objects;
 @Getter
 public final class InviteCode {
 
-    private static final int MAX_LENGTH = 8;
+    private static final int LENGTH = 8;
 
-    @Column(name = "invite_code", nullable = false, length = MAX_LENGTH, unique = true)
+    @Column(name = "invite_code", nullable = false, length = LENGTH, unique = true)
     private String value;
 
     public InviteCode(final String value) {
@@ -30,8 +29,8 @@ public final class InviteCode {
         if (Objects.isNull(value)) {
             throw new NullPointerException("팀 플레이스 초대코드는 null일 수 없습니다.");
         }
-        if (value.length() != MAX_LENGTH) {
-            throw new TeamPlaceInviteCodeException.LengthException();
+        if (value.length() != LENGTH) {
+            throw new IllegalArgumentException("맞지 않는 길이입니다.");
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -19,7 +19,7 @@ public class MemberAcceptanceFixture {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> PARTICIPATE_TEAM_PLACE(final String token, final String inviteCode) {
+    public static ExtractableResponse<Response> PARTICIPATE_TEAM_PLACE_REQUEST(final String token, final String inviteCode) {
         return RestAssured.given().log().all()
                 .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
                 .when().log().all()

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -18,4 +18,13 @@ public class MemberAcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> PARTICIPATE_TEAM_PLACE(final String token, final String inviteCode) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .when().log().all()
+                .post("/api/me/team-places/{inviteCode}", inviteCode)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -19,7 +19,7 @@ import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
-import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.PARTICIPATE_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.PARTICIPATE_TEAM_PLACE_REQUEST;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -98,7 +98,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final String PHILIP_TOKEN = jwtTokenProvider.generateToken(PHILIP.getEmail().getValue());
 
             // when
-            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, inviteCode);
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, inviteCode);
 
             //then
             TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
@@ -117,10 +117,10 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final String inviteCode = "aaaaaaaa";
             testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), ENGLISH_TEAM_PLACE));
             final String PHILIP_TOKEN = jwtTokenProvider.generateToken(PHILIP.getEmail().getValue());
-            PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, inviteCode);
+            PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, inviteCode);
 
             // when
-            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, inviteCode);
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, inviteCode);
 
             //then
             TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
@@ -140,7 +140,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final String invalidInviteCode = "aaaaaaaa";
 
             // when
-            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, invalidInviteCode);
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, invalidInviteCode);
 
             //then
             SoftAssertions.assertSoftly(softly -> {
@@ -158,7 +158,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final String invalidInviteCode = "aaaa";
 
             // when
-            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, invalidInviteCode);
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, invalidInviteCode);
 
             //then
             SoftAssertions.assertSoftly(softly -> {
@@ -176,7 +176,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), teamPlace));
 
             // when
-            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(WRONG_TOKEN, inviteCode);
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(WRONG_TOKEN, inviteCode);
 
             //then
             SoftAssertions.assertSoftly(softly -> {

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -149,6 +149,24 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
+        @DisplayName("양식에 맞지 않는 초대코드로 요청 시 예외를 반환한다.")
+        void failIfInvalidInviteCode() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final String PHILIP_TOKEN = jwtTokenProvider.generateToken(PHILIP.getEmail().getValue());
+            final String invalidInviteCode = "aaaa";
+
+            // when
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, invalidInviteCode);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            });
+        }
+
+        @Test
         @DisplayName("잘못된 인증 토큰으로 요청시 401 에러를 반환한다.")
         void failWithWrongToken() {
             // given

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -12,10 +12,14 @@ import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+import team.teamby.teambyteam.teamplace.domain.TeamPlaceInviteCode;
+import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.PARTICIPATE_TEAM_PLACE;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -76,6 +80,90 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자가 참여코드로 팀플레이스 참가 시")
+    class ParticipantTeamPlace {
+
+        @Test
+        @DisplayName("참여에 성공한다.")
+        void success() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final String inviteCode = "aaaaaaaa";
+            testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), ENGLISH_TEAM_PLACE));
+            final String PHILIP_TOKEN = jwtTokenProvider.generateToken(PHILIP.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, inviteCode);
+
+            //then
+            TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+                softly.assertThat(teamPlaceParticipantResponse.teamPlaceId()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("중복 참여시 아무일도 일어나지 않는다.")
+        void successIfDuplicateRequest() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final String inviteCode = "aaaaaaaa";
+            testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), ENGLISH_TEAM_PLACE));
+            final String PHILIP_TOKEN = jwtTokenProvider.generateToken(PHILIP.getEmail().getValue());
+            PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, inviteCode);
+
+            // when
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, inviteCode);
+
+            //then
+            TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+                softly.assertThat(teamPlaceParticipantResponse.teamPlaceId()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("없는 참여코드로 요청 시 예외를 반환한다.")
+        void failIfNotExistsInviteCode() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final String PHILIP_TOKEN = jwtTokenProvider.generateToken(PHILIP.getEmail().getValue());
+            final String invalidInviteCode = "aaaaaaaa";
+
+            // when
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(PHILIP_TOKEN, invalidInviteCode);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            });
+        }
+
+        @Test
+        @DisplayName("잘못된 인증 토큰으로 요청시 401 에러를 반환한다.")
+        void failWithWrongToken() {
+            // given
+            final String WRONG_TOKEN = "12j40jf390.0we9ru2i3hr8.912jrkejfi23j";
+            final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            final String inviteCode = "aaaaaaaa";
+            testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), teamPlace));
+
+            // when
+            final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE(WRONG_TOKEN, inviteCode);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            });
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -109,7 +109,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("중복 참여시 아무일도 일어나지 않는다.")
+        @DisplayName("이미 참여한 팀플레이스 기준으로 응답한다.")
         void successIfDuplicateRequest() {
             // given
             final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
@@ -149,7 +149,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("양식에 맞지 않는 초대코드로 요청 시 예외를 반환한다.")
+        @DisplayName("8자가 아닌 초대코드로 요청 시 예외를 반환한다.")
         void failIfInvalidInviteCode() {
             // given
             final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceInviteCodeRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceInviteCodeRepositoryTest.java
@@ -32,4 +32,20 @@ class TeamPlaceInviteCodeRepositoryTest extends RepositoryTest {
         //then
         assertThat(teamPlaceInviteCode.getInviteCode().getValue()).isEqualTo(inviteCode.getValue());
     }
+
+    @Test
+    @DisplayName("초대코드로 팀플레이스를 조회한다.")
+    public void getTeamPlaceByTeamPlaceInviteCode() {
+        //given
+        final TeamPlace teamPlace = ENGLISH_TEAM_PLACE();
+        final InviteCode inviteCode = new InviteCode(randomInviteCodeGenerator.generateRandomString());
+        final TeamPlace buildTeamPlace = testFixtureBuilder.buildTeamPlace(teamPlace);
+        testFixtureBuilder.buildTeamPlaceInviteCode(TEAM_PLACE_INVITE_CODE(inviteCode, teamPlace));
+
+        //when
+        final TeamPlaceInviteCode teamPlaceInviteCode = teamPlaceInviteCodeRepository.findByInviteCode(inviteCode).get();
+
+        //then
+        assertThat(teamPlaceInviteCode.getTeamPlace()).isEqualTo(buildTeamPlace);
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/vo/InviteCodeTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/domain/vo/InviteCodeTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import team.teamby.teambyteam.teamplace.exception.TeamPlaceInviteCodeException;
 
 class InviteCodeTest {
 
@@ -38,7 +37,7 @@ class InviteCodeTest {
     void failInviteCodeNotLength8(final String value) {
         // given & when & then
         Assertions.assertThatThrownBy(() -> new InviteCode(value))
-                .isInstanceOf(TeamPlaceInviteCodeException.LengthException.class)
-                .hasMessage("팀 플레이스의 초대코드의 길이가 맞지 않습니다.");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("맞지 않는 길이입니다.");
     }
 }


### PR DESCRIPTION
## 이슈번호
#284 

## PR 내용
멤버 정보와 초대코드를 이용해 팀플레이스를 가입한다.
이미 가입한 상태에서 재요청을 하는 경우 반환값은 동일하다.
없는 초대코드를 사용하는 경우 404를 반환한다.
잘못된 길이(!=8)의 초대코드로 요청하는 경우 400을 반환한다.

## 참고자료

## 의논할 거리
