### PR TITLE
[BE] 구글 로그인 시 리프레시 토큰도 발급하도록 리팩토링

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/GoogleOAuthService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/GoogleOAuthService.java
@@ -32,7 +32,10 @@ public class GoogleOAuthService {
         final GoogleTokenResponse googleTokenResponse = googleOAuthClient.getGoogleAccessToken(code);
         final OAuthMember oAuthMember = createOAuthMember(googleTokenResponse.idToken());
         createMemberIfNotExist(oAuthMember);
-        return new TokenResponse(jwtTokenProvider.generateAccessToken(oAuthMember.email()));
+        return new TokenResponse(
+                jwtTokenProvider.generateAccessToken(oAuthMember.email()),
+                jwtTokenProvider.generateRefreshToken(oAuthMember.email())
+        );
     }
 
     private OAuthMember createOAuthMember(final String googleIdToken) {

--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/dto/TokenResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/dto/TokenResponse.java
@@ -1,4 +1,4 @@
 package team.teamby.teambyteam.auth.oauth.application.dto;
 
-public record TokenResponse(String accessToken) {
+public record TokenResponse(String accessToken, String refreshToken) {
 }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
@@ -30,8 +30,9 @@ public class AuthController {
     @GetMapping("/code/google")
     public void googleRedirect(final HttpServletResponse response, @RequestParam final String code) throws IOException {
         final String baseUrl = "/login";
-        final String token = googleOAuthService.createToken(code).accessToken();
-        final String url = baseUrl + "?accessToken=" + token;
+        final String accessToken = googleOAuthService.createToken(code).accessToken();
+        final String refreshToken = googleOAuthService.createToken(code).refreshToken();
+        final String url = baseUrl + "?accessToken=" + accessToken + "?refreshToken=" + refreshToken;
 
         response.sendRedirect(url);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 @RequestMapping("/api/auth")
 public class AuthController {
 
+    private static final String QUERY_PARAM_ACCESS_TOKEN_KEY = "?accessToken=";
+    private static final String QUERY_PARAM_REFRESH_TOKEN_KEY = "?accessToken=";
     private final OAuthUriGenerator oAuthUriGenerator;
     private final GoogleOAuthService googleOAuthService;
 
@@ -32,7 +34,7 @@ public class AuthController {
         final String baseUrl = "/login";
         final String accessToken = googleOAuthService.createToken(code).accessToken();
         final String refreshToken = googleOAuthService.createToken(code).refreshToken();
-        final String url = baseUrl + "?accessToken=" + accessToken + "?refreshToken=" + refreshToken;
+        final String url = baseUrl + QUERY_PARAM_ACCESS_TOKEN_KEY + accessToken + QUERY_PARAM_REFRESH_TOKEN_KEY + refreshToken;
 
         response.sendRedirect(url);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
@@ -18,8 +18,11 @@ import java.io.IOException;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private static final String QUERY_PARAM_ACCESS_TOKEN_KEY = "?accessToken=";
-    private static final String QUERY_PARAM_REFRESH_TOKEN_KEY = "?accessToken=";
+    private static final StringBuilder sb = new StringBuilder();
+    private static final String QUERY_START_MARK = "?";
+    private static final String QUERY_AND_MARK = "&";
+    private static final String QUERY_PARAM_ACCESS_TOKEN_KEY = "accessToken=";
+    private static final String QUERY_PARAM_REFRESH_TOKEN_KEY = "refreshToken=";
     private final OAuthUriGenerator oAuthUriGenerator;
     private final GoogleOAuthService googleOAuthService;
 
@@ -34,8 +37,15 @@ public class AuthController {
         final String baseUrl = "/login";
         final String accessToken = googleOAuthService.createToken(code).accessToken();
         final String refreshToken = googleOAuthService.createToken(code).refreshToken();
-        final String url = baseUrl + QUERY_PARAM_ACCESS_TOKEN_KEY + accessToken + QUERY_PARAM_REFRESH_TOKEN_KEY + refreshToken;
 
-        response.sendRedirect(url);
+        StringBuilder url = sb.append(baseUrl)
+                .append(QUERY_START_MARK)
+                .append(QUERY_PARAM_ACCESS_TOKEN_KEY)
+                .append(accessToken)
+                .append(QUERY_AND_MARK)
+                .append(QUERY_PARAM_REFRESH_TOKEN_KEY)
+                .append(refreshToken);
+
+        response.sendRedirect(url.toString());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/presentation/AuthController.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private static final StringBuilder sb = new StringBuilder();
     private static final String QUERY_START_MARK = "?";
     private static final String QUERY_AND_MARK = "&";
     private static final String QUERY_PARAM_ACCESS_TOKEN_KEY = "accessToken=";
@@ -38,6 +37,12 @@ public class AuthController {
         final String accessToken = googleOAuthService.createToken(code).accessToken();
         final String refreshToken = googleOAuthService.createToken(code).refreshToken();
 
+        String url = generateUrl(baseUrl, accessToken, refreshToken);
+        response.sendRedirect(url);
+    }
+
+    private String generateUrl(final String baseUrl, final String accessToken, final String refreshToken) {
+        StringBuilder sb = new StringBuilder();
         StringBuilder url = sb.append(baseUrl)
                 .append(QUERY_START_MARK)
                 .append(QUERY_PARAM_ACCESS_TOKEN_KEY)
@@ -45,7 +50,6 @@ public class AuthController {
                 .append(QUERY_AND_MARK)
                 .append(QUERY_PARAM_REFRESH_TOKEN_KEY)
                 .append(refreshToken);
-
-        response.sendRedirect(url.toString());
+        return url.toString();
     }
 }


### PR DESCRIPTION
## 이슈번호
> #464 

## PR 내용

- 구글 로그인 시 리프레시 토큰도 발급하도록 리팩토링
- 테스트는 외부 API 테스트라 Mocking 해야해서 시간이 좀 걸려서 급하므로 이전에 이슈 생성해놨음 (테스트 하기 이슈)

## 참고자료

## 의논할 거리
