### PR TITLE
[FE] 팀 링크에서 https:// 로 시작하지 않는 경우 잘못된 주소로 이동하는 문제 해결

### DIFF
--- a/frontend/src/components/link/LinkTable/LinkTable.tsx
+++ b/frontend/src/components/link/LinkTable/LinkTable.tsx
@@ -11,7 +11,7 @@ import { useModal } from '~/hooks/useModal';
 import { useToast } from '~/hooks/useToast';
 import { linkTableHeaderValues } from '~/constants/link';
 import type { LinkSize } from '~/types/size';
-import { ensureHttpsPrefix } from '~/utils/ensureHttpsPrefix';
+import { generateHttpsUrl } from '~/utils/generateHttpsUrl';
 
 interface LinkTableProps {
   linkSize?: LinkSize;
@@ -75,7 +75,7 @@ const LinkTable = (props: LinkTableProps) => {
                   <tr key={id}>
                     <td>
                       <a
-                        href={ensureHttpsPrefix(url)}
+                        href={generateHttpsUrl(url)}
                         target="_blank"
                         rel="noreferrer"
                         title={title}

--- a/frontend/src/components/link/LinkTable/LinkTable.tsx
+++ b/frontend/src/components/link/LinkTable/LinkTable.tsx
@@ -11,6 +11,7 @@ import { useModal } from '~/hooks/useModal';
 import { useToast } from '~/hooks/useToast';
 import { linkTableHeaderValues } from '~/constants/link';
 import type { LinkSize } from '~/types/size';
+import { ensureHttpsPrefix } from '~/utils/ensureHttpsPrefix';
 
 interface LinkTableProps {
   linkSize?: LinkSize;
@@ -74,7 +75,7 @@ const LinkTable = (props: LinkTableProps) => {
                   <tr key={id}>
                     <td>
                       <a
-                        href={url}
+                        href={ensureHttpsPrefix(url)}
                         target="_blank"
                         rel="noreferrer"
                         title={title}

--- a/frontend/src/hooks/link/useTeamLinkAddModal.ts
+++ b/frontend/src/hooks/link/useTeamLinkAddModal.ts
@@ -8,6 +8,7 @@ import { useSendTeamLink } from '~/hooks/queries/useSendTeamLink';
 import { useModal } from '~/hooks/useModal';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import { useToast } from '~/hooks/useToast';
+import { ensureHttpsPrefix } from '~/utils/ensureHttpsPrefix';
 
 const URL_REGEX =
   /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i;
@@ -50,7 +51,7 @@ export const useTeamLinkAddModal = (linkRef: RefObject<HTMLInputElement>) => {
     mutateSendTeamLink(
       {
         title: linkName,
-        url: link,
+        url: ensureHttpsPrefix(link),
       },
       {
         onSuccess: () => {

--- a/frontend/src/hooks/link/useTeamLinkAddModal.ts
+++ b/frontend/src/hooks/link/useTeamLinkAddModal.ts
@@ -8,7 +8,7 @@ import { useSendTeamLink } from '~/hooks/queries/useSendTeamLink';
 import { useModal } from '~/hooks/useModal';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import { useToast } from '~/hooks/useToast';
-import { ensureHttpsPrefix } from '~/utils/ensureHttpsPrefix';
+import { generateHttpsUrl } from '~/utils/generateHttpsUrl';
 
 const URL_REGEX =
   /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i;
@@ -51,7 +51,7 @@ export const useTeamLinkAddModal = (linkRef: RefObject<HTMLInputElement>) => {
     mutateSendTeamLink(
       {
         title: linkName,
-        url: ensureHttpsPrefix(link),
+        url: generateHttpsUrl(link),
       },
       {
         onSuccess: () => {

--- a/frontend/src/utils/ensureHttpsPrefix.ts
+++ b/frontend/src/utils/ensureHttpsPrefix.ts
@@ -1,0 +1,9 @@
+const HTTPS_PREFIX_REGEX = /^https?:\/\/.*/;
+
+export const ensureHttpsPrefix = (url: string) => {
+  if (HTTPS_PREFIX_REGEX.test(url)) {
+    return url;
+  }
+
+  return `https://${url}`;
+};

--- a/frontend/src/utils/generateHttpsUrl.ts
+++ b/frontend/src/utils/generateHttpsUrl.ts
@@ -1,6 +1,6 @@
 const HTTPS_PREFIX_REGEX = /^https?:\/\/.*/;
 
-export const ensureHttpsPrefix = (url: string) => {
+export const generateHttpsUrl = (url: string) => {
   if (HTTPS_PREFIX_REGEX.test(url)) {
     return url;
   }


### PR DESCRIPTION
# [FE] 팀 링크에서 https:// 로 시작하지 않는 경우 잘못된 주소로 이동하는 문제 해결
## 이슈번호
> close #525 

## PR 내용
본 PR에서는 일부 링크에 한해 클릭 시 사용자가 입력한 주소가 아닌 팀바팀 내의 상대주소로 인식하여 잘못 이동하는 문제를 해결하였다.
- 사용자가 `https://` 또는 `http://` 로 시작하지 않는 주소를 입력했으면서, 그 주소가 유효하면 자동으로 `https://` 를 앞에 붙여 서버에 요청한다.
- 서버로부터 받아온 링크가 `https://` 또는 `http://` 로 시작하지 않는 경우, 자동으로 `https://` 를 앞에 붙인 후 랜더링한다.

