### PR TITLE
[BE] 예외상황시 발생로그 레벨 변경

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import team.teamby.teambyteam.teamplace.exception.TeamPlaceInviteCodeException;
 import team.teamby.teambyteam.token.exception.TokenException;
 
 import java.time.DateTimeException;
+import java.util.Random;
 
 @Slf4j
 @RestControllerAdvice
@@ -26,6 +27,11 @@ public class GlobalExceptionHandler {
 
     private static final String DEFAULT_ERROR_MESSAGE = "관리자에게 문의하세요.";
     private static final String DEFAULT_FORMAT_ERROR_MESSAGE = "잘못된 형식입니다.";
+
+    private static final Random random = new Random();
+    private static final String ERROR_KEY_FORMAT = "%n error key : %s";
+    private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
+    private static final int ERROR_KEY_LENGTH = 5;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
@@ -118,9 +124,15 @@ public class GlobalExceptionHandler {
     })
     public ResponseEntity<ErrorResponse> handleRuntimeException(final RuntimeException exception) {
         final String message = exception.getMessage();
-        log.error(message);
+
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ERROR_KEY_LENGTH; i++) {
+            sb.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
+        }
+        final String errorKeyInfo = String.format(ERROR_KEY_FORMAT, sb.toString());
+        log.error(message + errorKeyInfo);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE));
+                .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE + errorKeyInfo));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -118,7 +118,7 @@ public class GlobalExceptionHandler {
     })
     public ResponseEntity<ErrorResponse> handleRuntimeException(final RuntimeException exception) {
         final String message = exception.getMessage();
-        log.warn(message);
+        log.error(message);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE));

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -33,6 +33,8 @@ public class GlobalExceptionHandler {
     private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
     private static final int ERROR_KEY_LENGTH = 5;
 
+    private static final String EXCEPTION_CLASS_TYPE_MESSAGE_FORMANT = "%n class type : %s";
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
         final String defaultErrorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
@@ -130,7 +132,9 @@ public class GlobalExceptionHandler {
             sb.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
         }
         final String errorKeyInfo = String.format(ERROR_KEY_FORMAT, sb.toString());
-        log.error(message + errorKeyInfo);
+        final String exceptionTypeInfo = String.format(EXCEPTION_CLASS_TYPE_MESSAGE_FORMANT, exception.getClass());
+
+        log.error(message + errorKeyInfo + exceptionTypeInfo);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE + errorKeyInfo));


### PR DESCRIPTION
## PR 내용

- Runtime Exception시 생성되는 예외 로그 레벨 error로 변경
  - 해당 예외는 우리가 처리하지 못한 예외여서 warn이 아닌 error로 로깅이 되는것이 더 적합하다고 판단하여 수정했습니다.

- 예외메시지 로깅 및 출력시 예외 키값 추가
  - 사용자에게 예외발생에 대한 문의시 어떠한 오류인지 로그 트레이싱이 쉽도록 예외키값 추가
  - 사용자가 요청한 시간 또는 날짜를 추정할 수 있어서 모든 로깅에 대해서 unique한 값을 보장할 필요가 없다고 판단

## 참고자료

## 의논할 거리
