### PR TITLE
[ALL] main 브렌치 발생 release만 배포

### DIFF
--- a/.github/workflows/deploy-prod-latest.yml
+++ b/.github/workflows/deploy-prod-latest.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   build-backend:
+    name: Run for main branch only
+    if: github.event.release.target_commitish == 'main'
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -51,6 +53,8 @@ jobs:
           path: backend/build/libs/*.jar
 
   build-frontend:
+    name: Run for main branch only
+    if: github.event.release.target_commitish == 'main'
     runs-on: ubuntu-22.04
     defaults:
       run:


### PR DESCRIPTION
## PR 내용

- Release 생성시 운영서버 배포 워크플로우에 해당 release가 main브랜치에서 생성된 것인지 확인 추가

## 참고자료

[공식문서](https://docs.github.com/en/free-pro-team@latest/rest/releases/releases?apiVersion=2022-11-28#list-releases)

[stack over flow link](https://stackoverflow.com/questions/71083657/trigger-github-workflow-only-on-the-release-tag-event-and-specific-path)

## 의논할 거리
