### PR TITLE
[FE] 모아보기 페이지 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,9 @@ import StartPage from '~/pages/StartPage/StartPage';
 import TeamSelectPage from '~/pages/TeamSelectPage/TeamSelectPage';
 import CreatePage from '~/pages/CreatePage/CreatePage';
 import JoinPage from '~/pages/JoinPage/JoinPage';
-import TeamLinkPage from './pages/TeamLinkPage/TeamLinkPage';
+import TeamLinkPage from '~/pages/TeamLinkPage/TeamLinkPage';
+import TeamOverviewPage from '~/pages/TeamOverviewPage/TeamOverviewPage';
+import { ModalProvider } from './components/common/Modal/ModalContext';
 
 const App = () => {
   return (
@@ -23,6 +25,10 @@ const App = () => {
         <Route path={PATH_NAME.JOIN} element={<JoinPage />} />
         <Route element={<PageTemplate />}>
           <Route path={PATH_NAME.TEAM_SELECT} element={<TeamSelectPage />} />
+          <Route
+            path={PATH_NAME.TEAM_OVERVIEW}
+            element={<TeamOverviewPage />}
+          />
           <Route
             path={PATH_NAME.TEAM_CALENDAR}
             element={<TeamCalendarPage />}

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
       setTeamName(() => value);
 
       if (location.pathname === PATH_NAME.TEAM_SELECT) {
-        navigate(PATH_NAME.TEAM_CALENDAR);
+        navigate(PATH_NAME.TEAM_OVERVIEW);
       }
     },
     /*eslint-disable-next-line*/
@@ -75,7 +75,7 @@ const Header = () => {
     <>
       <S.Container tabIndex={0}>
         <S.InnerContainer>
-          <Link to={PATH_NAME.TEAM_CALENDAR} aria-label="홈 페이지로 가기 버튼">
+          <Link to={PATH_NAME.TEAM_OVERVIEW} aria-label="홈 페이지로 가기">
             <LogoIcon />
           </Link>
           <div>

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -75,7 +75,10 @@ const Header = () => {
     <>
       <S.Container tabIndex={0}>
         <S.InnerContainer>
-          <Link to={PATH_NAME.TEAM_OVERVIEW} aria-label="홈 페이지로 가기">
+          <Link
+            to={PATH_NAME.TEAM_OVERVIEW}
+            aria-label="모아보기 페이지로 가기"
+          >
             <LogoIcon />
           </Link>
           <div>

--- a/frontend/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/frontend/src/components/common/NavigationBar/NavigationBar.tsx
@@ -1,12 +1,11 @@
 import { PATH_NAME } from '~/constants/routes';
 import {
   CalendarIcon,
-  ExitIcon,
   FeedIcon,
   HomeIcon,
   ChainIcon,
   TeamAddIcon,
-} from '~/assets/svg'
+} from '~/assets/svg';
 import * as S from './NavigationBar.styled';
 
 const NavigationBar = () => {
@@ -15,7 +14,7 @@ const NavigationBar = () => {
       <S.Container>
         <S.MenuContainer>
           <S.MenuLink
-            to={PATH_NAME.TEAM_CALENDAR}
+            to={PATH_NAME.TEAM_OVERVIEW}
             aria-label="모아보기 페이지로 이동하기 버튼"
           >
             <HomeIcon />

--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -32,6 +32,7 @@ const ThreadList = (props: ThreadListProps) => {
     <>
       {noticeThread && noticeThread.id && (
         <NoticeThread
+          size={size}
           authorName={noticeThread.authorName}
           createdAt={noticeThread.createdAt}
           profileImageUrl={noticeThread.profileImageUrl}

--- a/frontend/src/components/link/LinkTable/LinkTable.tsx
+++ b/frontend/src/components/link/LinkTable/LinkTable.tsx
@@ -11,7 +11,7 @@ import { useModal } from '~/hooks/useModal';
 import { useToast } from '~/hooks/useToast';
 import { linkTableHeaderValues } from '~/constants/link';
 
-const TeamLinkTable = () => {
+const LinkTable = () => {
   const { openModal, isModalOpen } = useModal();
   const { teamPlaceId } = useTeamPlace();
   const teamLinks = useFetchTeamLinks(teamPlaceId);
@@ -100,4 +100,4 @@ const TeamLinkTable = () => {
   );
 };
 
-export default TeamLinkTable;
+export default LinkTable;

--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -5,6 +5,7 @@ export const PATH_NAME = {
   JOIN: '/join',
   CREATE: '/create',
   TEAM_SELECT: '/team',
+  TEAM_OVERVIEW: '/team/overview',
   TEAM_CALENDAR: '/team/calendar',
   TEAM_FEED: '/team/feed',
   TEAM_LINK: '/team/link',

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -8,11 +8,11 @@ import ThreadList from '~/components/feed/ThreadList/ThreadList';
 import type { ThreadSize } from '~/types/size';
 
 interface TeamFeedPageProps {
-  size?: ThreadSize;
+  threadSize?: ThreadSize;
 }
 
 const TeamFeedPage = (props: TeamFeedPageProps) => {
-  const { size = 'md' } = props;
+  const { threadSize = 'md' } = props;
   const { isModalOpen, openModal } = useModal();
   const [isShowScrollTopButton, setIsShowScrollTopButton] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -47,7 +47,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
 
   return (
     <S.ThreadContainer ref={ref}>
-      <ThreadList size={size} />
+      <ThreadList size={threadSize} />
       <S.MenuButtonWrapper>
         {isShowScrollTopButton && (
           <Button

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -5,8 +5,14 @@ import ThreadAddBottomSheet from '~/components/feed/ThreadAddBottomSheet/ThreadA
 import { ArrowUpIcon, WriteIcon } from '~/assets/svg';
 import { useEffect, useRef, useState } from 'react';
 import ThreadList from '~/components/feed/ThreadList/ThreadList';
+import type { ThreadSize } from '~/types/size';
 
-const TeamFeedPage = () => {
+interface TeamFeedPageProps {
+  size?: ThreadSize;
+}
+
+const TeamFeedPage = (props: TeamFeedPageProps) => {
+  const { size = 'md' } = props;
   const { isModalOpen, openModal } = useModal();
   const [isShowScrollTopButton, setIsShowScrollTopButton] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -41,7 +47,7 @@ const TeamFeedPage = () => {
 
   return (
     <S.ThreadContainer ref={ref}>
-      <ThreadList />
+      <ThreadList size={size} />
       <S.MenuButtonWrapper>
         {isShowScrollTopButton && (
           <Button

--- a/frontend/src/pages/TeamOverviewPage/TeamOverviewPage.styled.ts
+++ b/frontend/src/pages/TeamOverviewPage/TeamOverviewPage.styled.ts
@@ -1,0 +1,38 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.main`
+  display: grid;
+  grid-template-rows: 50% 50%;
+  grid-template-columns: 60% 40%;
+  grid-template-areas:
+    'calendar feed'
+    'link feed';
+  overflow: hidden;
+
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+
+  background-color: ${({ theme }) => theme.color.GRAY100};
+`;
+
+export const TeamCalendarSection = styled.section`
+  position: relative;
+  grid-area: calendar;
+  overflow: auto;
+
+  & > div {
+    overflow-y: auto;
+  }
+`;
+
+export const TeamLinkSection = styled.section`
+  position: relative;
+  grid-area: link;
+`;
+
+export const TeamFeedSection = styled.section`
+  position: relative;
+  grid-area: feed;
+  overflow: auto;
+`;

--- a/frontend/src/pages/TeamOverviewPage/TeamOverviewPage.tsx
+++ b/frontend/src/pages/TeamOverviewPage/TeamOverviewPage.tsx
@@ -19,7 +19,7 @@ const TeamOverviewPage = () => {
       </S.TeamLinkSection>
       <S.TeamFeedSection>
         <ModalProvider>
-          <TeamFeedPage size="sm" />
+          <TeamFeedPage threadSize="sm" />
         </ModalProvider>
       </S.TeamFeedSection>
     </S.Container>

--- a/frontend/src/pages/TeamOverviewPage/TeamOverviewPage.tsx
+++ b/frontend/src/pages/TeamOverviewPage/TeamOverviewPage.tsx
@@ -1,0 +1,29 @@
+import * as S from './TeamOverviewPage.styled';
+import TeamCalendarPage from '../TeamCalendarPage/TeamCalendarPage';
+import TeamLinkPage from '../TeamLinkPage/TeamLinkPage';
+import TeamFeedPage from '../TeamFeedPage/TeamFeedPage';
+import { ModalProvider } from '~/components/common/Modal/ModalContext';
+
+const TeamOverviewPage = () => {
+  return (
+    <S.Container>
+      <S.TeamCalendarSection>
+        <ModalProvider>
+          <TeamCalendarPage />
+        </ModalProvider>
+      </S.TeamCalendarSection>
+      <S.TeamLinkSection>
+        <ModalProvider>
+          <TeamLinkPage />
+        </ModalProvider>
+      </S.TeamLinkSection>
+      <S.TeamFeedSection>
+        <ModalProvider>
+          <TeamFeedPage size="sm" />
+        </ModalProvider>
+      </S.TeamFeedSection>
+    </S.Container>
+  );
+};
+
+export default TeamOverviewPage;

--- a/frontend/src/pages/TeamSelectPage/TeamSelectPage.tsx
+++ b/frontend/src/pages/TeamSelectPage/TeamSelectPage.tsx
@@ -12,7 +12,7 @@ const TeamSelectPage = () => {
   useEffect(() => {
     const teamPlaceId = localStorage.getItem(LOCAL_STORAGE_KEY.TEAM_PLACE_ID);
 
-    if (teamPlaceId) navigate(PATH_NAME.TEAM_CALENDAR);
+    if (teamPlaceId) navigate(PATH_NAME.TEAM_OVERVIEW);
   }, [navigate]);
 
   return (


### PR DESCRIPTION
# [FE] 모아보기 페이지 구현
## 이슈번호
> close #482

## PR 내용

본 PR에서는 모아보기 페이지를 구현하였다.
고도화 및 디자인은 적용되어 있지 않으므로 추후 고도화를 원할 경우에는 따로 작업을 하도록 한다.

페이지명은 `TeamOverviewPage`, 도메인 주소는 `/team/overview` 이다.

## 참고자료
- 요술토끼의 노트북 화면에서 본 모아보기 페이지
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/e737779a-b40d-40b3-9836-7010b9edb67e)

- 요술토끼의 데스크톱 모니터에서 본 모아보기 페이지
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/00076fb3-71b9-4399-b69b-1e3ff8a20ed4)

## 의논할 사항
생각보다 각각의 메뉴(팀 피드 / 팀 캘린더 / 팀 링크) 가 너무 큰 것 같은데...? 괜찮으려나? 어떻게 하면 좋을까
