### PR TITLE
[FE] 모아보기 페이지 모달 UI 개선

### DIFF
--- a/frontend/src/components/link/LinkAddModal/LinkAddModal.styled.ts
+++ b/frontend/src/components/link/LinkAddModal/LinkAddModal.styled.ts
@@ -1,4 +1,5 @@
 import { css, styled } from 'styled-components';
+import type { LinkSize } from '~/types/size';
 
 export const Backdrop = styled.div`
   position: fixed;
@@ -8,11 +9,24 @@ export const Backdrop = styled.div`
   height: 100%;
 `;
 
-export const Container = styled.div`
+export const Container = styled.div<{ linkSize: LinkSize }>`
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  ${({ linkSize }) => {
+    if (linkSize === 'md')
+      return css`
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      `;
+
+    if (linkSize === 'sm')
+      return css`
+        top: 100%;
+        left: 14%;
+        transform: translateY(-300px);
+      `;
+  }}
+
   display: flex;
   flex-direction: column;
 

--- a/frontend/src/components/link/LinkAddModal/LinkAddModal.tsx
+++ b/frontend/src/components/link/LinkAddModal/LinkAddModal.tsx
@@ -6,8 +6,15 @@ import Text from '~/components/common/Text/Text';
 import Input from '~/components/common/Input/Input';
 import { useRef } from 'react';
 import { useTeamLinkAddModal } from '~/hooks/link/useTeamLinkAddModal';
+import type { LinkSize } from '~/types/size';
 
-const LinkAddModal = () => {
+interface LinkAddModalProps {
+  linkSize?: LinkSize;
+}
+
+const LinkAddModal = (props: LinkAddModalProps) => {
+  const { linkSize = 'md' } = props;
+
   const linkRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -25,7 +32,7 @@ const LinkAddModal = () => {
   return (
     <Modal>
       <S.Backdrop onClick={handleClose} />
-      <S.Container>
+      <S.Container linkSize={linkSize}>
         <S.IconWrapper>
           <Button
             variant="plain"

--- a/frontend/src/components/link/LinkTable/LinkTable.tsx
+++ b/frontend/src/components/link/LinkTable/LinkTable.tsx
@@ -105,7 +105,7 @@ const LinkTable = (props: LinkTableProps) => {
           )}
         </S.TableContainer>
       </S.Container>
-      {isModalOpen && <LinkAddModal />}
+      {isModalOpen && <LinkAddModal linkSize={linkSize} />}
     </>
   );
 };

--- a/frontend/src/components/team_calendar/DailyScheduleModal/DailyScheduleModal.styled.ts
+++ b/frontend/src/components/team_calendar/DailyScheduleModal/DailyScheduleModal.styled.ts
@@ -1,4 +1,5 @@
-import { css, styled } from 'styled-components';
+import { type CSSProp, css, styled } from 'styled-components';
+import type { CalendarSize } from '~/types/size';
 import type { TeamPlaceColor } from '~/types/team';
 
 export const Backdrop = styled.div`
@@ -9,7 +10,7 @@ export const Backdrop = styled.div`
   left: 0;
 `;
 
-export const Container = styled.div`
+export const Container = styled.div<{ css: CSSProp }>`
   display: flex;
   position: absolute;
   flex-direction: column;
@@ -26,6 +27,8 @@ export const Container = styled.div`
     0 0 1px #1b1d1f33,
     0 15px 25px #1b1d1f33,
     0 5px 10px #1b1d1f1f;
+
+  ${({ css }) => css};
 `;
 
 export const Header = styled.div`
@@ -94,3 +97,32 @@ export const teamName = css`
 
   max-width: 200px;
 `;
+
+export const modalLocation = (
+  row: number,
+  column: number,
+  level: number,
+  calendarWidth: number,
+  calendarLeft: number,
+  calendarSize: CalendarSize,
+) => {
+  if (calendarSize === 'md')
+    return css`
+      position: absolute;
+      top: ${(row < 3 ? 92 : -199) + (row + 1) * 110 + level * 18}px;
+      left: ${(column > 3
+        ? calendarWidth / 7 - 550
+        : column === 3
+        ? -136.7
+        : 0) +
+      calendarLeft +
+      (calendarWidth * column) / 7}px;
+    `;
+
+  if (calendarSize == 'sm')
+    return css`
+      position: fixed;
+      top: 23%;
+      left: 19%;
+    `;
+};

--- a/frontend/src/components/team_calendar/DailyScheduleModal/DailyScheduleModal.tsx
+++ b/frontend/src/components/team_calendar/DailyScheduleModal/DailyScheduleModal.tsx
@@ -7,10 +7,11 @@ import Text from '~/components/common/Text/Text';
 import { parseDate } from '~/utils/parseDate';
 import { useFetchDailySchedules } from '~/hooks/queries/useFetchDailySchedules';
 import type { Position, SchedulePosition } from '~/types/schedule';
-import type { CSSProperties } from 'react';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
+import type { CalendarSize } from '~/types/size';
 
 export interface DailyScheduleModalProps {
+  calendarSize?: CalendarSize;
   position: Position;
   rawDate: Date;
   onScheduleModalOpen: ({
@@ -25,24 +26,24 @@ export interface DailyScheduleModalProps {
 }
 
 const DailyScheduleModal = (props: DailyScheduleModalProps) => {
-  const { rawDate, position, onScheduleModalOpen, onSetModalType } = props;
+  const {
+    rawDate,
+    position,
+    calendarSize = 'md',
+    onScheduleModalOpen,
+    onSetModalType,
+  } = props;
   const { row, column } = position;
   const { closeModal } = useModal();
   const { teamPlaceColor, teamPlaceId } = useTeamPlace();
 
   const { year, month, date } = parseDate(rawDate);
   const schedules = useFetchDailySchedules(teamPlaceId, year, month, date);
-  const modalLocation: CSSProperties = {
-    top: row < 3 ? `${(row + 2) * 118}px` : 'none',
-    bottom: row >= 3 ? `${(7 - row) * 120}px` : 'none',
-    left: column < 3 ? `${(column * 100) / 7}%` : 'none',
-    right: column >= 3 ? `${((6 - column) * 100) / 7}%` : 'none',
-  };
 
   return (
     <Modal>
       <S.Backdrop onClick={closeModal} />
-      <S.Container style={modalLocation}>
+      <S.Container css={S.modalLocation(row, column, 0, 1, 1, calendarSize)}>
         <S.Header>
           <Text>
             {month + 1}월 {date}일

--- a/frontend/src/components/team_calendar/ScheduleAddModal/ScheduleAddModal.styled.ts
+++ b/frontend/src/components/team_calendar/ScheduleAddModal/ScheduleAddModal.styled.ts
@@ -1,4 +1,5 @@
 import { styled, css } from 'styled-components';
+import type { CalendarSize } from '~/types/size';
 
 export const Backdrop = styled.div`
   position: fixed;
@@ -8,11 +9,22 @@ export const Backdrop = styled.div`
   height: 100%;
 `;
 
-export const Container = styled.div`
+export const Container = styled.div<{ calendarSize: CalendarSize }>`
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  ${({ calendarSize }) => {
+    if (calendarSize === 'md')
+      return css`
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      `;
+
+    if (calendarSize === 'sm')
+      return css`
+        top: 20%;
+        left: 13.5%;
+      `;
+  }}
   display: flex;
   flex-direction: column;
 

--- a/frontend/src/components/team_calendar/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/team_calendar/ScheduleAddModal/ScheduleAddModal.tsx
@@ -11,13 +11,15 @@ import TeamBadge from '~/components/team/TeamBadge/TeamBadge';
 import TimeTableMenu from '~/components/team_calendar/TimeTableMenu/TimeTableMenu';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import { useRef, useEffect } from 'react';
+import type { CalendarSize } from '~/types/size';
 
 interface ScheduleAddModalProps {
+  calendarSize?: CalendarSize;
   clickedDate: Date;
 }
 
 const ScheduleAddModal = (props: ScheduleAddModalProps) => {
-  const { clickedDate } = props;
+  const { clickedDate, calendarSize = 'md' } = props;
   const { closeModal } = useModal();
   const { teamPlaceColor, displayName } = useTeamPlace();
   const {
@@ -42,7 +44,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
   return (
     <Modal>
       <S.Backdrop onClick={closeModal} />
-      <S.Container>
+      <S.Container calendarSize={calendarSize}>
         <S.Header>
           <Button
             variant="plain"

--- a/frontend/src/components/team_calendar/ScheduleEditModal/ScheduleEditModal.styled.ts
+++ b/frontend/src/components/team_calendar/ScheduleEditModal/ScheduleEditModal.styled.ts
@@ -1,4 +1,5 @@
 import { styled, css } from 'styled-components';
+import type { CalendarSize } from '~/types/size';
 
 export const Backdrop = styled.div`
   position: fixed;
@@ -8,11 +9,22 @@ export const Backdrop = styled.div`
   height: 100%;
 `;
 
-export const Container = styled.div`
+export const Container = styled.div<{ calendarSize: CalendarSize }>`
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  ${({ calendarSize }) => {
+    if (calendarSize === 'md')
+      return css`
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      `;
+
+    if (calendarSize === 'sm')
+      return css`
+        top: 20%;
+        left: 13.5%;
+      `;
+  }}
   display: flex;
   flex-direction: column;
 

--- a/frontend/src/components/team_calendar/ScheduleEditModal/ScheduleEditModal.tsx
+++ b/frontend/src/components/team_calendar/ScheduleEditModal/ScheduleEditModal.tsx
@@ -11,14 +11,16 @@ import TeamBadge from '~/components/team/TeamBadge/TeamBadge';
 import TimeTableMenu from '~/components/team_calendar/TimeTableMenu/TimeTableMenu';
 import Checkbox from '~/components/common/Checkbox/Checkbox';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
+import type { CalendarSize } from '~/types/size';
 
 interface ScheduleEditModalProps {
+  calendarSize?: CalendarSize;
   scheduleId: Schedule['id'];
   initialSchedule?: Schedule;
 }
 
 const ScheduleEditModal = (props: ScheduleEditModalProps) => {
-  const { scheduleId, initialSchedule } = props;
+  const { scheduleId, initialSchedule, calendarSize = 'md' } = props;
   const { closeModal } = useModal();
   const { teamPlaceColor, displayName } = useTeamPlace();
 
@@ -42,7 +44,7 @@ const ScheduleEditModal = (props: ScheduleEditModalProps) => {
   return (
     <Modal>
       <S.Backdrop onClick={closeModal} />
-      <S.Container>
+      <S.Container calendarSize={calendarSize}>
         <S.Header>
           <Button
             variant="plain"

--- a/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.styled.ts
+++ b/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.styled.ts
@@ -1,6 +1,7 @@
-import { styled, css } from 'styled-components';
+import { styled, css, type CSSProp } from 'styled-components';
+import type { CalendarSize } from '~/types/size';
 
-export const Container = styled.div`
+export const Container = styled.div<{ css: CSSProp }>`
   display: flex;
   flex-direction: column;
   z-index: ${({ theme }) => theme.zIndex.MODAL};
@@ -17,6 +18,8 @@ export const Container = styled.div`
     0 0 1px #1b1d1f33,
     0 15px 25px #1b1d1f33,
     0 5px 10px #1b1d1f1f;
+
+  ${({ css }) => css};
 `;
 
 export const Backdrop = styled.div`
@@ -87,3 +90,32 @@ export const closeButton = css`
 
   cursor: pointer;
 `;
+
+export const modalLocation = (
+  row: number,
+  column: number,
+  level: number,
+  calendarWidth: number,
+  calendarLeft: number,
+  calendarSize: CalendarSize,
+) => {
+  if (calendarSize === 'md')
+    return css`
+      position: absolute;
+      top: ${(row < 3 ? 92 : -199) + (row + 1) * 110 + level * 18}px;
+      left: ${(column > 3
+        ? calendarWidth / 7 - 550
+        : column === 3
+        ? -136.7
+        : 0) +
+      calendarLeft +
+      (calendarWidth * column) / 7}px;
+    `;
+
+  if (calendarSize == 'sm')
+    return css`
+      position: fixed;
+      top: 26%;
+      left: 12%;
+    `;
+};

--- a/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.tsx
+++ b/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from 'react';
 import Modal from '~/components/common/Modal/Modal';
 import Text from '~/components/common/Text/Text';
 import { useModal } from '~/hooks/useModal';
@@ -12,15 +11,22 @@ import { useDeleteSchedule } from '~/hooks/queries/useDeleteSchedule';
 import TeamBadge from '~/components/team/TeamBadge/TeamBadge';
 import { useToast } from '~/hooks/useToast';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
+import type { CalendarSize } from '~/types/size';
 
 interface ScheduleModalProps {
+  calendarSize?: CalendarSize;
   scheduleId: number;
   position: SchedulePosition;
   onOpenScheduleEditModal: () => void;
 }
 
 const ScheduleModal = (props: ScheduleModalProps) => {
-  const { scheduleId, position, onOpenScheduleEditModal } = props;
+  const {
+    scheduleId,
+    position,
+    onOpenScheduleEditModal,
+    calendarSize = 'md',
+  } = props;
   const { closeModal } = useModal();
   const { showToast } = useToast();
   const { teamPlaceColor, teamPlaceId, displayName } = useTeamPlace();
@@ -32,13 +38,6 @@ const ScheduleModal = (props: ScheduleModalProps) => {
   const { title, startDateTime, endDateTime } = scheduleById;
 
   const { row, column, level } = position;
-  const modalLocation: CSSProperties = {
-    position: 'absolute',
-    top: row < 3 ? `${(row + 1) * 120 + level * 18 + 60}px` : 'none',
-    bottom: row >= 3 ? `${(6 - row) * 120 - level * 18}px` : 'none',
-    left: column < 3 ? `${(column * 100) / 7}%` : 'none',
-    right: column >= 3 ? `${((6 - column) * 100) / 7}%` : 'none',
-  };
 
   const handleScheduleDelete = () => {
     if (confirm('일정을 삭제하시겠어요?')) {
@@ -54,7 +53,9 @@ const ScheduleModal = (props: ScheduleModalProps) => {
   return (
     <Modal>
       <S.Backdrop onClick={closeModal} />
-      <S.Container style={modalLocation}>
+      <S.Container
+        css={S.modalLocation(row, column, level, 1, 1, calendarSize)}
+      >
         <S.Header>
           <S.TeamWrapper>
             <TeamBadge teamPlaceColor={teamPlaceColor} size="lg" />

--- a/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
+++ b/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
@@ -212,10 +212,14 @@ const TeamCalendar = (props: TeamCalendarProps) => {
         </div>
       </S.Container>
       {isModalOpen && modalType === MODAL_OPEN_TYPE.ADD && (
-        <ScheduleAddModal clickedDate={clickedDate} />
+        <ScheduleAddModal
+          calendarSize={calendarSize}
+          clickedDate={clickedDate}
+        />
       )}
       {isModalOpen && modalType === MODAL_OPEN_TYPE.VIEW && (
         <ScheduleModal
+          calendarSize={calendarSize}
           scheduleId={modalScheduleId}
           position={modalPosition}
           onOpenScheduleEditModal={() => handleModalOpen(MODAL_OPEN_TYPE.EDIT)}
@@ -223,6 +227,7 @@ const TeamCalendar = (props: TeamCalendarProps) => {
       )}
       {isModalOpen && modalType === MODAL_OPEN_TYPE.EDIT && (
         <ScheduleEditModal
+          calendarSize={calendarSize}
           scheduleId={modalScheduleId}
           initialSchedule={schedules.find(
             (schedule) => schedule.id === modalScheduleId,
@@ -231,6 +236,7 @@ const TeamCalendar = (props: TeamCalendarProps) => {
       )}
       {isModalOpen && modalType === MODAL_OPEN_TYPE.DAILY && (
         <DailyScheduleModal
+          calendarSize={calendarSize}
           rawDate={dailyModalDate}
           position={dailyModalPosition}
           onScheduleModalOpen={handleScheduleModalOpen}


### PR DESCRIPTION
# [FE] 모아보기 페이지 모달 UI 개선
## 이슈번호
> close #151 #531

## PR 내용
모아보기 페이지에서 모달들의 위치의 각 도메인별 영역으로 고정했습니다.
 캘린더의 일정 등록 수정 조회, 하루조회 모달은 클릭한 위치에 상관없이 고정됩니다.

요토의 PR과 합쳐야 합니다. 또한 제 PR에서 캘린더 페이지의 모달 위치는 요토 PR 과 합치기 위해 상수 박아둔거라 이상하게 보일 가능성이 큽니다. 모아보기 페이지 모달만 확인하면 됩니다.

<img width="1279" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/af78e172-748f-46ee-8b82-256e7f3e47f1">
<img width="1280" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/d603f7c8-9f6f-487e-a399-fd059696a0cc">
<img width="1280" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/7152dfb1-9c96-407f-8254-33217df07f59">
<img width="1280" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/64ff4145-4e49-496b-92ea-9bb569d75faf">
<img width="1280" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/dfc087fc-ec8c-439e-96cb-5525355d785e">

## 참고자료

## 의논할 거리
