### PR TITLE
[BE] 소속된 팀의 팀원 조회시 본인 여부 필드 추가

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -104,6 +104,10 @@ public class MemberTeamPlace extends BaseEntity {
         this.displayMemberName = displayMemberName;
     }
 
+    public boolean isOwnedBy(final Member member) {
+        return this.member.equals(member);
+    }
+
     public Long findMemberId() {
         return member.getId();
     }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
@@ -14,6 +14,7 @@ import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceInviteCodeResponse;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceMemberResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceMembersResponse;
 import team.teamby.teambyteam.teamplace.domain.RandomInviteCodeGenerator;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
@@ -82,8 +83,15 @@ public class TeamPlaceService {
     }
 
     @Transactional(readOnly = true)
-    public TeamPlaceMembersResponse findMembers(final Long teamPlaceId) {
+    public TeamPlaceMembersResponse findMembers(final Long teamPlaceId, final MemberEmailDto memberEmailDto) {
+        final Member loginMember = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
         final List<MemberTeamPlace> memberTeamPlaces = memberTeamPlaceRepository.findAllByTeamPlaceId(teamPlaceId);
-        return TeamPlaceMembersResponse.from(memberTeamPlaces);
+
+        final List<TeamPlaceMemberResponse> teamPlaceMembers = memberTeamPlaces.stream()
+                .map(memberTeamPlace -> TeamPlaceMemberResponse.of(memberTeamPlace, loginMember))
+                .toList();
+
+        return TeamPlaceMembersResponse.from(teamPlaceMembers);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMemberResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMemberResponse.java
@@ -10,7 +10,7 @@ public record TeamPlaceMemberResponse(Long id, String name, String profileImageU
                 memberTeamPlace.findMemberId(),
                 memberTeamPlace.findMemberName(),
                 memberTeamPlace.findMemberProfileImageUrl(),
-                memberTeamPlace.getMember().equals(loginMember)
+                memberTeamPlace.isOwnedBy(loginMember)
         );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMemberResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMemberResponse.java
@@ -1,14 +1,16 @@
 package team.teamby.teambyteam.teamplace.application.dto;
 
+import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 
-public record TeamPlaceMemberResponse(Long id, String name, String profileImageUrl) {
+public record TeamPlaceMemberResponse(Long id, String name, String profileImageUrl, Boolean isMe) {
 
-    public static TeamPlaceMemberResponse of(final MemberTeamPlace memberTeamPlace) {
+    public static TeamPlaceMemberResponse of(final MemberTeamPlace memberTeamPlace, final Member loginMember) {
         return new TeamPlaceMemberResponse(
                 memberTeamPlace.findMemberId(),
                 memberTeamPlace.findMemberName(),
-                memberTeamPlace.findMemberProfileImageUrl()
+                memberTeamPlace.findMemberProfileImageUrl(),
+                memberTeamPlace.getMember().equals(loginMember)
         );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMembersResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMembersResponse.java
@@ -1,15 +1,10 @@
 package team.teamby.teambyteam.teamplace.application.dto;
 
-import team.teamby.teambyteam.member.domain.MemberTeamPlace;
-
 import java.util.List;
 
 public record TeamPlaceMembersResponse(List<TeamPlaceMemberResponse> members) {
 
-    public static TeamPlaceMembersResponse from(final List<MemberTeamPlace> memberTeamPlaces) {
-        return new TeamPlaceMembersResponse(memberTeamPlaces.stream()
-                .map(TeamPlaceMemberResponse::of)
-                .toList()
-        );
+    public static TeamPlaceMembersResponse from(final List<TeamPlaceMemberResponse> members) {
+        return new TeamPlaceMembersResponse(members);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
@@ -46,9 +46,10 @@ public class TeamPlaceController {
 
     @GetMapping("/{teamPlaceId}/members")
     public ResponseEntity<TeamPlaceMembersResponse> getTeamPlaceMembers(
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
             @PathVariable final Long teamPlaceId
     ) {
-        final TeamPlaceMembersResponse response = teamPlaceService.findMembers(teamPlaceId);
+        final TeamPlaceMembersResponse response = teamPlaceService.findMembers(teamPlaceId, memberEmailDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -251,9 +251,12 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
         @DisplayName("팀 플레이스 참여 멤버 조회에 성공한다.")
         void success() {
             // given
-            final TeamPlaceMembersResponse response = TeamPlaceMembersResponse.from(List.of(
-                    memberTeamPlace1, memberTeamPlace2, memberTeamPlace3, memberTeamPlace4
-            ));
+            final List<MemberTeamPlace> memberTeamPlaces = List.of(memberTeamPlace1, memberTeamPlace2, memberTeamPlace3, memberTeamPlace4);
+            final List<TeamPlaceMemberResponse> teamPlaceMembers = memberTeamPlaces.stream()
+                    .map(memberTeamPlace -> TeamPlaceMemberResponse.of(memberTeamPlace, member1))
+                    .toList();
+
+            final TeamPlaceMembersResponse response = TeamPlaceMembersResponse.from(teamPlaceMembers);
             final List<TeamPlaceMemberResponse> expectedResponse = response.members();
 
             final String accessToken = jwtTokenProvider.generateAccessToken(member1.getEmail().getValue());

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
@@ -18,6 +18,7 @@ import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceInviteCodeResponse;
+import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceMemberResponse;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceMembersResponse;
 import team.teamby.teambyteam.teamplace.domain.RandomInviteCodeGenerator;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
@@ -172,12 +173,15 @@ class TeamPlaceServiceTest extends ServiceTest {
             final MemberTeamPlace memberTeamPlace3 = testFixtureBuilder.buildMemberTeamPlace(SEONGHA, ENGLISH_TEAM_PLACE);
             final MemberTeamPlace memberTeamPlace4 = testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
 
-            final TeamPlaceMembersResponse expectedResponse = TeamPlaceMembersResponse.from(List.of(
-                    memberTeamPlace1, memberTeamPlace2, memberTeamPlace3, memberTeamPlace4
-            ));
+            final List<MemberTeamPlace> memberTeamPlaces = List.of(memberTeamPlace1, memberTeamPlace2, memberTeamPlace3, memberTeamPlace4);
+            final List<TeamPlaceMemberResponse> teamPlaceMembers = memberTeamPlaces.stream()
+                    .map(memberTeamPlace -> TeamPlaceMemberResponse.of(memberTeamPlace, PHILIP))
+                    .toList();
+
+            final TeamPlaceMembersResponse expectedResponse = TeamPlaceMembersResponse.from(teamPlaceMembers);
 
             // when
-            final TeamPlaceMembersResponse actualResponse = teamPlaceService.findMembers(ENGLISH_TEAM_PLACE.getId());
+            final TeamPlaceMembersResponse actualResponse = teamPlaceService.findMembers(ENGLISH_TEAM_PLACE.getId(), new MemberEmailDto(PHILIP.getEmail().getValue()));
 
             // then
             assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);


### PR DESCRIPTION
## 이슈번호
> close #592

## PR 내용

- 소속된 팀의 팀원 조회시 본인 여부 필드 추가

- 필드명 : `isMe`

## 참고자료

## 의논할 거리
