### PR TITLE
[BE] 팀플레이스 생성 요청시 예외 코드 오류 수정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -83,7 +83,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {
             ScheduleException.SpanWrongOrderException.class,
-            TeamPlaceInviteCodeException.LengthException.class
+            TeamPlaceInviteCodeException.LengthException.class,
+            TeamPlaceException.NameLengthException.class,
+            TeamPlaceException.NameBlankException.class
     })
     public ResponseEntity<String> handleCustomBadRequestException(final RuntimeException exception) {
         final String message = exception.getMessage();

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceCreateRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceCreateRequest.java
@@ -1,4 +1,8 @@
 package team.teamby.teambyteam.teamplace.application.dto;
 
-public record TeamPlaceCreateRequest(String name) {
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamPlaceCreateRequest(
+        @NotBlank(message = "팀플레이스 이름이 있어야 합니다.") String name
+) {
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.teamplace.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class TeamPlaceController {
     @PostMapping
     public ResponseEntity<TeamPlaceCreateResponse> createTeamPlace(
             @AuthPrincipal final MemberEmailDto memberEmailDto,
-            @RequestBody final TeamPlaceCreateRequest teamPlaceCreateRequest
+            @RequestBody @Valid final TeamPlaceCreateRequest teamPlaceCreateRequest
     ) {
         final TeamPlaceCreateResponse response = teamPlaceService.create(memberEmailDto, teamPlaceCreateRequest);
 

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -66,6 +66,43 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
         }
+
+        @Test
+        @DisplayName("팀플레이스의 이름이 없으면 생성에 실패한다.")
+        void failWithBlankTeamPlaceName() {
+            // given
+            final Member ENDL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final String ENDL_TOKEN = jwtTokenProvider.generateAccessToken(ENDL.getEmail().getValue());
+            final String BLANK_NAME = "";
+            final TeamPlaceCreateRequest request = new TeamPlaceCreateRequest(BLANK_NAME);
+
+            // when
+            final ExtractableResponse<Response> response = CREATE_TEAM_PLACE(ENDL_TOKEN, request);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(response.body().asString()).contains("팀플레이스 이름이 있어야 합니다.");
+            });
+        }
+
+        @Test
+        @DisplayName("너무 긴 이름(30자 초과)의 팀플레이스는 생성할 수 없다.")
+        void failWithLongTeamPlaceName() {
+            final Member ENDL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final String ENDL_TOKEN = jwtTokenProvider.generateAccessToken(ENDL.getEmail().getValue());
+            final String BLANK_NAME = "a".repeat(31);
+            final TeamPlaceCreateRequest request = new TeamPlaceCreateRequest(BLANK_NAME);
+
+            // when
+            final ExtractableResponse<Response> response = CREATE_TEAM_PLACE(ENDL_TOKEN, request);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(response.body().asString()).contains("팀 플레이스 이름의 길이가 최대 이름 길이를 초과했습니다.");
+            });
+        }
     }
 
     @Nested


### PR DESCRIPTION
## PR 내용

기존 : 팀플레이스 생성시 잘못된 이름 요청에 500 예외 발생
수정 : 팀플레이스 생성요청시 공백, 31자이상등의 입력에서 404 예외 발생으로 변경

## 참고자료

## 의논할 거리
