### PR TITLE
[BE] 회원 탈퇴 api 구현

### DIFF
--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -1,5 +1,5 @@
 == 멤버 API
-나의 정보 조회, 나의 참여한 팀플에이스 조회, 팀플레이스 탈퇴, 팀플레이스 참여
+나의 정보 조회, 나의 참여한 팀플레이스 조회, 팀플레이스 탈퇴, 팀플레이스 참여
 
 === 1. 나의 정보 조회
 
@@ -102,3 +102,22 @@ include::{snippets}/members/particiPateTeamPlace/fail/invalidLengthInviteCode/ht
 
 ==== Response
 include::{snippets}/members/particiPateTeamPlace/fail/invalidLengthInviteCode/http-response.adoc[]
+
+=== 5. 회원 탈퇴
+
+====== 요청 Header
+include::{snippets}/members/leaveAccount/success/request-headers.adoc[]
+
+==== Request
+include::{snippets}/members/leaveAccount/success/http-request.adoc[]
+
+==== Response
+include::{snippets}/members/leaveAccount/success/http-response.adoc[]
+
+=== 5-1. 회원 탈퇴 실패 (인증되지 않은 사용자)
+
+==== Request
+include::{snippets}/members/leaveAccount/fail/notRegistered/http-request.adoc[]
+
+==== Response
+include::{snippets}/members/leaveAccount/fail/notRegistered/http-response.adoc[]

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -114,10 +114,18 @@ include::{snippets}/members/leaveAccount/success/http-request.adoc[]
 ==== Response
 include::{snippets}/members/leaveAccount/success/http-response.adoc[]
 
-=== 5-1. 회원 탈퇴 실패 (인증되지 않은 사용자)
+=== 5-1. 회원 탈퇴 실패 (존재하지 않는 사용자)
 
 ==== Request
 include::{snippets}/members/leaveAccount/fail/notRegistered/http-request.adoc[]
 
 ==== Response
 include::{snippets}/members/leaveAccount/fail/notRegistered/http-response.adoc[]
+
+=== 5-2. 회원 탈퇴 실패 (인증되지 않은 사용자)
+
+==== Request
+include::{snippets}/members/leaveAccount/fail/unAuthorized/http-request.adoc[]
+
+==== Response
+include::{snippets}/members/leaveAccount/fail/unAuthorized/http-response.adoc[]

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -89,4 +89,12 @@ public class MemberService {
 
         return MemberInfoResponse.of(member);
     }
+
+    public void leaveMember(final MemberEmailDto memberEmailDto) {
+        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
+        memberRepository.delete(member);
+
+        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", memberEmailDto.email());
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -53,4 +53,10 @@ public class MemberController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @DeleteMapping("/account")
+    public ResponseEntity<Void> deleteAccount(@AuthPrincipal final MemberEmailDto memberEmailDto) {
+        memberService.leaveMember(memberEmailDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -37,6 +37,15 @@ public class MemberAcceptanceFixture {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> DELETE_ACCOUNT(final String token) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .when().log().all()
+                .delete("/api/me/account")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> PARTICIPATE_TEAM_PLACE_REQUEST(final String token, final String inviteCode) {
         return RestAssured.given().log().all()
                 .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -328,5 +328,21 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             //then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
         }
+
+        @Test
+        @DisplayName("잘못된 인증 토큰으로 요청시 401 에러를 반환한다.")
+        void failWithWrongToken() {
+            // given
+            final String WRONG_TOKEN = "12j40jf390.0we9ru2i3hr8.912jrkejfi23j";
+
+            // when
+            final ExtractableResponse<Response> response = DELETE_ACCOUNT(WRONG_TOKEN);
+
+            //then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
+            });
+        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -19,6 +19,7 @@ import team.teamby.teambyteam.teamplace.domain.TeamPlaceInviteCode;
 import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_ACCOUNT;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_LEAVE_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_MY_INFORMATION;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
@@ -293,6 +294,39 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자가 탈퇴 요청시")
+    class DeleteAccount {
+
+        @Test
+        @DisplayName("탈퇴에 성공한다.")
+        void success() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final String PHILIP_TOKEN = jwtTokenProvider.generateAccessToken(PHILIP.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = DELETE_ACCOUNT(PHILIP_TOKEN);
+
+            //then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자로 요청시 실패한다.")
+        void failWithUnAuthorizedMember() {
+            // given
+            final String mail = "notRegistered@gmail.com";
+            final String NOT_REGISTERED_MEMBER_TOKEN = jwtTokenProvider.generateAccessToken(mail);
+
+            // when
+            final ExtractableResponse<Response> response = DELETE_ACCOUNT(NOT_REGISTERED_MEMBER_TOKEN);
+
+            //then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/docs/MemberApiDocsTest.java
@@ -12,6 +12,7 @@ import team.teamby.teambyteam.member.application.MemberService;
 import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlaceResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.member.presentation.MemberController;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
@@ -350,6 +351,56 @@ public final class MemberApiDocsTest extends ApiDocsTest {
                                     pathParameters(
                                             parameterWithName("inviteCode").description("참여할 팀플레이스의 초대코드")
                                     ),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
+                                    ),
+                                    responseBody()
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("멤버 탈퇴 문서화")
+    class DeleteAccountDocs {
+
+        @Test
+        @DisplayName("멤버 탈퇴 성공")
+        void success() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/api/me/account")
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent())
+                    .andDo(print())
+                    .andDo(document("members/leaveAccount/success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
+                                    ),
+                                    responseBody()
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("없는 멤버 탈퇴 실패")
+        void failIfNotRegisteredMember() throws Exception {
+            //given
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willThrow(new MemberException.MemberNotFoundException("없는 이메일"));
+
+
+            // when & then
+            mockMvc.perform(delete("/api/me/account")
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andDo(print())
+                    .andDo(document("members/leaveAccount/fail/notRegistered",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
                                     requestHeaders(
                                             headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
                                     ),

--- a/backend/src/test/java/team/teamby/teambyteam/member/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/docs/MemberApiDocsTest.java
@@ -408,5 +408,29 @@ public final class MemberApiDocsTest extends ApiDocsTest {
                             )
                     );
         }
+
+        @Test
+        @DisplayName("인증되지 않은 요청 시 실패")
+        void failIfNotAuthenticated() throws Exception {
+            // given
+            given(memberInterceptor.preHandle(any(), any(), any()))
+                    .willThrow(new AuthenticationException.FailAuthenticationException());
+
+            // when & then
+            mockMvc.perform(delete("/api/me/account")
+                            .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(print())
+                    .andDo(document("members/leaveAccount/fail/unAuthorized",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION_HEADER_KEY).description("사용자 JWT 인증 정보")
+                                    ),
+                                    responseBody()
+                            )
+                    );
+        }
     }
 }


### PR DESCRIPTION
## 이슈번호
#591 

## PR 내용
회원 탈퇴 api
회원 없을 시 404 에러
회원 탈퇴 시 팀플레이스 모두 탈퇴
회원 탈퇴시 즉시 회원 정보 삭제(기타 기록은 삭제되지 않음)

## 참고자료

## 의논할 거리
