### PR TITLE
[BE] 500 에러 로깅용 코드 작성(에러 메시지 반환은 하지 않음)

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/exception/AuthenticationException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/exception/AuthenticationException.java
@@ -1,14 +1,12 @@
 package team.teamby.teambyteam.auth.exception;
 
-import team.teamby.teambyteam.member.exception.MemberException;
-
 public class AuthenticationException extends RuntimeException {
 
     public AuthenticationException(final String message) {
         super(message);
     }
 
-    public static class FailAuthenticationException extends MemberException {
+    public static class FailAuthenticationException extends AuthenticationException {
         public FailAuthenticationException() {
             super("인증이 실패했습니다.");
         }

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -23,6 +23,8 @@ import java.time.format.DateTimeParseException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final String INTERNAL_SERVER_ERROR_MESSAGE = "관리자에게 문의하세요.";
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
         final String defaultErrorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
@@ -97,5 +99,16 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(value = {
+            RuntimeException.class
+    })
+    public ResponseEntity<ErrorResponse> handleRuntimeException(final RuntimeException exception) {
+        final String message = exception.getMessage();
+        log.warn(message);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(INTERNAL_SERVER_ERROR_MESSAGE));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -4,9 +4,11 @@ import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import team.teamby.teambyteam.auth.exception.AuthenticationException;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
@@ -17,13 +19,12 @@ import team.teamby.teambyteam.teamplace.exception.TeamPlaceInviteCodeException;
 import team.teamby.teambyteam.token.exception.TokenException;
 
 import java.time.DateTimeException;
-import java.time.format.DateTimeParseException;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final String INTERNAL_SERVER_ERROR_MESSAGE = "관리자에게 문의하세요.";
+    private static final String DEFAULT_ERROR_MESSAGE = "관리자에게 문의하세요.";
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
@@ -35,7 +36,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = {
-            DateTimeParseException.class,
+            HttpMessageNotReadableException.class,
             DateTimeException.class
     })
     public ResponseEntity<ErrorResponse> handleDateTimeParseException(final DateTimeException exception) {
@@ -43,6 +44,16 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse("DateTime 형식이 잘못되었습니다. 서버 관리자에게 문의해주세요."));
+    }
+
+    @ExceptionHandler(value = {
+            MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(final MethodArgumentTypeMismatchException exception) {
+        log.warn(exception.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(value = {
@@ -109,6 +120,6 @@ public class GlobalExceptionHandler {
         log.warn(message);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse(INTERNAL_SERVER_ERROR_MESSAGE));
+                .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -25,6 +25,7 @@ import java.time.DateTimeException;
 public class GlobalExceptionHandler {
 
     private static final String DEFAULT_ERROR_MESSAGE = "관리자에게 문의하세요.";
+    private static final String DEFAULT_FORMAT_ERROR_MESSAGE = "잘못된 형식입니다.";
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
@@ -53,7 +54,7 @@ public class GlobalExceptionHandler {
         log.warn(exception.getMessage());
 
         return ResponseEntity.badRequest()
-                .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE));
+                .body(new ErrorResponse(DEFAULT_FORMAT_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(value = {


### PR DESCRIPTION
## 이슈번호
#563 

## PR 내용
500 에러 로깅을 위한 코드입니다.

HttpMessageNotReadableException: 일정 수정 시 json 에러를 잡는다. 
예시) 10:10이 아니라 10-10 
발생위치 추정: @RequestBody 

DateTimeException: 기간 요청에 잘못된 형식으로 요청하는 경우 
예시) -1월 
발생 위치 추정: Service 계층 

MethodArgumentTypeMismatchException: 기간 요쳥에 잘못된 형식으로 요쳥하는 경우 
예시)y2023 
발생 위치 추정: @RequestParam

## 참고자료

## 의논할 거리
