### PR TITLE
[FE] 이전 달과 다음 달의 데이터를 미리 불러오는 기능 구현

### DIFF
--- a/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
+++ b/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
@@ -6,22 +6,23 @@ import ScheduleModal from '~/components/team_calendar/ScheduleModal/ScheduleModa
 import ScheduleBar from '~/components/team_calendar/ScheduleBar/ScheduleBar';
 import ScheduleAddModal from '~/components/team_calendar/ScheduleAddModal/ScheduleAddModal';
 import ScheduleEditModal from '~/components/team_calendar/ScheduleEditModal/ScheduleEditModal';
-import * as S from './TeamCalendar.styled';
+import ScheduleMoreCell from '~/components/team_calendar/ScheduleMoreCell/ScheduleMoreCell';
+import DailyScheduleModal from '~/components/team_calendar/DailyScheduleModal/DailyScheduleModal';
 import useCalendar from '~/hooks/useCalendar';
 import { useScheduleModal } from '~/hooks/schedule/useScheduleModal';
 import { useFetchSchedules } from '~/hooks/queries/useFetchSchedules';
 import { useModal } from '~/hooks/useModal';
-import { generateScheduleBars } from '~/utils/generateScheduleBars';
-import { DAYS_OF_WEEK, MODAL_OPEN_TYPE } from '~/constants/calendar';
-import { ArrowLeftIcon, ArrowRightIcon, PlusIcon } from '~/assets/svg';
-import { arrayOf } from '~/utils/arrayOf';
-import ScheduleMoreCell from '~/components/team_calendar/ScheduleMoreCell/ScheduleMoreCell';
-import type { Position, ModalOpenType } from '~/types/schedule';
-import DailyScheduleModal from '~/components/team_calendar/DailyScheduleModal/DailyScheduleModal';
-import { getDateByPosition } from '~/utils/getDateByPosition';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
-import type { CalendarSize } from '~/types/size';
 import { useCalendarResizePosition } from '~/hooks/useCalendarResizePosition';
+import { DAYS_OF_WEEK, MODAL_OPEN_TYPE } from '~/constants/calendar';
+import { generateScheduleBars } from '~/utils/generateScheduleBars';
+import { arrayOf } from '~/utils/arrayOf';
+import { getDateByPosition } from '~/utils/getDateByPosition';
+import type { Position, ModalOpenType } from '~/types/schedule';
+import type { CalendarSize } from '~/types/size';
+import { ArrowLeftIcon, ArrowRightIcon, PlusIcon } from '~/assets/svg';
+import * as S from './TeamCalendar.styled';
+import { usePrefetchSchedules } from '~/hooks/queries/usePrefetchSchedules';
 
 interface TeamCalendarProps {
   calendarSize?: CalendarSize;
@@ -29,6 +30,7 @@ interface TeamCalendarProps {
 
 const TeamCalendar = (props: TeamCalendarProps) => {
   const { calendarSize = 'md' } = props;
+
   const { teamPlaceId } = useTeamPlace();
   const {
     year,
@@ -38,13 +40,16 @@ const TeamCalendar = (props: TeamCalendarProps) => {
 
     handlers: { handlePrevButtonClick, handleNextButtonClick },
   } = useCalendar();
-  const schedules = useFetchSchedules(teamPlaceId, year, month);
   const { isModalOpen, openModal } = useModal();
   const {
     modalScheduleId,
     modalPosition,
     handlers: { handleScheduleModalOpen },
   } = useScheduleModal();
+
+  const schedules = useFetchSchedules(teamPlaceId, year, month);
+  usePrefetchSchedules(teamPlaceId, year, month - 1);
+  usePrefetchSchedules(teamPlaceId, year, month + 1);
 
   const [clickedDate, setClickedDate] = useState(currentDate);
   const [modalType, setModalType] = useState<ModalOpenType>(

--- a/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
+++ b/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
@@ -48,8 +48,17 @@ const TeamCalendar = (props: TeamCalendarProps) => {
   } = useScheduleModal();
 
   const schedules = useFetchSchedules(teamPlaceId, year, month);
-  usePrefetchSchedules(teamPlaceId, year, month - 1);
-  usePrefetchSchedules(teamPlaceId, year, month + 1);
+  // NOTE: month의 값은 0부터 시작하므로 1월, 11월에 해당하는 month의 값은 각각 0, 11이다.
+  usePrefetchSchedules(
+    teamPlaceId,
+    month === 11 ? year + 1 : year,
+    month === 11 ? 0 : month + 1,
+  );
+  usePrefetchSchedules(
+    teamPlaceId,
+    month === 0 ? year - 1 : year,
+    month === 0 ? 11 : month - 1,
+  );
 
   const [clickedDate, setClickedDate] = useState(currentDate);
   const [modalType, setModalType] = useState<ModalOpenType>(

--- a/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
+++ b/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
@@ -14,6 +14,7 @@ import { useFetchSchedules } from '~/hooks/queries/useFetchSchedules';
 import { useModal } from '~/hooks/useModal';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import { useCalendarResizePosition } from '~/hooks/useCalendarResizePosition';
+import { usePrefetchSchedules } from '~/hooks/queries/usePrefetchSchedules';
 import { DAYS_OF_WEEK, MODAL_OPEN_TYPE } from '~/constants/calendar';
 import { generateScheduleBars } from '~/utils/generateScheduleBars';
 import { arrayOf } from '~/utils/arrayOf';
@@ -22,7 +23,6 @@ import type { Position, ModalOpenType } from '~/types/schedule';
 import type { CalendarSize } from '~/types/size';
 import { ArrowLeftIcon, ArrowRightIcon, PlusIcon } from '~/assets/svg';
 import * as S from './TeamCalendar.styled';
-import { usePrefetchSchedules } from '~/hooks/queries/usePrefetchSchedules';
 
 interface TeamCalendarProps {
   calendarSize?: CalendarSize;

--- a/frontend/src/hooks/queries/usePrefetchSchedules.ts
+++ b/frontend/src/hooks/queries/usePrefetchSchedules.ts
@@ -1,0 +1,14 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { fetchSchedules } from '~/apis/schedule';
+
+export const usePrefetchSchedules = async (
+  teamPlaceId: number,
+  year: number,
+  month: number,
+) => {
+  const queryClient = useQueryClient();
+
+  await queryClient.prefetchQuery(['schedules', teamPlaceId, year, month], () =>
+    fetchSchedules(teamPlaceId, year, month + 1),
+  );
+};


### PR DESCRIPTION
# [FE] 이전 달과 다음 달의 데이터를 미리 불러오는 기능 구현
## 이슈번호
> close #586 

## PR 내용
- 이전 달과 다음 달의 데이터를 미리 불러오는 기능 구현

## 참고자료
https://tanstack.com/query/v4/docs/react/guides/prefetching

## 의논할 거리
- Prefetching으로 문제가 해결되는지 아직 알 수 없으므로 개발 서버 배포 후 확인 필요함
