### PR TITLE
[FE] 알림이 오는 액션 이후 thread 관련 쿼리를 무효화

### DIFF
--- a/frontend/src/hooks/queries/useDeleteSchedule.ts
+++ b/frontend/src/hooks/queries/useDeleteSchedule.ts
@@ -11,6 +11,7 @@ export const useDeleteSchedule = (teamPlaceId: number, scheduleId: number) => {
         queryClient.removeQueries(['schedule', teamPlaceId, scheduleId]);
         queryClient.invalidateQueries(['mySchedules']);
         queryClient.invalidateQueries(['myDailySchedules']);
+        queryClient.invalidateQueries(['threadData', teamPlaceId]);
       },
       onError: () => {
         alert('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');

--- a/frontend/src/hooks/queries/useDeleteTeamLink.ts
+++ b/frontend/src/hooks/queries/useDeleteTeamLink.ts
@@ -8,6 +8,7 @@ export const useDeleteTeamLink = (teamPlaceId: number) => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['teamLinks', teamPlaceId]);
+        queryClient.invalidateQueries(['threadData', teamPlaceId]);
       },
     },
   );

--- a/frontend/src/hooks/queries/useModifySchedule.ts
+++ b/frontend/src/hooks/queries/useModifySchedule.ts
@@ -15,6 +15,7 @@ export const useModifySchedule = (
         queryClient.invalidateQueries(['schedule', teamPlaceId, scheduleId]);
         queryClient.invalidateQueries(['mySchedules']);
         queryClient.invalidateQueries(['myDailySchedules']);
+        queryClient.invalidateQueries(['threadData', teamPlaceId]);
       },
     },
   );

--- a/frontend/src/hooks/queries/useSendSchedule.ts
+++ b/frontend/src/hooks/queries/useSendSchedule.ts
@@ -11,6 +11,7 @@ export const useSendSchedule = (teamPlaceId: number) => {
         queryClient.invalidateQueries(['schedules', teamPlaceId]);
         queryClient.invalidateQueries(['mySchedules']);
         queryClient.invalidateQueries(['myDailySchedules']);
+        queryClient.invalidateQueries(['threadData', teamPlaceId]);
       },
     },
   );

--- a/frontend/src/hooks/queries/useSendTeamLink.ts
+++ b/frontend/src/hooks/queries/useSendTeamLink.ts
@@ -7,8 +7,10 @@ export const useSendTeamLink = (teamPlaceId: number) => {
   const { mutate } = useMutation(
     (body: TeamLinkWithoutInfo) => sendTeamLink(teamPlaceId, body),
     {
-      onSuccess: () =>
-        queryClient.invalidateQueries(['teamLinks', teamPlaceId]),
+      onSuccess: () => {
+        queryClient.invalidateQueries(['teamLinks', teamPlaceId]);
+        queryClient.invalidateQueries(['threadData', teamPlaceId]);
+      },
     },
   );
 


### PR DESCRIPTION
# [FE] 알림이 오는 액션 이후 thread 관련 쿼리를 무효화
## 이슈번호
> close #547 

## PR 내용
- [FE] 알림이 오는 액션 이후 thread 관련 쿼리를 무효화하여 갱신되도록 수정
