### PR TITLE
[BE] 내정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.member.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
@@ -74,5 +75,13 @@ public class MemberService {
             throw new TeamPlaceInviteCodeException.LengthException();
         }
         return inviteCodeVo;
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInformation(final MemberEmailDto memberEmailDto) {
+        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+
+        return MemberInfoResponse.of(member);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/dto/MemberInfoResponse.java
@@ -1,0 +1,19 @@
+package team.teamby.teambyteam.member.application.dto;
+
+import team.teamby.teambyteam.member.domain.Member;
+
+public record MemberInfoResponse(
+        Long id,
+        String name,
+        String profileImageUrl,
+        String email
+) {
+    public static MemberInfoResponse of(final Member member) {
+        return new MemberInfoResponse(
+                member.getId(),
+                member.getName().getValue(),
+                member.getProfileImageUrl().getValue(),
+                member.getEmail().getValue()
+        );
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.application.MemberService;
+import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
@@ -21,6 +22,13 @@ import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResp
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<MemberInfoResponse> getMyInformation(@AuthPrincipal final MemberEmailDto memberEmailDto) {
+        final MemberInfoResponse myInformation = memberService.getMemberInformation(memberEmailDto);
+
+        return ResponseEntity.ok(myInformation);
+    }
 
     @GetMapping("/team-places")
     public ResponseEntity<TeamPlacesResponse> getParticipatedTeamPlaces(@AuthPrincipal final MemberEmailDto memberEmailDto) {

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -10,6 +10,15 @@ public class MemberAcceptanceFixture {
 
     private static final String JWT_PREFIX = "Bearer ";
 
+    public static ExtractableResponse<Response> GET_MY_INFORMATION(final String token) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .when().log().all()
+                .get("/api/me")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> GET_PARTICIPATED_TEAM_PLACES(final String token) {
         return RestAssured.given().log().all()
                 .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlaceResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
@@ -208,6 +209,41 @@ class MemberServiceTest extends ServiceTest {
                         .isInstanceOf(TeamPlaceInviteCodeException.NotFoundException.class)
                         .hasMessage("존재하지 않는 초대코드 입니다.");
             });
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자의 정보시")
+    class GetMyInformation {
+
+        @Test
+        @DisplayName("정보 조회에 성공한다.")
+        void success() {
+            // given
+            final Member REGISTERED_MEMBER = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+
+            // when
+            final MemberInfoResponse response = memberService.getMemberInformation(new MemberEmailDto(REGISTERED_MEMBER.getEmail().getValue()));
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.id()).isEqualTo(REGISTERED_MEMBER.getId());
+                softly.assertThat(response.name()).isEqualTo(REGISTERED_MEMBER.getName().getValue());
+                softly.assertThat(response.profileImageUrl()).isEqualTo(REGISTERED_MEMBER.getProfileImageUrl().getValue());
+                softly.assertThat(response.email()).isEqualTo(REGISTERED_MEMBER.getEmail().getValue());
+            });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자이메일로 조회시 실패한다.")
+        void failWithNotRegisteredMember() {
+            // given
+            final Member NON_REGISTERED_MEMBER = MemberFixtures.ROY();
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> memberService.getMemberInformation(new MemberEmailDto(NON_REGISTERED_MEMBER.getEmail().getValue())))
+                    .isInstanceOf(MemberException.MemberNotFoundException.class)
+                    .hasMessage("조회한 멤버가 존재하지 않습니다.");
         }
     }
 }


### PR DESCRIPTION
## 이슈번호
> close #450

## PR 내용

- 로그인한 사용자가 내 정보를 조회하는 기능 구현
- 인증된 사용자의 요청시 응답 body와 함께 200 응답
- 인증되지 않은 사용자의 요청시 401 응답

## 참고자료

## 의논할 거리
