### PR TITLE
[FE] 랜딩 페이지의 장식 컴포넌트를 3개의 메뉴에도 적용

### DIFF
--- a/frontend/src/pages/CreatePage/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage/CreatePage.tsx
@@ -4,6 +4,7 @@ import Input from '~/components/common/Input/Input';
 import { useRef } from 'react';
 import Button from '~/components/common/Button/Button';
 import { useTeamCreate } from '~/hooks/team/useTeamCreate';
+import IntroCardPile from '~/components/landing/IntroCardPile/IntroCardPile';
 
 const CreatePage = () => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -42,6 +43,7 @@ const CreatePage = () => {
           </Button>
         </S.TeamNameForm>
       </S.InnerContainer>
+      <IntroCardPile animation={false} />
     </S.Container>
   );
 };

--- a/frontend/src/pages/JoinPage/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage/JoinPage.tsx
@@ -6,6 +6,7 @@ import { useRef, useEffect } from 'react';
 import { PATH_NAME } from '~/constants/routes';
 import { useNavigate } from 'react-router-dom';
 import { useTeamJoin } from '~/hooks/team/useTeamJoin';
+import IntroCardPile from '~/components/landing/IntroCardPile/IntroCardPile';
 
 const JoinPage = () => {
   const ref = useRef<HTMLDivElement>(null);
@@ -83,6 +84,7 @@ const JoinPage = () => {
           </Button>
         </S.InviteCodeForm>
       </S.InnerContainer>
+      <IntroCardPile animation={false} />
     </S.Container>
   );
 };

--- a/frontend/src/pages/StartPage/StartPage.tsx
+++ b/frontend/src/pages/StartPage/StartPage.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PATH_NAME } from '~/constants/routes';
 import { START_TYPE } from '~/constants/team';
+import IntroCardPile from '~/components/landing/IntroCardPile/IntroCardPile';
 
 type StartType = (typeof START_TYPE)[keyof typeof START_TYPE];
 
@@ -60,6 +61,7 @@ const StartPage = () => {
           </Button>
         </S.ButtonContainer>
       </S.InnerContainer>
+      <IntroCardPile animation={false} />
     </S.Container>
   );
 };


### PR DESCRIPTION
# [FE] 랜딩 페이지의 장식 컴포넌트를 3개의 메뉴에도 적용
## 이슈번호
> close #436

## PR 내용
본 PR에서는 아래 3개의 메뉴에 대해 랜딩 페이지에 구현된 장식 컴포넌트를 적용하였다.
애니메이션은 비활성화 되어 있다.

- 팀 생성 페이지 - `/create`
- 팀 참가 페이지 - `/join`
- 팀 생성/참가 선택 페이지 - `/start`

## 참고자료
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/1c2bdd38-2bec-414e-8680-8c98680c0ddf)