### PR TITLE
[FE] 팀 이름이 길면 선택칸 보다 넘치는 버그 수정

### DIFF
--- a/frontend/src/components/team/TeamPlaceMenu/TeamPlaceMenu.styled.ts
+++ b/frontend/src/components/team/TeamPlaceMenu/TeamPlaceMenu.styled.ts
@@ -10,12 +10,15 @@ export const teamPlaceButton = css`
 `;
 
 export const teamPlaceName = css`
+  display: block;
   overflow: hidden;
-  white-space: nowrap;
   text-overflow: ellipsis;
 
-  font-size: 26px;
-  font-weight: bold;
+  width: 300px;
+  margin-left: 6px;
+
+  font: bold 24px/26px 'Pretendard';
+  white-space: nowrap;
 `;
 
 export const teamName = css`

--- a/frontend/src/components/team/TeamPlaceMenu/TeamPlaceMenu.tsx
+++ b/frontend/src/components/team/TeamPlaceMenu/TeamPlaceMenu.tsx
@@ -28,6 +28,7 @@ const TeamPlaceMenu = (props: TeamPlaceMenuProps) => {
         type="button"
         css={S.teamPlaceButton}
         aria-label="목록에서 팀 선택하기"
+        title={displayValue}
       >
         <Text as="span" css={S.teamPlaceName}>
           {displayValue}


### PR DESCRIPTION
# [FE] 팀 이름이 길면 선택칸 보다 넘치는 버그 수정
## 이슈번호
> close #549 

## PR 내용
<img width="346" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/9823d9b9-5488-4779-b8d5-cc691ab76c11">

## 참고자료

## 의논할 거리
