### PR TITLE
[BE] 리프레시 토큰 발급 시 DB 저장하도록 버그 fix

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/GoogleOAuthService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/GoogleOAuthService.java
@@ -14,8 +14,11 @@ import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.domain.vo.Name;
+import team.teamby.teambyteam.token.domain.Token;
+import team.teamby.teambyteam.token.domain.TokenRepository;
 
 import java.util.Base64;
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,17 +32,19 @@ public class GoogleOAuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleOAuthClient googleOAuthClient;
     private final MemberRepository memberRepository;
+    private final TokenRepository tokenRepository;
 
     public TokenResponse createToken(final String code) {
         final GoogleTokenResponse googleTokenResponse = googleOAuthClient.getGoogleAccessToken(code);
         final OAuthMember oAuthMember = createOAuthMember(googleTokenResponse.idToken());
-        createMemberIfNotExist(oAuthMember);
+        final Member member = createMemberIfNotExist(oAuthMember);
+
+        final String accessToken = jwtTokenProvider.generateAccessToken(oAuthMember.email());
+        final String refreshToken = jwtTokenProvider.generateRefreshToken(oAuthMember.email());
+        tokenRepository.save(new Token(member, refreshToken));
 
         log.info("토큰 생성 - 사용자 이메일 : {}", oAuthMember.email());
-        return new TokenResponse(
-                jwtTokenProvider.generateAccessToken(oAuthMember.email()),
-                jwtTokenProvider.generateRefreshToken(oAuthMember.email())
-        );
+        return new TokenResponse(accessToken, refreshToken);
     }
 
     private OAuthMember createOAuthMember(final String googleIdToken) {
@@ -54,12 +59,13 @@ public class GoogleOAuthService {
         return new OAuthMember(email, rawName, picture);
     }
 
-    private void createMemberIfNotExist(final OAuthMember oAuthMember) {
-        if (memberRepository.existsByEmail(new Email(oAuthMember.email()))) {
-            return;
+    private Member createMemberIfNotExist(final OAuthMember oAuthMember) {
+        Optional<Member> optionalMember = memberRepository.findByEmail(new Email(oAuthMember.email()));
+        if (optionalMember.isPresent()) {
+            return optionalMember.get();
         }
         final Member member = new Member(oAuthMember.displayName(), oAuthMember.email(), oAuthMember.imageUrl());
-        memberRepository.save(member);
+        return memberRepository.save(member);
     }
 
     private String extractElementFromToken(final String googleIdToken, final String key) {


### PR DESCRIPTION
## 이슈번호
> 긴급으로, 이슈 X

## 버그 발생 상황
- `/code/google`로 로그인 요청 들어왔을 시, 응답으로 RefreshToken QueryParameter에 Key-Value로 넣었음
 - 이때, QueryParameter에 생성한 RefreshToken을 넣기 전, Service에서 DB에 먼저 토큰을 저장하지 않음.
 -> 이후에 토큰 재발급 시 QueryParameter에 발급한 토큰을 DB에 넣지 않았으므로 토큰을 찾을 수 없다는 버그 발생

## 리팩토링
- GoogleOAuthService의 createToken()에서 토큰을 생성하고, DB에 저장하도록 리팩토링
   - 이 과정에서, Token Entity를 생성하기 위해 영속화된 Member가 필요했음.
   - 기존에 createMemberIfNotExist()에서는 exist 쿼리로 Email에 해당하는 멤버가 존재하면 Early Return 했지만,
   - Email에 해당하는 멤버가 존재하면 해당 멤버를 반환해야 했음 
     - 그래서 findByEmail로 Optional<Member>를 받아서 처리했음.

## 참고자료

## 의논할 거리
