### PR TITLE
[BE] 문서화 공통 클래스 ApiDocsTest 구현

### DIFF
--- a/backend/src/test/java/team/teamby/teambyteam/common/ApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/ApiDocsTest.java
@@ -12,22 +12,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
 import team.teamby.teambyteam.auth.presentation.MemberInterceptor;
 import team.teamby.teambyteam.auth.presentation.TeamPlaceParticipationInterceptor;
-import team.teamby.teambyteam.schedule.application.MyCalendarScheduleService;
 import team.teamby.teambyteam.schedule.application.TeamCalendarScheduleService;
-import team.teamby.teambyteam.schedule.presentation.MyCalendarScheduleController;
-import team.teamby.teambyteam.schedule.presentation.TeamCalendarScheduleController;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @AutoConfigureRestDocs
-@WebMvcTest(value = {
-        TeamCalendarScheduleController.class,
-        MyCalendarScheduleController.class
-})
-@MockBean(value = {
-        JpaMetamodelMappingContext.class
-})
+@WebMvcTest
+@MockBean(JpaMetamodelMappingContext.class)
 public abstract class ApiDocsTest {
 
     protected static final String AUTHORIZATION_HEADER_KEY = HttpHeaders.AUTHORIZATION;
@@ -51,8 +43,6 @@ public abstract class ApiDocsTest {
     @MockBean
     protected TeamCalendarScheduleService teamCalendarScheduleService;
 
-    @MockBean
-    protected MyCalendarScheduleService myCalendarScheduleService;
 
     @BeforeEach
     void setup() throws Exception {

--- a/backend/src/test/java/team/teamby/teambyteam/common/ApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/ApiDocsTest.java
@@ -1,0 +1,64 @@
+package team.teamby.teambyteam.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
+import team.teamby.teambyteam.auth.presentation.MemberInterceptor;
+import team.teamby.teambyteam.auth.presentation.TeamPlaceParticipationInterceptor;
+import team.teamby.teambyteam.schedule.application.MyCalendarScheduleService;
+import team.teamby.teambyteam.schedule.application.TeamCalendarScheduleService;
+import team.teamby.teambyteam.schedule.presentation.MyCalendarScheduleController;
+import team.teamby.teambyteam.schedule.presentation.TeamCalendarScheduleController;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@AutoConfigureRestDocs
+@WebMvcTest(value = {
+        TeamCalendarScheduleController.class,
+        MyCalendarScheduleController.class
+})
+@MockBean(value = {
+        JpaMetamodelMappingContext.class
+})
+public abstract class ApiDocsTest {
+
+    protected static final String AUTHORIZATION_HEADER_KEY = HttpHeaders.AUTHORIZATION;
+    protected static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaa.bbbb.cccc";
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected MemberInterceptor memberInterceptor;
+
+    @MockBean
+    protected TeamPlaceParticipationInterceptor teamPlaceParticipationInterceptor;
+
+    @MockBean
+    protected JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    protected TeamCalendarScheduleService teamCalendarScheduleService;
+
+    @MockBean
+    protected MyCalendarScheduleService myCalendarScheduleService;
+
+    @BeforeEach
+    void setup() throws Exception {
+        given(memberInterceptor.preHandle(any(), any(), any()))
+                .willReturn(true);
+        given(teamPlaceParticipationInterceptor.preHandle(any(), any(), any()))
+                .willReturn(true);
+    }
+}


### PR DESCRIPTION
## 이슈번호
> #418 

## PR 내용

문서화 공통 클래스 ApiDocsTest 구현
* JpaMetamodelMappingContext MockBean은 JPA Auditing(BaseEntity) 관련 기능이어서 MockBean
* MemberInterceptor, teamPlaceParticipationInterceptor는 모두 통과하도록 @BeforeEach 설정
  * 상속받는 문서화 클래스에서 사용하기 위해 접근 제어자 protected 처리

---
### 리팩토링

**각각의 Controller, Service는 문서화 테스트 클래스 내에서 @WebMvcTest, @MockBean으로 선언해서 사용!**
-> 안하면 빈 주입 오류나므로 꼭 매 테스트 마다 잊지말고 하기

## 참고자료

## 의논할 거리
