### PR TITLE
[BE] 공지 작성자 표기 오류 수정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -63,7 +63,8 @@ public class NoticeService {
     }
 
     private NoticeResponse mapToNoticeResponse(final Notice notice) {
-        final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findById(notice.getAuthorId())
+        final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository
+                .findByTeamPlaceIdAndMemberId(notice.getTeamPlaceId(), notice.getAuthorId())
                 .orElse(MemberTeamPlace.UNKNOWN_MEMBER_TEAM_PLACE);
         return NoticeResponse.of(notice, memberTeamPlace);
     }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -126,6 +126,8 @@ class NoticeServiceTest extends ServiceTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(noticeResponse).isPresent();
                 softly.assertThat(noticeResponse.get().content()).isEqualTo("3rdNotice");
+                softly.assertThat(noticeResponse.get().authorId()).isEqualTo(member.getId());
+                softly.assertThat(noticeResponse.get().authorName()).isEqualTo(memberTeamPlace.getDisplayMemberName().getValue());
             });
         }
 


### PR DESCRIPTION
## 이슈번호
> close #452 

## PR 내용

- 공지 작성자 조회시 해당 팀플레이스와 작성자 아이디로 조회하도록 수정
- 관련 테스트 추가

## 참고자료

## 의논할 거리
