### PR TITLE
[FE] 0번 id를 갖는 팀플레이스에 계속 접근 시 권한 오류

### DIFF
--- a/frontend/src/hooks/queries/useFetchDailySchedules.ts
+++ b/frontend/src/hooks/queries/useFetchDailySchedules.ts
@@ -7,8 +7,12 @@ export const useFetchDailySchedules = (
   month: number,
   day: number,
 ) => {
-  const { data } = useQuery(['dailySchedules', year, month, day], () =>
-    fetchSchedules(teamPlaceId, year, month + 1, day),
+  const { data } = useQuery(
+    ['dailySchedules', year, month, day],
+    () => fetchSchedules(teamPlaceId, year, month + 1, day),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   if (data === undefined) return [];

--- a/frontend/src/hooks/queries/useFetchNoticeThread.ts
+++ b/frontend/src/hooks/queries/useFetchNoticeThread.ts
@@ -2,8 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchNoticeThread } from '~/apis/feed';
 
 export const useFetchNoticeThread = (teamPlaceId: number) => {
-  const { data: noticeThread } = useQuery(['noticeThread', teamPlaceId], () =>
-    fetchNoticeThread(teamPlaceId),
+  const { data: noticeThread } = useQuery(
+    ['noticeThread', teamPlaceId],
+    () => fetchNoticeThread(teamPlaceId),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   if (noticeThread === undefined) return {};

--- a/frontend/src/hooks/queries/useFetchScheduleById.ts
+++ b/frontend/src/hooks/queries/useFetchScheduleById.ts
@@ -8,6 +8,9 @@ export const useFetchScheduleById = (
   const { data: scheduleById } = useQuery(
     ['schedule', teamPlaceId, scheduleId],
     () => fetchScheduleById(teamPlaceId, scheduleId),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   return { scheduleById };

--- a/frontend/src/hooks/queries/useFetchSchedules.ts
+++ b/frontend/src/hooks/queries/useFetchSchedules.ts
@@ -6,8 +6,12 @@ export const useFetchSchedules = (
   year: number,
   month: number,
 ) => {
-  const { data } = useQuery(['schedules', teamPlaceId, year, month], () =>
-    fetchSchedules(teamPlaceId, year, month + 1),
+  const { data } = useQuery(
+    ['schedules', teamPlaceId, year, month],
+    () => fetchSchedules(teamPlaceId, year, month + 1),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   if (data === undefined) return [];

--- a/frontend/src/hooks/queries/useFetchTeamLinks.tsx
+++ b/frontend/src/hooks/queries/useFetchTeamLinks.tsx
@@ -2,8 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchTeamLinks } from '~/apis/link';
 
 export const useFetchTeamLinks = (teamPlaceId: number) => {
-  const { data } = useQuery(['teamLinks', teamPlaceId], () =>
-    fetchTeamLinks(teamPlaceId),
+  const { data } = useQuery(
+    ['teamLinks', teamPlaceId],
+    () => fetchTeamLinks(teamPlaceId),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   if (data === undefined) return [];

--- a/frontend/src/hooks/queries/useFetchTeamPlaceInviteCode.ts
+++ b/frontend/src/hooks/queries/useFetchTeamPlaceInviteCode.ts
@@ -2,8 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchTeamPlaceInviteCode } from '~/apis/team';
 
 export const useFetchTeamPlaceInviteCode = (teamPlaceId: number) => {
-  const { data } = useQuery(['teamPlaceInviteCode', teamPlaceId], () =>
-    fetchTeamPlaceInviteCode(teamPlaceId),
+  const { data } = useQuery(
+    ['teamPlaceInviteCode', teamPlaceId],
+    () => fetchTeamPlaceInviteCode(teamPlaceId),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   const { teamPlaceId: id, inviteCode } = data ?? {};

--- a/frontend/src/hooks/queries/useFetchTeamPlaceMembers.ts
+++ b/frontend/src/hooks/queries/useFetchTeamPlaceMembers.ts
@@ -2,8 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchTeamPlaceMembers } from '~/apis/team';
 
 export const useFetchTeamPlaceMembers = (teamPlaceId: number) => {
-  const { data } = useQuery(['teamPlaceMembers', teamPlaceId], () =>
-    fetchTeamPlaceMembers(teamPlaceId),
+  const { data } = useQuery(
+    ['teamPlaceMembers', teamPlaceId],
+    () => fetchTeamPlaceMembers(teamPlaceId),
+    {
+      enabled: teamPlaceId > 0,
+    },
   );
 
   const { members } = data ?? {};

--- a/frontend/src/hooks/queries/useFetchThreads.ts
+++ b/frontend/src/hooks/queries/useFetchThreads.ts
@@ -15,6 +15,7 @@ export const useFetchThreads = (teamPlaceId: number) => {
         if (lastPage.threads.length !== THREAD_SIZE) return undefined;
         return lastPage.threads[THREAD_SIZE - 1].id;
       },
+      enabled: teamPlaceId > 0,
     },
   );
 


### PR DESCRIPTION
# [FE] 0번 id를 갖는 팀플레이스에 계속 접근 시 권한 오류
## 이슈번호
> close #493 

## PR 내용
- 0번 id를 갖는 팀플레이스에 계속 접근 시 권한 오류
- teamPlaceId에 종속적인 쿼리에 enabled 옵션 추가

## 참고자료
https://tanstack.com/query/v4/docs/react/guides/dependent-queries
