### PR TITLE
[FE] 스레드 무한 스크롤 fetchNextPage에 teamPlaceId 판별 조건문 추가

### DIFF
--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -23,8 +23,11 @@ const ThreadList = (props: ThreadListProps) => {
   const { noticeThread } = useFetchNoticeThread(teamPlaceId);
   const observeRef = useRef<HTMLDivElement>(null);
 
-  const onIntersect: IntersectionObserverCallback = ([entry]) =>
-    entry.isIntersecting && fetchNextPage();
+  const onIntersect: IntersectionObserverCallback = ([entry]) => {
+    if (entry.isIntersecting && teamPlaceId > 0) {
+      fetchNextPage();
+    }
+  };
 
   useIntersectionObserver(observeRef, onIntersect);
 


### PR DESCRIPTION
# [FE] fetchNextPage에 teamPlaceId 판별 조건문 추가
## 이슈번호
> close #517 

## PR 내용
- 스레드 무한 스크롤 fetchNextPage에 teamPlaceId 판별 조건문 추가
