### PR TITLE
[BE] 팀플레이스 색상 변경 기능 / 문서화 구현

### DIFF
--- a/backend/src/docs/asciidoc/teamPlace.adoc
+++ b/backend/src/docs/asciidoc/teamPlace.adoc
@@ -69,3 +69,36 @@ include::{snippets}/teamPlaces/getInviteCode/failWithForbiddenMember/http-reques
 ==== Response
 
 include::{snippets}/teamPlaces/getInviteCode/failWithForbiddenMember/http-response.adoc[]
+
+=== 3. 팀플레이스 색상 변경
+
+====== 요청 Header
+include::{snippets}/teamPlaces/changeTeamPlaceColor/success/request-headers.adoc[]
+
+==== Request
+include::{snippets}/teamPlaces/changeTeamPlaceColor/success/http-request.adoc[]
+include::{snippets}/teamPlaces/changeTeamPlaceColor/success/request-fields.adoc[]
+
+
+==== Response
+include::{snippets}/teamPlaces/changeTeamPlaceColor/success/http-response.adoc[]
+
+=== 3.1 소속되지 않은 팀플레이스 색상 변경 실패
+
+==== Request
+
+include::{snippets}/teamPlaces/changeTeamPlaceColor/failWhenNotParticipatedTeamPlace/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/teamPlaces/changeTeamPlaceColor/failWhenNotParticipatedTeamPlace/http-response.adoc[]
+
+=== 3.2 존재하지 않는 팀플레이스 색상 번호 요청 시 실패
+
+==== Request
+
+include::{snippets}/teamPlaces/changeTeamPlaceColor/failWhenNotExistTeamPlaceColor/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/teamPlaces/changeTeamPlaceColor/failWhenNotExistTeamPlaceColor/http-response.adoc[]

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -111,7 +111,8 @@ public class GlobalExceptionHandler {
             ScheduleException.SpanWrongOrderException.class,
             TeamPlaceInviteCodeException.LengthException.class,
             TeamPlaceException.NameLengthException.class,
-            TeamPlaceException.NameBlankException.class
+            TeamPlaceException.NameBlankException.class,
+            MemberTeamPlaceException.TeamPlaceColorNotExistException.class
     })
     public ResponseEntity<ErrorResponse> handleCustomBadRequestException(final RuntimeException exception) {
         final String message = exception.getMessage();

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -106,6 +106,7 @@ public class MemberTeamPlace extends BaseEntity {
 
     public void changeTeamPlaceColor(final TeamPlaceColor teamPlaceColor) {
         this.teamPlaceColor = teamPlaceColor;
+    }
 
     public boolean isOwnedBy(final Member member) {
         return this.member.equals(member);

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -104,6 +104,10 @@ public class MemberTeamPlace extends BaseEntity {
         this.displayMemberName = displayMemberName;
     }
 
+    public void changeTeamPlaceColor(final TeamPlaceColor teamPlaceColor) {
+        this.teamPlaceColor = teamPlaceColor;
+    }
+
     public boolean isOwnedBy(final Member member) {
         return this.member.equals(member);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/TeamPlaceColor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/TeamPlaceColor.java
@@ -2,6 +2,9 @@ package team.teamby.teambyteam.member.domain;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -19,4 +22,11 @@ public enum TeamPlaceColor {
     J(9);
 
     private final int colorNumber;
+
+    public static TeamPlaceColor findTeamPlaceColor(int colorNumber) {
+        return Arrays.stream(values())
+                .filter(teamPlaceColor -> teamPlaceColor.colorNumber == colorNumber)
+                .findAny()
+                .orElseThrow(() -> new MemberTeamPlaceException.TeamPlaceColorNotExistException(colorNumber));
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberTeamPlaceException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/exception/MemberTeamPlaceException.java
@@ -46,4 +46,14 @@ public class MemberTeamPlaceException extends RuntimeException {
             );
         }
     }
+
+    public static class TeamPlaceColorNotExistException extends MemberTeamPlaceException {
+
+        public TeamPlaceColorNotExistException(final int colorNumber) {
+            super(String.format(
+                    "존재하지 않는 팀 플레이스 색상입니다. - request info { team_place_color : %d }",
+                    colorNumber
+            ));
+        }
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
@@ -102,14 +102,14 @@ public class TeamPlaceService {
     public void changeMemberTeamPlaceColor(final MemberEmailDto memberEmailDto,
                                            final Long teamPlaceId,
                                            final TeamPlaceChangeColorRequest request) {
-        String memberEmail = memberEmailDto.email();
-        IdOnly memberId = memberRepository.findIdByEmail(new Email(memberEmail))
+        final String memberEmail = memberEmailDto.email();
+        final IdOnly memberId = memberRepository.findIdByEmail(new Email(memberEmail))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmail));
 
-        MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, memberId.id())
+        final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, memberId.id())
                 .orElseThrow(() -> new MemberTeamPlaceException.NotFoundParticipatedTeamPlaceException(memberEmail, teamPlaceId));
 
-        TeamPlaceColor findTeamPlaceColor = TeamPlaceColor.findTeamPlaceColor(request.teamPlaceColor());
+        final TeamPlaceColor findTeamPlaceColor = TeamPlaceColor.findTeamPlaceColor(request.teamPlaceColor());
         memberTeamPlace.changeTeamPlaceColor(findTeamPlaceColor);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
@@ -5,12 +5,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
+import team.teamby.teambyteam.member.domain.TeamPlaceColor;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceInviteCodeResponse;
@@ -93,5 +97,19 @@ public class TeamPlaceService {
                 .toList();
 
         return TeamPlaceMembersResponse.from(teamPlaceMembers);
+    }
+
+    public void changeMemberTeamPlaceColor(final MemberEmailDto memberEmailDto,
+                                           final Long teamPlaceId,
+                                           final TeamPlaceChangeColorRequest request) {
+        String memberEmail = memberEmailDto.email();
+        IdOnly memberId = memberRepository.findIdByEmail(new Email(memberEmail))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmail));
+
+        MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, memberId.id())
+                .orElseThrow(() -> new MemberTeamPlaceException.NotFoundParticipatedTeamPlaceException(memberEmail, teamPlaceId));
+
+        TeamPlaceColor findTeamPlaceColor = TeamPlaceColor.findTeamPlaceColor(request.teamPlaceColor());
+        memberTeamPlace.changeTeamPlaceColor(findTeamPlaceColor);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceChangeColorRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceChangeColorRequest.java
@@ -1,0 +1,4 @@
+package team.teamby.teambyteam.teamplace.application.dto;
+
+public record TeamPlaceChangeColorRequest(int teamPlaceColor) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.teamplace.application.TeamPlaceService;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceInviteCodeResponse;
@@ -52,5 +54,15 @@ public class TeamPlaceController {
         final TeamPlaceMembersResponse response = teamPlaceService.findMembers(teamPlaceId, memberEmailDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/{teamPlaceId}/color")
+    public ResponseEntity<Void> changeMemberTeamPlaceColor(
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
+            @PathVariable final Long teamPlaceId,
+            @RequestBody final TeamPlaceChangeColorRequest teamPlaceChangeColorRequest) {
+        teamPlaceService.changeMemberTeamPlaceColor(memberEmailDto, teamPlaceId, teamPlaceChangeColorRequest);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamPlaceAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamPlaceAcceptanceFixture.java
@@ -5,6 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 
 public class TeamPlaceAcceptanceFixture {
@@ -33,6 +34,20 @@ public class TeamPlaceAcceptanceFixture {
         return RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token)
                 .get("/api/team-places/{teamPlaceId}/members", teamPlaceId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> CHANGE_MEMBER_TEAM_PLACE_COLOR(
+            final String token,
+            final Long teamPlaceId,
+            final TeamPlaceChangeColorRequest request
+    ) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .patch("/api/team-places/{teamPlaceId}/color", teamPlaceId)
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/TeamPlaceColorTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/TeamPlaceColorTest.java
@@ -1,0 +1,37 @@
+package team.teamby.teambyteam.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TeamPlaceColorTest {
+
+    @Test
+    @DisplayName("올바른 색상 번호로 해당 팀 플레이스 색상을 찾는다.")
+    void findTeamPlaceColor() {
+        // given
+        final TeamPlaceColor teamPlaceColor = TeamPlaceColor.A;
+        final int colorNumber = teamPlaceColor.getColorNumber();
+
+        // when
+        final TeamPlaceColor findTeamPlaceColor = TeamPlaceColor.findTeamPlaceColor(colorNumber);
+
+        // then
+        assertThat(findTeamPlaceColor).isEqualTo(teamPlaceColor);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 10})
+    @DisplayName("존재하지 않는 색상 번호로 해당 팀 플레이스 색상을 찾을 시 예외가 발생한다.")
+    void failFindTeamPlaceColorWhenNotExistColorNumber(int notExistColorNumber) {
+        // when & then
+        assertThatThrownBy(() -> TeamPlaceColor.findTeamPlaceColor(notExistColorNumber))
+                .isInstanceOf(MemberTeamPlaceException.TeamPlaceColorNotExistException.class)
+                .hasMessage(String.format("존재하지 않는 팀 플레이스 색상입니다. - request info { team_place_color : %d }", notExistColorNumber));
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/TeamPlaceColorTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/TeamPlaceColorTest.java
@@ -28,7 +28,7 @@ class TeamPlaceColorTest {
     @ParameterizedTest
     @ValueSource(ints = {-1, 10})
     @DisplayName("존재하지 않는 색상 번호로 해당 팀 플레이스 색상을 찾을 시 예외가 발생한다.")
-    void failFindTeamPlaceColorWhenNotExistColorNumber(int notExistColorNumber) {
+    void failFindTeamPlaceColorWhenNotExistColorNumber(final int notExistColorNumber) {
         // when & then
         assertThatThrownBy(() -> TeamPlaceColor.findTeamPlaceColor(notExistColorNumber))
                 .isInstanceOf(MemberTeamPlaceException.TeamPlaceColorNotExistException.class)

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -15,6 +15,7 @@ import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceInviteCodeResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceMemberResponse;
@@ -34,6 +35,7 @@ import static team.teamby.teambyteam.common.fixtures.TokenFixtures.EXPIRED_ACCES
 import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MALFORMED_JWT_TOKEN;
 import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MISSING_CLAIM_ACCESS_TOKEN;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
+import static team.teamby.teambyteam.common.fixtures.acceptance.TeamPlaceAcceptanceFixture.CHANGE_MEMBER_TEAM_PLACE_COLOR;
 import static team.teamby.teambyteam.common.fixtures.acceptance.TeamPlaceAcceptanceFixture.CREATE_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.acceptance.TeamPlaceAcceptanceFixture.GET_MEMBERS_REQUEST;
 import static team.teamby.teambyteam.common.fixtures.acceptance.TeamPlaceAcceptanceFixture.GET_TEAM_PLACE_INVITE_CODE;
@@ -293,6 +295,151 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
 
             // when
             final ExtractableResponse<Response> response = GET_MEMBERS_REQUEST(accessToken, notParticipatedTeamPlaceId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+                softly.assertThat(response.jsonPath().getString("error")).contains("접근할 수 없는 팀플레이스입니다.");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("팀 플레이스 색상 변경 시")
+    class ChangeMemberTeamPlaceColor {
+        private Member member;
+        private TeamPlace teamPlace;
+        private MemberTeamPlace memberTeamPlace;
+
+        @BeforeEach
+        void setUp() {
+            member = testFixtureBuilder.buildMember(SEONGHA());
+            teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            memberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
+        }
+
+        @Test
+        @DisplayName("팀 플레이스 색상 변경에 성공한다.")
+        void success() {
+            // given
+            final int teamPlaceColorToChange = 1;
+            final String token = jwtTokenProvider.generateAccessToken(member.getEmail().getValue());
+            final Long teamPlaceId = teamPlace.getId();
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(token, teamPlaceId, request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원이면 실패한다.")
+        void failWhenNotExistMember() {
+            // given
+            final int teamPlaceColorToChange = 1;
+            final String notExistMemberToken = jwtTokenProvider.generateAccessToken("notExistMemberEmail@gmail.com");
+            final Long teamPlaceId = teamPlace.getId();
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(notExistMemberToken, teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+                softly.assertThat(response.jsonPath().getString("error")).contains("조회한 멤버가 존재하지 않습니다.");
+            });
+        }
+
+        @Test
+        @DisplayName("만료된 토큰으로 요청을 보내면 실패한다.")
+        void failWhenExpiredToken() {
+            // given
+            final int teamPlaceColorToChange = 1;
+            final String expiredToken = EXPIRED_ACCESS_TOKEN;
+            final Long teamPlaceId = teamPlace.getId();
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(expiredToken, teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.jsonPath().getString("error")).isEqualTo("EXPIRED_ACCESS_TOKEN");
+            });
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰 형식으로 요청을 보내면 실패한다.")
+        void failWhenWrongToken() {
+            // given
+            final int teamPlaceColorToChange = 1;
+            final String malformedToken = MALFORMED_JWT_TOKEN;
+            final Long teamPlaceId = teamPlace.getId();
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(malformedToken, teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.jsonPath().getString("error")).isEqualTo("인증이 실패했습니다.");
+            });
+        }
+
+        @Test
+        @DisplayName("이메일이 누락된 토큰으로 요청을 보내면 실패한다.")
+        void failWhenMissingClaimToken() {
+            // given
+            final int teamPlaceColorToChange = 1;
+            final String missingClaimToken = MISSING_CLAIM_ACCESS_TOKEN;
+            final Long teamPlaceId = teamPlace.getId();
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(missingClaimToken, teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.jsonPath().getString("error")).isEqualTo("인증이 실패했습니다.");
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 10})
+        @DisplayName("요청한 색상 번호가 존재하지 않으면 실패한다.")
+        void failWhenNotExistTeamPlaceColor(int notExistTeamPlaceColor) {
+            // given
+            final String token = jwtTokenProvider.generateAccessToken(member.getEmail().getValue());
+            final Long teamPlaceId = teamPlace.getId();
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(notExistTeamPlaceColor);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(token, teamPlaceId, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(response.jsonPath().getString("error")).contains("존재하지 않는 팀 플레이스 색상입니다.");
+            });
+        }
+
+        @Test
+        @DisplayName("회원이 소속된 팀플레이스가 아니라면 실패한다.")
+        void failWhenNotParticipatedTeamPlace() {
+            // given
+            final int teamPlaceColorToChange = 1;
+            final String token = jwtTokenProvider.generateAccessToken(member.getEmail().getValue());
+            final Long notParticipatedTeamPlaceId = 2L;
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(token, notParticipatedTeamPlaceId, request);
 
             // then
             assertSoftly(softly -> {

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
@@ -15,6 +15,8 @@ import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.DisplayTeamPlaceName;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceInviteCodeResponse;
@@ -33,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ENDEL;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
@@ -185,6 +188,75 @@ class TeamPlaceServiceTest extends ServiceTest {
 
             // then
             assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+        }
+    }
+
+    @Nested
+    @DisplayName("팀 플레이스 색상 변경 시")
+    class ChangeTeamPlaceColor {
+
+        @Test
+        @DisplayName("변경에 성공한다.")
+        void success() {
+            // given
+            final Member member = testFixtureBuilder.buildMember(PHILIP());
+            final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
+
+            final MemberEmailDto memberEmailDto = new MemberEmailDto(member.getEmail().getValue());
+            final Long teamPlaceId = teamPlace.getId();
+            final int teamPlaceColorToChange = 9;
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when
+            teamPlaceService.changeMemberTeamPlaceColor(memberEmailDto, teamPlaceId, request);
+            final MemberTeamPlace findMemberTeamPlace =
+                    memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlace.getId(), member.getId()).get();
+
+            // then
+            assertThat(findMemberTeamPlace.getTeamPlaceColor().getColorNumber()).isEqualTo(teamPlaceColorToChange);
+        }
+
+        @Test
+        @DisplayName("이메일에 해당하는 멤버가 없으면 예외가 발생한다.")
+        void failWhenNotExistMemberEmail() {
+            // given
+            final Member member = testFixtureBuilder.buildMember(PHILIP());
+            final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
+            final String notExistMemberEmail = "notExistMemberEmail@gmail.com";
+
+            final MemberEmailDto memberEmailDto = new MemberEmailDto(notExistMemberEmail);
+            final Long teamPlaceId = teamPlace.getId();
+            final int teamPlaceColorToChange = 9;
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when & then
+            assertThatThrownBy(() -> teamPlaceService.changeMemberTeamPlaceColor(memberEmailDto, teamPlaceId, request))
+                    .isInstanceOf(MemberException.MemberNotFoundException.class)
+                    .hasMessage(String.format("조회한 멤버가 존재하지 않습니다. - request info { email : %s }",
+                            notExistMemberEmail));
+        }
+
+        @Test
+        @DisplayName("팀 플레이스 ID, 멤버 ID에 해당하는 MemberTeamPlace가 없으면 예외가 발생한다.")
+        void failWhenNotExistMemberTeamPlace() {
+            // given
+            final Member member = testFixtureBuilder.buildMember(PHILIP());
+            final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+
+            final  MemberEmailDto memberEmailDto = new MemberEmailDto(member.getEmail().getValue());
+            final Long teamPlaceId = teamPlace.getId();
+            final int teamPlaceColorToChange = 9;
+            final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
+
+            // when & then
+            assertThatThrownBy(() -> teamPlaceService.changeMemberTeamPlaceColor(memberEmailDto, teamPlaceId, request))
+                    .isInstanceOf(MemberTeamPlaceException.NotFoundParticipatedTeamPlaceException.class)
+                    .hasMessage(String.format(
+                            "해당 팀 플레이스에 가입되어 있지 않습니다. - request info { member_email : %s, team_place_id : %d }",
+                            memberEmailDto.email(),
+                            teamPlaceId));
         }
     }
 }


### PR DESCRIPTION
## 이슈번호
> close #588 #589 

## PR 내용
- 팀 플레이스 색상 변경 기능 / 문서화 구현
 - `TeamPlaceColor` ENUM에서 ColorNumber에 해당하는 색상 찾아서 반환하는 기능 추가
   -  색상 번호에 해당하는 TeamPlaceColor가 없다면 커스텀 예외 발생해서 Handler에서 400으로 처리하도록 구현
  - API URI가 `/api/team-places/{teamPlaceId}/color` 이므로 TeamPlaceController가 존재하는 TeamPlace 패키지(TeamPlaceService)에서 구현


## 참고자료

## 의논할 거리
