### PR TITLE
[FE] 라우터가 요구되는 컴포넌트를 스토리북에서 확인할 수 있도록 스토리북에 라우터를 추가

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -7,7 +7,7 @@ import GlobalStyle from '../src/styles/GlobalStyle';
 import { ModalProvider } from '../src/components/common/Modal/ModalContext';
 import { ToastProvider } from '../src/components/common/Toast/ToastContext';
 import { TeamPlaceProvider } from '../src/contexts/TeamPlaceContext';
-
+import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Preview } from '@storybook/react';
 
@@ -30,18 +30,20 @@ const queryClient = new QueryClient();
 
 export const decorators = [
   (Story) => (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <TeamPlaceProvider>
-          <ToastProvider>
-            <ModalProvider>
-              <GlobalStyle />
-              <Story />
-            </ModalProvider>
-          </ToastProvider>
-        </TeamPlaceProvider>
-      </ThemeProvider>
-    </QueryClientProvider>
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <TeamPlaceProvider>
+            <ToastProvider>
+              <ModalProvider>
+                <GlobalStyle />
+                <Story />
+              </ModalProvider>
+            </ToastProvider>
+          </TeamPlaceProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </BrowserRouter>
   ),
   mswDecorator,
 ];


### PR DESCRIPTION
# [FE] 라우터가 요구되는 컴포넌트를 스토리북에서 확인할 수 있도록 스토리북에 라우터를 추가
## 이슈번호
> close #476 

## PR 내용
본 PR에서는 `<BrowserRouter>` 를 스토리북의 데코레이터에 추가하여, 라우터가 요구되는 컴포넌트들이 오류가 발생하면서 랜더링이 되지 못 했던 문제를 해결하였다.

## 참고자료
### Before
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/f5a40904-bed4-4240-a474-630834bc5c02)

### After
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/cb49fa00-7b00-4ee4-83d3-9e8b5bff7828)

