### PR TITLE
[FE]팀 참가, 생성 페이지 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,10 @@ import LoginPage from '~/pages/LoginPage/LoginPage';
 import PageTemplate from '~/pages/PageTemplate/PageTemplate';
 import TeamCalendarPage from '~/pages/TeamCalendarPage/TeamCalendarPage';
 import TeamFeedPage from '~/pages/TeamFeedPage/TeamFeedPage';
+import StartPage from '~/pages/StartPage/StartPage';
 import TeamSelectPage from '~/pages/TeamSelectPage/TeamSelectPage';
+import CreatePage from '~/pages/CreatePage/CreatePage';
+import JoinPage from '~/pages/JoinPage/JoinPage';
 
 const App = () => {
   return (
@@ -14,6 +17,9 @@ const App = () => {
       <Route path={PATH_NAME.LANDING} element={<LandingPage />} />
       <Route path={PATH_NAME.LOGIN} element={<LoginPage />} />
       <Route element={<ProtectRoute />}>
+        <Route path={PATH_NAME.START} element={<StartPage />} />
+        <Route path={PATH_NAME.CREATE} element={<CreatePage />} />
+        <Route path={PATH_NAME.JOIN} element={<JoinPage />} />
         <Route element={<PageTemplate />}>
           <Route path={PATH_NAME.TEAM_SELECT} element={<TeamSelectPage />} />
           <Route

--- a/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
+++ b/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { PATH_NAME } from '~/constants/routes';
+import { TeamPlaceProvider } from '~/contexts/TeamPlaceContext';
 
 const ProtectRoute = () => {
   const navigate = useNavigate();
@@ -15,7 +16,11 @@ const ProtectRoute = () => {
     }
   }, []);
 
-  return <Outlet />;
+  return (
+    <TeamPlaceProvider>
+      <Outlet />
+    </TeamPlaceProvider>
+  );
 };
 
 export default ProtectRoute;

--- a/frontend/src/components/common/Text/Text.styled.ts
+++ b/frontend/src/components/common/Text/Text.styled.ts
@@ -5,6 +5,7 @@ import type { TextProps, Weight } from './Text';
 const fontWeight: Record<Weight, number> = {
   light: 100,
   normal: 400,
+  semiBold: 600,
   bold: 800,
 };
 

--- a/frontend/src/components/common/Text/Text.tsx
+++ b/frontend/src/components/common/Text/Text.tsx
@@ -3,7 +3,7 @@ import type { CSSProp } from 'styled-components';
 import type { Size } from '~/types/size';
 import * as S from './Text.styled';
 
-export type Weight = 'light' | 'normal' | 'bold';
+export type Weight = 'light' | 'normal' | 'semiBold' | 'bold';
 export interface TextProps {
   as?:
     | 'h1'

--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -1,6 +1,9 @@
 export const PATH_NAME = {
   LANDING: '/',
   LOGIN: '/login',
+  START: '/start',
+  JOIN: '/join',
+  CREATE: '/create',
   TEAM_SELECT: '/team',
   TEAM_CALENDAR: '/team/calendar',
   TEAM_FEED: '/team/feed',

--- a/frontend/src/contexts/TeamPlaceContext.tsx
+++ b/frontend/src/contexts/TeamPlaceContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useCallback, useEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PATH_NAME } from '~/constants/routes';
 import { useFetchTeamPlaces } from '~/hooks/queries/useFetchTeamPlaces';
 import type { TeamPlace, TeamPlaceColor } from '~/types/team';
 import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
@@ -18,7 +20,7 @@ export const TeamPlaceContext = createContext<TeamPlaceContextProps>(
 
 export const TeamPlaceProvider = (props: PropsWithChildren) => {
   const { children } = props;
-  const teamPlaces = useFetchTeamPlaces();
+  const { teamPlaces } = useFetchTeamPlaces();
   const [teamPlaceId, setTeamPlaceId] = useState(0);
   const [teamPlaceColor, setTeamPlaceColor] = useState<TeamPlaceColor>(100);
   const [displayName, setDisplayName] = useState('');
@@ -46,10 +48,13 @@ export const TeamPlaceProvider = (props: PropsWithChildren) => {
   }, [changeTeamPlace]);
 
   useEffect(() => {
-    const initTeamPlaceId =
-      Number(localStorage.getItem('teamPlaceId')) ?? teamPlaces[0].id;
-    setTeamPlaceId(initTeamPlaceId);
-  }, []);
+    if (teamPlaces.length === 0) return;
+
+    const id = localStorage.getItem('teamPlaceId');
+    const initTeamPlaceId = id === null ? teamPlaces[0].id : Number(id);
+
+    changeTeamPlace(initTeamPlaceId);
+  }, [teamPlaces]);
 
   const value = {
     teamPlaces,

--- a/frontend/src/contexts/TeamPlaceContext.tsx
+++ b/frontend/src/contexts/TeamPlaceContext.tsx
@@ -20,7 +20,7 @@ export const TeamPlaceContext = createContext<TeamPlaceContextProps>(
 
 export const TeamPlaceProvider = (props: PropsWithChildren) => {
   const { children } = props;
-  const { teamPlaces } = useFetchTeamPlaces();
+  const { teamPlaces, isFetched } = useFetchTeamPlaces();
   const [teamPlaceId, setTeamPlaceId] = useState(0);
   const [teamPlaceColor, setTeamPlaceColor] = useState<TeamPlaceColor>(100);
   const [displayName, setDisplayName] = useState('');
@@ -40,21 +40,15 @@ export const TeamPlaceProvider = (props: PropsWithChildren) => {
   );
 
   useEffect(() => {
-    const id = localStorage.getItem('teamPlaceId');
+    if (!isFetched) return;
 
-    if (id) {
-      changeTeamPlace(Number(id));
-    }
-  }, [changeTeamPlace]);
-
-  useEffect(() => {
     if (teamPlaces.length === 0) return;
 
     const id = localStorage.getItem('teamPlaceId');
     const initTeamPlaceId = id === null ? teamPlaces[0].id : Number(id);
 
     changeTeamPlace(initTeamPlaceId);
-  }, [teamPlaces]);
+  }, [isFetched, changeTeamPlace]);
 
   const value = {
     teamPlaces,

--- a/frontend/src/contexts/TeamPlaceContext.tsx
+++ b/frontend/src/contexts/TeamPlaceContext.tsx
@@ -1,7 +1,5 @@
 import { createContext, useCallback, useEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { PATH_NAME } from '~/constants/routes';
 import { useFetchTeamPlaces } from '~/hooks/queries/useFetchTeamPlaces';
 import type { TeamPlace, TeamPlaceColor } from '~/types/team';
 import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
@@ -48,7 +46,7 @@ export const TeamPlaceProvider = (props: PropsWithChildren) => {
     const initTeamPlaceId = id === null ? teamPlaces[0].id : Number(id);
 
     changeTeamPlace(initTeamPlaceId);
-  }, [isFetched, changeTeamPlace]);
+  }, [isFetched, changeTeamPlace, teamPlaces]);
 
   const value = {
     teamPlaces,

--- a/frontend/src/hooks/queries/useFetchTeamPlaces.ts
+++ b/frontend/src/hooks/queries/useFetchTeamPlaces.ts
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchTeamPlaces } from '~/apis/team';
 
 export const useFetchTeamPlaces = () => {
-  const { data } = useQuery(['teamPlaces'], () => fetchTeamPlaces());
+  const { data, isFetched } = useQuery(['teamPlaces'], () => fetchTeamPlaces());
 
-  if (data === undefined) return [];
+  if (data === undefined) return { teamPlaces: [], isFetched };
 
   const { teamPlaces } = data;
 
-  return teamPlaces;
+  return { teamPlaces, isFetched };
 };

--- a/frontend/src/pages/CreatePage/CreatePage.styled.ts
+++ b/frontend/src/pages/CreatePage/CreatePage.styled.ts
@@ -32,7 +32,6 @@ export const TeamNameForm = styled.form`
 export const BodyContainer = styled.div`
   display: flex;
   flex-direction: column;
-
   gap: 22px;
 `;
 
@@ -80,6 +79,7 @@ export const submitButton = css`
   display: flex;
   justify-content: center;
   align-self: flex-end;
+
   width: 100px;
   border-radius: 10px;
 `;

--- a/frontend/src/pages/CreatePage/CreatePage.styled.ts
+++ b/frontend/src/pages/CreatePage/CreatePage.styled.ts
@@ -1,0 +1,85 @@
+import { css, styled } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  overflow-x: hidden;
+
+  width: 100vw;
+  height: 100vh;
+  padding-right: 120px;
+`;
+
+export const InnerContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 340px;
+  height: 380px;
+
+  animation: ${({ theme }) => theme.animation.slideLeft} 0.6s ease-in-out
+    forwards;
+`;
+
+export const TeamNameForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+`;
+
+export const BodyContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 22px;
+`;
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  height: 70px;
+
+  border-radius: 14px;
+
+  box-shadow:
+    0 0 1px #1b1d1f33,
+    0 15px 25px #1b1d1f33,
+    0 5px 10px #1b1d1f1f;
+`;
+
+export const explainText = css`
+  display: flex;
+  justify-content: center;
+  color: ${({ theme }) => theme.color.GRAY600};
+`;
+
+export const titleText = css`
+  display: flex;
+  justify-content: center;
+
+  width: 100%;
+
+  font-size: 32px;
+  color: ${({ theme }) => theme.color.PRIMARY};
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
+`;
+
+export const inputTitle = css`
+  padding: 10px 20px;
+
+  border: none;
+  border-radius: 14px;
+  background-color: transparent;
+
+  font-size: 24px;
+`;
+
+export const submitButton = css`
+  display: flex;
+  justify-content: center;
+  align-self: flex-end;
+  width: 100px;
+  border-radius: 10px;
+`;

--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -52,7 +52,7 @@ const CreatePage = () => {
               간단한 입력으로 쉽게 팀을 만들어 보세요!
             </Text>
           </S.BodyContainer>
-          <Button css={S.submitButton} aria-label="팀 생성버튼">
+          <Button css={S.submitButton} aria-label="팀 생성">
             팀 생성
           </Button>
         </S.TeamNameForm>

--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -1,0 +1,69 @@
+import Text from '~/components/common/Text/Text';
+import * as S from './CreatePage.styled';
+import Input from '~/components/common/Input/Input';
+import {
+  type ChangeEventHandler,
+  type FormEventHandler,
+  useState,
+  useRef,
+  useEffect,
+} from 'react';
+import Button from '~/components/common/Button/Button';
+
+const CreatePage = () => {
+  const [teamName, setTeamName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleTeamNameBlur: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setTeamName(() => e.target.value);
+  };
+
+  const handleTeamNameSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    const isRightName = confirm(`"${teamName}"으로 팀을 생성하시겠 습니까?`);
+
+    if (!isRightName) {
+      inputRef.current?.focus();
+      return;
+    }
+    alert(teamName);
+  };
+
+  return (
+    <S.Container>
+      <S.InnerContainer>
+        <Text weight="semiBold" css={S.titleText}>
+          팀 개설하기
+        </Text>
+        <S.TeamNameForm onSubmit={handleTeamNameSubmit}>
+          <S.BodyContainer>
+            <S.InputWrapper>
+              <Input
+                width="100%"
+                height="100%"
+                placeholder="팀 이름 입력"
+                css={S.inputTitle}
+                ref={inputRef}
+                onBlur={handleTeamNameBlur}
+                required
+              />
+            </S.InputWrapper>
+            <Text weight="semiBold" css={S.explainText}>
+              간단한 입력으로 쉽게 공간을 만들어 보세요!
+            </Text>
+          </S.BodyContainer>
+          <Button css={S.submitButton} aria-label="팀 생성버튼">
+            팀 생성
+          </Button>
+        </S.TeamNameForm>
+      </S.InnerContainer>
+    </S.Container>
+  );
+};
+
+export default CreatePage;

--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -42,9 +42,10 @@ const CreatePage = () => {
                 width="100%"
                 height="100%"
                 placeholder="팀 이름 입력"
-                css={S.inputTitle}
                 ref={inputRef}
+                value={teamName}
                 onChange={handleTeamNameChange}
+                css={S.inputTitle}
                 required
               />
             </S.InputWrapper>

--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -20,7 +20,7 @@ const CreatePage = () => {
   const handleTeamNameSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
 
-    const isRightName = confirm(`"${teamName}"으로 팀을 생성하시겠 습니까?`);
+    const isRightName = confirm(`"${teamName}"으로 팀을 생성하시겠습니까?`);
 
     if (!isRightName) {
       inputRef.current?.focus();
@@ -49,7 +49,7 @@ const CreatePage = () => {
               />
             </S.InputWrapper>
             <Text weight="semiBold" css={S.explainText}>
-              간단한 입력으로 쉽게 공간을 만들어 보세요!
+              간단한 입력으로 쉽게 팀을 만들어 보세요!
             </Text>
           </S.BodyContainer>
           <Button css={S.submitButton} aria-label="팀 생성버튼">

--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -13,7 +13,7 @@ const CreatePage = () => {
   const [teamName, setTeamName] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleTeamNameBlur: ChangeEventHandler<HTMLInputElement> = (e) => {
+  const handleTeamNameChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setTeamName(() => e.target.value);
   };
 
@@ -44,7 +44,7 @@ const CreatePage = () => {
                 placeholder="팀 이름 입력"
                 css={S.inputTitle}
                 ref={inputRef}
-                onBlur={handleTeamNameBlur}
+                onChange={handleTeamNameChange}
                 required
               />
             </S.InputWrapper>

--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -6,17 +6,12 @@ import {
   type FormEventHandler,
   useState,
   useRef,
-  useEffect,
 } from 'react';
 import Button from '~/components/common/Button/Button';
 
 const CreatePage = () => {
   const [teamName, setTeamName] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
 
   const handleTeamNameBlur: ChangeEventHandler<HTMLInputElement> = (e) => {
     setTeamName(() => e.target.value);

--- a/frontend/src/pages/JoinPage/JoinPage.styled.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.styled.tsx
@@ -1,0 +1,101 @@
+import { Link } from 'react-router-dom';
+import { css, styled } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  overflow-x: hidden;
+
+  width: 100vw;
+  height: 100vh;
+  padding-right: 120px;
+`;
+
+export const InnerContainer = styled.div<{ isLinkClicked: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 340px;
+  height: 380px;
+
+  animation: ${({ theme, isLinkClicked }) =>
+      isLinkClicked ? theme.animation.slideRight : theme.animation.slideLeft}
+    0.6s ease-in-out forwards;
+`;
+
+export const InviteCodeForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+`;
+
+export const BodyContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 22px;
+`;
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  height: 70px;
+
+  border-radius: 14px;
+
+  box-shadow:
+    0 0 1px #1b1d1f33,
+    0 15px 25px #1b1d1f33,
+    0 5px 10px #1b1d1f1f;
+`;
+
+export const createPageButton = css`
+  padding: 0;
+
+  font-size: 16px;
+  font-weight: 600;
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
+  color: ${({ theme }) => theme.color.PRIMARY};
+
+  &:hover {
+    opacity: 0.6;
+  }
+`;
+
+export const explainText = css`
+  margin-right: 10px;
+
+  color: ${({ theme }) => theme.color.GRAY600};
+`;
+
+export const titleText = css`
+  display: flex;
+  justify-content: center;
+
+  width: 100%;
+
+  font-size: 32px;
+  color: ${({ theme }) => theme.color.PRIMARY};
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
+`;
+
+export const inputTitle = css`
+  padding: 10px 20px;
+
+  border: none;
+  border-radius: 14px;
+  background-color: transparent;
+
+  font-size: 20px;
+`;
+
+export const submitButton = css`
+  display: flex;
+  justify-content: center;
+  align-self: flex-end;
+  width: 100px;
+  border-radius: 10px;
+`;

--- a/frontend/src/pages/JoinPage/JoinPage.styled.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.styled.tsx
@@ -34,7 +34,6 @@ export const InviteCodeForm = styled.form`
 export const BodyContainer = styled.div`
   display: flex;
   flex-direction: column;
-
   gap: 22px;
 `;
 
@@ -53,10 +52,10 @@ export const InputWrapper = styled.div`
 export const createPageButton = css`
   padding: 0;
 
+  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
+
   font-size: 16px;
   font-weight: 600;
-
-  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
   color: ${({ theme }) => theme.color.PRIMARY};
 
   &:hover {
@@ -76,10 +75,10 @@ export const titleText = css`
 
   width: 100%;
 
+  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
+
   font-size: 32px;
   color: ${({ theme }) => theme.color.PRIMARY};
-
-  border-bottom: 1px solid ${({ theme }) => theme.color.PRIMARY};
 `;
 
 export const inputTitle = css`
@@ -96,6 +95,8 @@ export const submitButton = css`
   display: flex;
   justify-content: center;
   align-self: flex-end;
+
   width: 100px;
+
   border-radius: 10px;
 `;

--- a/frontend/src/pages/JoinPage/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.tsx
@@ -31,7 +31,7 @@ const JoinPage = () => {
     });
   }, [isClicked]);
 
-  const handleInviteCodeBlur: ChangeEventHandler<HTMLInputElement> = (e) => {
+  const handleInviteCodeChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setInviteCode(() => e.target.value);
   };
 
@@ -66,7 +66,7 @@ const JoinPage = () => {
                 placeholder="팀 이름 입력"
                 css={S.inputTitle}
                 ref={inputRef}
-                onBlur={handleInviteCodeBlur}
+                onChange={handleInviteCodeChange}
                 required={isRequired}
               />
             </S.InputWrapper>

--- a/frontend/src/pages/JoinPage/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.tsx
@@ -1,0 +1,96 @@
+import Text from '~/components/common/Text/Text';
+import * as S from './JoinPage.styled';
+import Input from '~/components/common/Input/Input';
+import Button from '~/components/common/Button/Button';
+import {
+  type ChangeEventHandler,
+  type FormEventHandler,
+  type MouseEventHandler,
+  useRef,
+  useState,
+  useEffect,
+} from 'react';
+import { PATH_NAME } from '~/constants/routes';
+import { useNavigate } from 'react-router-dom';
+
+const JoinPage = () => {
+  const [inviteCode, setInviteCode] = useState('');
+  const [isClicked, setIsClicked] = useState(false);
+  const [isRequired, setIsRequired] = useState(true);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isClicked || ref.current === null) {
+      return;
+    }
+
+    ref.current.getAnimations().forEach((animation) => {
+      animation.onfinish = () => navigate(PATH_NAME.CREATE);
+    });
+  }, [isClicked]);
+
+  const handleInviteCodeBlur: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setInviteCode(() => e.target.value);
+  };
+
+  const handleTeamNameSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    alert(inviteCode);
+    inputRef.current?.focus();
+
+    return;
+  };
+
+  const handleCreatePageClicked: MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.preventDefault();
+
+    setIsRequired(false);
+    setIsClicked(true);
+  };
+
+  return (
+    <S.Container>
+      <S.InnerContainer ref={ref} isLinkClicked={isClicked}>
+        <Text weight="semiBold" css={S.titleText}>
+          팀 참가하기
+        </Text>
+        <S.InviteCodeForm onSubmit={handleTeamNameSubmit}>
+          <S.BodyContainer>
+            <S.InputWrapper>
+              <Input
+                width="100%"
+                height="100%"
+                placeholder="팀 이름 입력"
+                css={S.inputTitle}
+                ref={inputRef}
+                onBlur={handleInviteCodeBlur}
+                required={isRequired}
+              />
+            </S.InputWrapper>
+            <div>
+              <Text as="span" weight="semiBold" css={S.explainText}>
+                참여코드가 없으신가요?
+              </Text>
+              <Button
+                variant="plain"
+                css={S.createPageButton}
+                aria-label="팀 생성하기 페이지 이동 버튼"
+                onClick={handleCreatePageClicked}
+              >
+                직접 팀을 만들어보세요!
+              </Button>
+            </div>
+          </S.BodyContainer>
+          <Button css={S.submitButton} aria-label="팀 생성버튼">
+            팀 참가
+          </Button>
+        </S.InviteCodeForm>
+      </S.InnerContainer>
+    </S.Container>
+  );
+};
+
+export default JoinPage;

--- a/frontend/src/pages/JoinPage/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.tsx
@@ -47,8 +47,8 @@ const JoinPage = () => {
   const handleCreatePageClicked: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();
 
-    setIsRequired(false);
-    setIsClicked(true);
+    setIsRequired(() => false);
+    setIsClicked(() => true);
   };
 
   return (

--- a/frontend/src/pages/JoinPage/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.tsx
@@ -64,9 +64,10 @@ const JoinPage = () => {
                 width="100%"
                 height="100%"
                 placeholder="팀 이름 입력"
-                css={S.inputTitle}
                 ref={inputRef}
+                value={inviteCode}
                 onChange={handleInviteCodeChange}
+                css={S.inputTitle}
                 required={isRequired}
               />
             </S.InputWrapper>

--- a/frontend/src/pages/JoinPage/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.tsx
@@ -77,14 +77,14 @@ const JoinPage = () => {
               <Button
                 variant="plain"
                 css={S.createPageButton}
-                aria-label="팀 생성하기 페이지 이동 버튼"
+                aria-label="팀 생성하기 페이지 이동"
                 onClick={handleCreatePageClicked}
               >
                 직접 팀을 만들어보세요!
               </Button>
             </div>
           </S.BodyContainer>
-          <Button css={S.submitButton} aria-label="팀 생성버튼">
+          <Button css={S.submitButton} aria-label="팀 참가">
             팀 참가
           </Button>
         </S.InviteCodeForm>

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
 const LandingPage = () => {
   const navigate = useNavigate();
   const accessToken = localStorage.getItem('accessToken');
+  const teamPlaceId = localStorage.getItem('teamPlaceId');
 
   const handleGoogleLogin = async () => {
     const { googleLoginUrl } = await fetchGoogleLogin();
@@ -20,8 +21,13 @@ const LandingPage = () => {
   };
 
   useEffect(() => {
-    if (accessToken) {
+    if (accessToken && teamPlaceId) {
       navigate(PATH_NAME.TEAM_SELECT);
+      return;
+    }
+
+    if (accessToken) {
+      localStorage.removeItem('accessToken');
       return;
     }
   }, []);

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -7,8 +7,6 @@ import { useEffect } from 'react';
 
 const LandingPage = () => {
   const navigate = useNavigate();
-  const accessToken = localStorage.getItem('accessToken');
-  const teamPlaceId = localStorage.getItem('teamPlaceId');
 
   const handleGoogleLogin = async () => {
     const { googleLoginUrl } = await fetchGoogleLogin();
@@ -21,6 +19,9 @@ const LandingPage = () => {
   };
 
   useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    const teamPlaceId = localStorage.getItem('teamPlaceId');
+
     if (accessToken && teamPlaceId) {
       navigate(PATH_NAME.TEAM_SELECT);
       return;

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -7,10 +7,11 @@ const LoginPage = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const accessToken = params.get('accessToken');
-  localStorage.setItem('accessToken', accessToken ?? '');
   const { teamPlaces, isFetched } = useFetchTeamPlaces();
 
   useEffect(() => {
+    localStorage.setItem('accessToken', accessToken ?? '');
+
     if (!accessToken) {
       alert('로그인이 필요합니다.');
       localStorage.removeItem('accessToken');

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -1,24 +1,32 @@
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { PATH_NAME } from '~/constants/routes';
+import { useFetchTeamPlaces } from '~/hooks/queries/useFetchTeamPlaces';
 
 const LoginPage = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const accessToken = params.get('accessToken');
+  localStorage.setItem('accessToken', accessToken ?? '');
+  const { teamPlaces, isFetched } = useFetchTeamPlaces();
 
   useEffect(() => {
     if (!accessToken) {
       alert('로그인이 필요합니다.');
+      localStorage.removeItem('accessToken');
       navigate(PATH_NAME.LANDING);
 
       return;
     }
-
-    localStorage.setItem('accessToken', accessToken);
-    navigate(PATH_NAME.TEAM_SELECT);
   }, []);
 
+  useEffect(() => {
+    if (isFetched) {
+      teamPlaces.length === 0
+        ? navigate(PATH_NAME.START)
+        : navigate(PATH_NAME.TEAM_SELECT);
+    }
+  }, [isFetched]);
   return <></>;
 };
 

--- a/frontend/src/pages/PageTemplate/PageTemplate.tsx
+++ b/frontend/src/pages/PageTemplate/PageTemplate.tsx
@@ -3,18 +3,17 @@ import NavigationBar from '~/components/common/NavigationBar/NavigationBar';
 import SideBar from '~/components/common/SideBar/SideBar';
 import { Outlet } from 'react-router-dom';
 import Header from '~/components/common/Header/Header';
-import { TeamPlaceProvider } from '~/contexts/TeamPlaceContext';
 
 const PageTemplate = () => {
   return (
-    <TeamPlaceProvider>
+    <>
       <Header />
       <S.Container>
         <NavigationBar />
         <Outlet />
         <SideBar />
       </S.Container>
-    </TeamPlaceProvider>
+    </>
   );
 };
 

--- a/frontend/src/pages/StartPage/StartPage.styled.ts
+++ b/frontend/src/pages/StartPage/StartPage.styled.ts
@@ -4,19 +4,24 @@ export const Container = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  overflow-x: hidden;
 
   width: 100vw;
   height: 100vh;
   padding-right: 120px;
 `;
 
-export const InnerContainer = styled.div`
+export const InnerContainer = styled.div<{ clickedButton: string | undefined }>`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 
   width: 340px;
   height: 460px;
+
+  animation: ${({ theme, clickedButton }) =>
+      clickedButton && theme.animation.slideRight}
+    0.6s ease-in-out forwards;
 `;
 
 export const ButtonContainer = styled.div`

--- a/frontend/src/pages/StartPage/StartPage.styled.ts
+++ b/frontend/src/pages/StartPage/StartPage.styled.ts
@@ -27,7 +27,6 @@ export const InnerContainer = styled.div<{ clickedButton: string | undefined }>`
 export const ButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
-
   gap: 10px;
 `;
 

--- a/frontend/src/pages/StartPage/StartPage.styled.ts
+++ b/frontend/src/pages/StartPage/StartPage.styled.ts
@@ -1,0 +1,48 @@
+import { css, styled } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+
+  width: 100vw;
+  height: 100vh;
+  padding-right: 120px;
+`;
+
+export const InnerContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 340px;
+  height: 460px;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 10px;
+`;
+
+export const explainText = css`
+  color: ${({ theme }) => theme.color.GRAY600};
+`;
+
+export const startTeamButton = (variant?: 'normal') => css`
+  width: 100%;
+  height: 70px;
+  padding: 16px 80px;
+
+  border-radius: 14px;
+
+  font-size: 32px;
+  font-weight: 600;
+  color: ${({ theme }) => variant === 'normal' && theme.color.PRIMARY};
+
+  box-shadow:
+    0 0 1px #1b1d1f33,
+    0 15px 25px #1b1d1f33,
+    0 5px 10px #1b1d1f1f;
+`;

--- a/frontend/src/pages/StartPage/StartPage.tsx
+++ b/frontend/src/pages/StartPage/StartPage.tsx
@@ -1,0 +1,38 @@
+import Text from '~/components/common/Text/Text';
+import * as S from './StartPage.styled';
+import Button from '~/components/common/Button/Button';
+
+const StartPage = () => {
+  return (
+    <S.Container>
+      <S.InnerContainer>
+        <S.ButtonContainer>
+          <Text weight="semiBold" css={S.explainText}>
+            우리 팀만의 공간이 필요하신가요?
+          </Text>
+          <Button
+            variant="primary"
+            css={S.startTeamButton()}
+            aria-label="팀 개설하기 버튼"
+          >
+            팀 개설하기
+          </Button>
+        </S.ButtonContainer>
+        <S.ButtonContainer>
+          <Text weight="semiBold" css={S.explainText}>
+            초대코드가 있으신가요?
+          </Text>
+          <Button
+            variant="normal"
+            css={S.startTeamButton('normal')}
+            aria-label="팀 개설하기 버튼"
+          >
+            팀 참가하기
+          </Button>
+        </S.ButtonContainer>
+      </S.InnerContainer>
+    </S.Container>
+  );
+};
+
+export default StartPage;

--- a/frontend/src/pages/StartPage/StartPage.tsx
+++ b/frontend/src/pages/StartPage/StartPage.tsx
@@ -40,7 +40,7 @@ const StartPage = () => {
             variant="primary"
             css={S.startTeamButton()}
             onClick={() => handleButtonClick('create')}
-            aria-label="팀 생성하기 버튼"
+            aria-label="팀 생성하기"
           >
             팀 생성하기
           </Button>
@@ -53,6 +53,7 @@ const StartPage = () => {
             variant="normal"
             css={S.startTeamButton('normal')}
             onClick={() => handleButtonClick('join')}
+            aria-label="팀 참가하기"
           >
             팀 참가하기
           </Button>

--- a/frontend/src/pages/StartPage/StartPage.tsx
+++ b/frontend/src/pages/StartPage/StartPage.tsx
@@ -1,11 +1,37 @@
 import Text from '~/components/common/Text/Text';
 import * as S from './StartPage.styled';
 import Button from '~/components/common/Button/Button';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PATH_NAME } from '~/constants/routes';
+
+type StartType = 'create' | 'join';
 
 const StartPage = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [clickedButton, setClickedButton] = useState<StartType>();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!clickedButton || ref.current === null) {
+      return;
+    }
+
+    ref.current.getAnimations().forEach((animation) => {
+      animation.onfinish = () =>
+        clickedButton === 'create'
+          ? navigate(PATH_NAME.CREATE)
+          : navigate(PATH_NAME.JOIN);
+    });
+  }, [clickedButton]);
+
+  const handleButtonClick = (value: StartType) => {
+    setClickedButton(() => value);
+  };
+
   return (
     <S.Container>
-      <S.InnerContainer>
+      <S.InnerContainer ref={ref} clickedButton={clickedButton}>
         <S.ButtonContainer>
           <Text weight="semiBold" css={S.explainText}>
             우리 팀만의 공간이 필요하신가요?
@@ -13,9 +39,10 @@ const StartPage = () => {
           <Button
             variant="primary"
             css={S.startTeamButton()}
-            aria-label="팀 개설하기 버튼"
+            onClick={() => handleButtonClick('create')}
+            aria-label="팀 생성하기 버튼"
           >
-            팀 개설하기
+            팀 생성하기
           </Button>
         </S.ButtonContainer>
         <S.ButtonContainer>
@@ -25,6 +52,7 @@ const StartPage = () => {
           <Button
             variant="normal"
             css={S.startTeamButton('normal')}
+            onClick={() => handleButtonClick('join')}
             aria-label="팀 개설하기 버튼"
           >
             팀 참가하기

--- a/frontend/src/pages/StartPage/StartPage.tsx
+++ b/frontend/src/pages/StartPage/StartPage.tsx
@@ -53,7 +53,6 @@ const StartPage = () => {
             variant="normal"
             css={S.startTeamButton('normal')}
             onClick={() => handleButtonClick('join')}
-            aria-label="팀 개설하기 버튼"
           >
             팀 참가하기
           </Button>

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -59,6 +59,22 @@ const animation = {
       transform: translateY(100%);
     }  
   `,
+  slideLeft: keyframes`
+    from {
+      transform: translateX(140%);
+    }
+    to {
+      transform: translateX(0);
+    }  
+  `,
+  slideRight: keyframes`
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(140%);
+    }  
+  `,
   fadeInUp: keyframes`
     from {
       opacity: 0;


### PR DESCRIPTION
# [FE]팀 참가, 생성 페이지 구현
## 이슈번호
> close #395 

## PR 내용
로그인 시 팀이 없으면 자동으로 /start로 이동
><이전 flow>
로그인 페이지에서 "토큰" 을 획득
/team 으로 이동
/team 에서 백엔드에 소속 팀 정보를 요청하고, 요청 결과에 따라 적합한 페이지로 이동 = 페이지 여러 번 이동해서 버벅거림, 뒤로가기 시 원치 않는 사이트로 이동할 수 있음
<바꾼 로직>
/login 에서 토큰을 받은 이후 팀 정보도 요청 -> 리다이렉트 시키기 전 우리가 팀 소속여부를 알 수 있음
<현재 flow>
로그인 페이지에서 "토큰" 을 획득하고, 이후 비동기 요청을 보내 "팀 정보" 도 획득
토큰과 팀 정보를 통틀어서 다음 페이지로 어떻게 이동할지를 정하고, 이동 = 페이지 여러 번 이동할 필요 없음, 뒤로가기 시 예상했던 페이지로 이동

/landing 에서 accessToken과 teamPlaceId 둘 다 있을 시만 자동 로그인 되도록 변경

teamPlaceProvider에서 teamPlaces 패치가 끝난 후, local에 있으면 해당 팀 id 초기값으로, 없으면 팀 중 가장 먼저팀 id 를 초기값으로 정하도록 변경

## 참고자료
local에 access 넣고 /start로 가서 확인해주시면 됩니당

## 의논할 거리
