### PR TITLE
[BE] 리프레시 토큰이 db에 있는 사용자의 재 로그인시 오류 수정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/GoogleOAuthService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/oauth/application/GoogleOAuthService.java
@@ -41,10 +41,19 @@ public class GoogleOAuthService {
 
         final String accessToken = jwtTokenProvider.generateAccessToken(oAuthMember.email());
         final String refreshToken = jwtTokenProvider.generateRefreshToken(oAuthMember.email());
-        tokenRepository.save(new Token(member, refreshToken));
+
+        saveOrUpdateRefreshToken(member, refreshToken);
 
         log.info("토큰 생성 - 사용자 이메일 : {}", oAuthMember.email());
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    private void saveOrUpdateRefreshToken(Member member, String refreshToken) {
+        tokenRepository.findByMember(member)
+                .ifPresentOrElse(
+                        token -> token.changeToken(refreshToken),
+                        () -> tokenRepository.save(new Token(member, refreshToken))
+                );
     }
 
     private OAuthMember createOAuthMember(final String googleIdToken) {

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenService.java
@@ -24,7 +24,8 @@ public class TokenService {
         final String generateAccessToken = jwtTokenProvider.generateAccessToken(email);
         final String generateRefreshToken = jwtTokenProvider.generateRefreshToken(email);
         final Token token = tokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(TokenException.TokenNotFoundException::new);
+                .orElseThrow(() -> new TokenException.TokenNotFoundException(email));
+
         token.changeToken(generateRefreshToken);
 
         log.info("인증 토큰 재발급 - 재발급 받은 사용자 이메일 : {}", email);

--- a/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
@@ -1,10 +1,15 @@
 package team.teamby.teambyteam.token.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.teamby.teambyteam.member.domain.Member;
 
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByRefreshToken(final String refreshToken);
+
+    Optional<Token> findByMember(final Member member);
+
+    boolean existsByMember(final Member member);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
@@ -10,6 +10,4 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
     Optional<Token> findByRefreshToken(final String refreshToken);
 
     Optional<Token> findByMember(final Member member);
-
-    boolean existsByMember(final Member member);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/exception/TokenException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/exception/TokenException.java
@@ -7,8 +7,8 @@ public class TokenException extends RuntimeException {
     }
 
     public static class TokenNotFoundException extends TokenException {
-        public TokenNotFoundException() {
-            super("토큰을 찾을 수 없습니다.");
+        public TokenNotFoundException(final String email) {
+            super(String.format("토큰을 찾을 수 없습니다. - request info { email : %s }", email));
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/token/acceptance/TokenAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/token/acceptance/TokenAcceptanceTest.java
@@ -112,7 +112,7 @@ public class TokenAcceptanceTest extends AcceptanceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-            softly.assertThat(response.jsonPath().getString("error")).isEqualTo("토큰을 찾을 수 없습니다.");
+            softly.assertThat(response.jsonPath().getString("error")).contains("토큰을 찾을 수 없습니다.");
             softly.assertThat(response.header(ACCESS_TOKEN_HEADER)).isNull();
             softly.assertThat(response.header(REFRESH_TOKEN_HEADER)).isNull();
         });

--- a/backend/src/test/java/team/teamby/teambyteam/token/application/TokenServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/token/application/TokenServiceTest.java
@@ -91,6 +91,6 @@ class TokenServiceTest extends ServiceTest {
         // when & then
         assertThatThrownBy(() -> tokenService.reissueToken(refreshToken))
                 .isInstanceOf(TokenException.TokenNotFoundException.class)
-                .hasMessage("토큰을 찾을 수 없습니다.");
+                .hasMessageContaining("토큰을 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
## PR 내용

기존 문제 : Refresh token의 정보가 db에 있는 멤버의 로그인 요청시 오류 발생

원인 : token table의 member_id가 unique 값이여서 기존에 해당 유무를 검증하지 않고 save하여 오류 발생

해결 : 회원로그인시 refresh token가 저장되어있는지 유무에 따라 저장 또는 기존 토큰 업데이트

## 참고자료

## 의논할 거리
