### PR TITLE
[BE] 회원정보 수정 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -111,7 +111,9 @@ public class GlobalExceptionHandler {
             ScheduleException.SpanWrongOrderException.class,
             TeamPlaceInviteCodeException.LengthException.class,
             TeamPlaceException.NameLengthException.class,
-            TeamPlaceException.NameBlankException.class
+            TeamPlaceException.NameBlankException.class,
+            MemberException.NameLengthException.class,
+            MemberException.NameBlankException.class
     })
     public ResponseEntity<ErrorResponse> handleCustomBadRequestException(final RuntimeException exception) {
         final String message = exception.getMessage();

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -95,8 +95,6 @@ public class MemberService {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
 
-        member.changeDisplayName(memberUpdateRequest.name());
-
         member.changeName(memberUpdateRequest.name());
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -96,13 +96,7 @@ public class MemberService {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
 
-        final List<MemberTeamPlace> memberTeamPlaces = member.getMemberTeamPlaces();
-
-        for (final MemberTeamPlace memberTeamPlace : memberTeamPlaces) {
-            if (memberTeamPlace.getDisplayMemberName().getValue().equals(member.getName().getValue())) {
-                memberTeamPlace.changeDisplayMemberName(new DisplayMemberName(memberUpdateRequest.name()));
-            }
-        }
+        member.changeDisplayName(new DisplayMemberName(memberUpdateRequest.name()));
 
         member.changeName(memberUpdateRequest.name());
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -104,6 +104,6 @@ public class MemberService {
             }
         }
 
-        member.change(memberUpdateRequest.name());
+        member.changeName(memberUpdateRequest.name());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -7,11 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
@@ -88,5 +90,20 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
 
         return MemberInfoResponse.of(member);
+    }
+
+    public void updateMemberInformation(final MemberUpdateRequest memberUpdateRequest, final MemberEmailDto memberEmailDto) {
+        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
+
+        final List<MemberTeamPlace> memberTeamPlaces = member.getMemberTeamPlaces();
+
+        for (final MemberTeamPlace memberTeamPlace : memberTeamPlaces) {
+            if (memberTeamPlace.getDisplayMemberName().getValue().equals(member.getName().getValue())) {
+                memberTeamPlace.changeDisplayMemberName(new DisplayMemberName(memberUpdateRequest.name()));
+            }
+        }
+
+        member.change(memberUpdateRequest.name());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -13,7 +13,6 @@ import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
-import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
@@ -96,7 +95,7 @@ public class MemberService {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
 
-        member.changeDisplayName(new DisplayMemberName(memberUpdateRequest.name()));
+        member.changeDisplayName(memberUpdateRequest.name());
 
         member.changeName(memberUpdateRequest.name());
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/configuration/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/configuration/dto/MemberUpdateRequest.java
@@ -1,0 +1,9 @@
+package team.teamby.teambyteam.member.configuration.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberUpdateRequest(
+        @NotBlank(message = "회원명은 빈 값일 수 없습니다.")
+        String name
+) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -105,10 +105,10 @@ public class Member extends BaseEntity {
         this.name = name.change(nameToUpdate);
     }
 
-    public void changeDisplayName(final DisplayMemberName newDisplayName) {
+    public void changeDisplayName(final String name) {
         for (final MemberTeamPlace memberTeamPlace : this.memberTeamPlaces) {
-            if (memberTeamPlace.isDefaultDisplayMemberName(this.name.getValue())) {
-                memberTeamPlace.changeDisplayMemberName(newDisplayName);
+            if (memberTeamPlace.isDefaultDisplayName(this.name.getValue())) {
+                memberTeamPlace.changeDisplayMemberName(new DisplayMemberName(name));
             }
         }
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -12,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.domain.vo.Name;
 import team.teamby.teambyteam.member.domain.vo.ProfileImageUrl;
@@ -102,5 +103,13 @@ public class Member extends BaseEntity {
 
     public void changeName(final String nameToUpdate) {
         this.name = name.change(nameToUpdate);
+    }
+
+    public void changeDisplayName(final DisplayMemberName newDisplayName) {
+        for (final MemberTeamPlace memberTeamPlace : this.memberTeamPlaces) {
+            if (memberTeamPlace.isDefaultDisplayMemberName(this.name.getValue())) {
+                memberTeamPlace.changeDisplayMemberName(newDisplayName);
+            }
+        }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -102,12 +102,13 @@ public class Member extends BaseEntity {
     }
 
     public void changeName(final String nameToUpdate) {
+        changeAllDefaultDisplayName(nameToUpdate);
         this.name = name.change(nameToUpdate);
     }
 
-    public void changeDisplayName(final String name) {
+    private void changeAllDefaultDisplayName(final String name) {
         for (final MemberTeamPlace memberTeamPlace : this.memberTeamPlaces) {
-            if (memberTeamPlace.isDefaultDisplayName(this.name.getValue())) {
+            if (memberTeamPlace.isDefaultDisplayName()) {
                 memberTeamPlace.changeDisplayMemberName(new DisplayMemberName(name));
             }
         }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -100,7 +100,7 @@ public class Member extends BaseEntity {
         return teamPlaceToLeave;
     }
 
-    public void change(final String nameToUpdate) {
+    public void changeName(final String nameToUpdate) {
         this.name = name.change(nameToUpdate);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -99,4 +99,8 @@ public class Member extends BaseEntity {
         memberTeamPlaces.remove(teamPlaceToLeave);
         return teamPlaceToLeave;
     }
+
+    public void change(final String nameToUpdate) {
+        this.name = name.change(nameToUpdate);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -117,14 +117,14 @@ public class MemberTeamPlace extends BaseEntity {
     }
 
     public String findMemberProfileImageUrl() {
-       return member.getProfileImageUrl().getValue();
+        return member.getProfileImageUrl().getValue();
     }
 
     public Long findTeamPlaceId() {
         return teamPlace.getId();
     }
 
-    public boolean isDefaultDisplayMemberName(String defaultMemberName) {
+    public boolean isDefaultDisplayName(final String defaultMemberName) {
         return this.displayMemberName.getValue().equals(defaultMemberName);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -123,4 +123,8 @@ public class MemberTeamPlace extends BaseEntity {
     public Long findTeamPlaceId() {
         return teamPlace.getId();
     }
+
+    public boolean isDefaultDisplayMemberName(String defaultMemberName) {
+        return this.displayMemberName.getValue().equals(defaultMemberName);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -132,7 +132,7 @@ public class MemberTeamPlace extends BaseEntity {
         return teamPlace.getId();
     }
 
-    public boolean isDefaultDisplayName(final String defaultMemberName) {
-        return this.displayMemberName.getValue().equals(defaultMemberName);
+    public boolean isDefaultDisplayName() {
+        return this.displayMemberName.getValue().equals(member.getName().getValue());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/Name.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/Name.java
@@ -22,14 +22,19 @@ public class Name {
     private String value;
 
     public Name(final String value) {
-        validate(value);
-        this.value = value.trim();
+        validateNull(value);
+        final String trimmedValue = value.trim();
+        validate(trimmedValue);
+        this.value = trimmedValue;
     }
 
-    private void validate(final String value) {
+    private void validateNull(final String value) {
         if (Objects.isNull(value)) {
             throw new NullPointerException("멤버 이름은 null일 수 없습니다.");
         }
+    }
+
+    private void validate(final String value) {
         if (value.length() > MAX_LENGTH) {
             throw new MemberException.NameLengthException(MAX_LENGTH, value);
         }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/Name.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/Name.java
@@ -23,7 +23,7 @@ public class Name {
 
     public Name(final String value) {
         validate(value);
-        this.value = value;
+        this.value = value.trim();
     }
 
     private void validate(final String value) {
@@ -36,5 +36,9 @@ public class Name {
         if (value.isBlank()) {
             throw new MemberException.NameBlankException();
         }
+    }
+
+    public Name change(final String name) {
+        return new Name(name);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -1,15 +1,19 @@
 package team.teamby.teambyteam.member.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.application.MemberService;
+import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;
@@ -52,5 +56,15 @@ public class MemberController {
         final TeamPlaceParticipantResponse response = memberService.participateTeamPlace(memberEmailDto, inviteCode);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> updateMyInformation(
+            @RequestBody @Valid final MemberUpdateRequest memberUpdateRequest,
+            @AuthPrincipal final MemberEmailDto memberEmailDto
+    ) {
+        memberService.updateMemberInformation(memberUpdateRequest, memberEmailDto);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -5,6 +5,8 @@ import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
 
 public class MemberAcceptanceFixture {
 
@@ -42,6 +44,16 @@ public class MemberAcceptanceFixture {
                 .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
                 .when().log().all()
                 .post("/api/me/team-places/{inviteCode}", inviteCode)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> UPDATE_MEMBER_INFORMATION(final String token, final MemberUpdateRequest request) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .patch("/api/me")
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -2,15 +2,16 @@ package team.teamby.teambyteam.member.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import team.teamby.teambyteam.common.AcceptanceTest;
-import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
 import team.teamby.teambyteam.common.fixtures.TokenFixtures;
+import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;
@@ -19,10 +20,9 @@ import team.teamby.teambyteam.teamplace.domain.TeamPlaceInviteCode;
 import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_LEAVE_TEAM_PLACE;
-import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_MY_INFORMATION;
-import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
-import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.PARTICIPATE_TEAM_PLACE_REQUEST;
+import static org.assertj.core.api.SoftAssertions.*;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.*;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.*;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -35,14 +35,14 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("내 정보 조회에 성공한다.")
         void success() {
             // given
-            final Member AUTHORIZED_MEMBER = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final Member AUTHORIZED_MEMBER = testFixtureBuilder.buildMember(PHILIP());
             final String TOKEN = jwtTokenProvider.generateAccessToken(AUTHORIZED_MEMBER.getEmail().getValue());
 
             // when
             final ExtractableResponse<Response> response = GET_MY_INFORMATION(TOKEN);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(response.jsonPath().getLong("id")).isEqualTo(AUTHORIZED_MEMBER.getId());
                 softly.assertThat(response.jsonPath().getString("name")).isEqualTo(AUTHORIZED_MEMBER.getName().getValue());
@@ -60,7 +60,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_MY_INFORMATION(TokenFixtures.MALFORMED_JWT_TOKEN);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
@@ -75,7 +75,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("조회에 성공한다.")
         void success() {
             // given
-            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final Member ENDEL = testFixtureBuilder.buildMember(ENDEL());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
             final TeamPlace STATICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.STATICS_TEAM_PLACE());
@@ -91,7 +91,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             final TeamPlacesResponse teamPlacesResponse = response.body().as(TeamPlacesResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(3);
                 softly.assertThat(teamPlacesResponse.teamPlaces().get(0).id()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
@@ -107,7 +107,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("등록되지 않은 사용자로 요청시 실패한다.")
         void failWithUnAuthorizedMember() {
             // given
-            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final Member ENDEL = testFixtureBuilder.buildMember(ENDEL());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
             final TeamPlace STATICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.STATICS_TEAM_PLACE());
@@ -116,7 +116,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             testFixtureBuilder.buildMemberTeamPlace(ENDEL, JAPANESE_TEAM_PLACE);
             testFixtureBuilder.buildMemberTeamPlace(ENDEL, STATICS_TEAM_PLACE);
 
-            final Member unAuthorizedMember = MemberFixtures.PHILIP();
+            final Member unAuthorizedMember = PHILIP();
             final String UNAUTHORIZED_TOKEN = jwtTokenProvider.generateAccessToken(unAuthorizedMember.getEmail().getValue());
 
             // when
@@ -135,7 +135,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("팀플레이스 탈퇴에 성공한다.")
         void success() {
             // given
-            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final Member ENDEL = testFixtureBuilder.buildMember(ENDEL());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
 
@@ -146,7 +146,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             final TeamPlacesResponse teamPlacesResponse = GET_PARTICIPATED_TEAM_PLACES(ENDEL_TOKEN).body().as(TeamPlacesResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
                 softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(0);
             });
@@ -156,7 +156,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("인증되지 않은 사용자로 요청시 실패한다.")
         void failWithUnAuthorizedMember() {
             // given
-            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final Member ENDEL = testFixtureBuilder.buildMember(ENDEL());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
 
@@ -165,7 +165,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             // when
             final ExtractableResponse<Response> response = DELETE_LEAVE_TEAM_PLACE(UNAUTHORIZED_TOKEN, ENGLISH_TEAM_PLACE.getId());
 
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
@@ -175,7 +175,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("소속되지 않은 팀플레이스의 탈퇴 요청시 실패한다.")
         void failWithUnParticipatedTeamPlace() {
             // given
-            final Member ENDEL = testFixtureBuilder.buildMember(MemberFixtures.ENDEL());
+            final Member ENDEL = testFixtureBuilder.buildMember(ENDEL());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final TeamPlace JAPANESE_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.JAPANESE_TEAM_PLACE());
             testFixtureBuilder.buildMemberTeamPlace(ENDEL, ENGLISH_TEAM_PLACE);
@@ -186,7 +186,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = DELETE_LEAVE_TEAM_PLACE(ENDEL_TOKEN, JAPANESE_TEAM_PLACE.getId());
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
                 softly.assertThat(response.body().asString()).contains("접근할 수 없는 팀플레이스입니다.");
             });
@@ -201,7 +201,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("참여에 성공한다.")
         void success() {
             // given
-            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final String inviteCode = "aaaaaaaa";
             testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), ENGLISH_TEAM_PLACE));
@@ -212,7 +212,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
                 softly.assertThat(teamPlaceParticipantResponse.teamPlaceId()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
             });
@@ -222,7 +222,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("이미 참여한 팀플레이스 기준으로 응답한다.")
         void successIfDuplicateRequest() {
             // given
-            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final String inviteCode = "aaaaaaaa";
             testFixtureBuilder.buildTeamPlaceInviteCode(new TeamPlaceInviteCode(new InviteCode(inviteCode), ENGLISH_TEAM_PLACE));
@@ -234,7 +234,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
                 softly.assertThat(teamPlaceParticipantResponse.teamPlaceId()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
             });
@@ -244,7 +244,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("없는 참여코드로 요청 시 예외를 반환한다.")
         void failIfNotExistsInviteCode() {
             // given
-            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
             testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final String PHILIP_TOKEN = jwtTokenProvider.generateAccessToken(PHILIP.getEmail().getValue());
             final String invalidInviteCode = "aaaaaaaa";
@@ -253,7 +253,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, invalidInviteCode);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
             });
         }
@@ -262,7 +262,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @DisplayName("8자가 아닌 초대코드로 요청 시 예외를 반환한다.")
         void failIfInvalidInviteCode() {
             // given
-            final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
             testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
             final String PHILIP_TOKEN = jwtTokenProvider.generateAccessToken(PHILIP.getEmail().getValue());
             final String invalidInviteCode = "aaaa";
@@ -271,7 +271,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, invalidInviteCode);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
             });
         }
@@ -289,10 +289,84 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(WRONG_TOKEN, inviteCode);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 이름 정보 수정 시")
+    class updateMemberInformation {
+
+        @Test
+        @DisplayName("이름 수정에 성공한다.")
+        void success() {
+            // given
+            final Member AUTHORIZED_MEMBER = testFixtureBuilder.buildMember(PHILIP());
+            final String VALID_TOKEN = jwtTokenProvider.generateAccessToken(AUTHORIZED_MEMBER.getEmail().getValue());
+            final MemberUpdateRequest request = new MemberUpdateRequest("양재필");
+
+            // when
+            final ExtractableResponse<Response> response = UPDATE_MEMBER_INFORMATION(VALID_TOKEN, request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰의 경우 실패한다.")
+        void failWithWrongToken() {
+            // given
+            final String MAL_FORMED_JWT_TOKEN = TokenFixtures.MALFORMED_JWT_TOKEN;
+            final MemberUpdateRequest request = new MemberUpdateRequest("김덕우");
+
+            // when
+            final ExtractableResponse<Response> response = UPDATE_MEMBER_INFORMATION(MAL_FORMED_JWT_TOKEN, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
+            });
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 사용자로 요청시 실패한다.")
+        void failWithUnAuthorizedMember() {
+            // given
+            final Member UTHORIZED_MEMBER = testFixtureBuilder.buildMember(ROY());
+            final TeamPlace PARTICIPATED_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(UTHORIZED_MEMBER, PARTICIPATED_TEAM_PLACE);
+            final MemberUpdateRequest request = new MemberUpdateRequest("김덕우");
+
+            final Member UNAUTHORIZED_MEMBER = PHILIP();
+            final String UNAUTHORIZED_TOKEN = jwtTokenProvider.generateAccessToken(UNAUTHORIZED_MEMBER.getEmail().getValue());
+
+            // when
+            final ExtractableResponse<Response> response = UPDATE_MEMBER_INFORMATION(UNAUTHORIZED_TOKEN, request);
+
+            //then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "   "})
+        @DisplayName("변경할 사용자명이 빈값일 경우 실패한다.")
+        void failWithEmptyMemberNameInfo(final String memberNameToUpdate) {
+            // given
+            final Member UTHORIZED_MEMBER = testFixtureBuilder.buildMember(ROY());
+            final TeamPlace PARTICIPATED_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.ENGLISH_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(UTHORIZED_MEMBER, PARTICIPATED_TEAM_PLACE);
+            final String VALID_TOKEN = jwtTokenProvider.generateAccessToken(UTHORIZED_MEMBER.getEmail().getValue());
+            final MemberUpdateRequest emptyValueRequest = new MemberUpdateRequest(memberNameToUpdate);
+
+            // when
+            final ExtractableResponse<Response> response = UPDATE_MEMBER_INFORMATION(VALID_TOKEN, emptyValueRequest);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -275,26 +275,6 @@ class MemberServiceTest extends ServiceTest {
             });
         }
 
-        @ParameterizedTest
-        @ValueSource(strings = {" 김덕우", "김덕우 ", " 김덕우 ", "   김덕우   "})
-        @DisplayName("변경할 사용자명의 앞뒤에 공백이 존재할 경우 자동으로 공백이 제거된다.")
-        void successWithTrimmedMemberNameToUpdate(final String nameToUpdate) {
-            // given
-            final Member member = testFixtureBuilder.buildMember(ROY());
-            final String trimmedNameToUpdate = "김덕우";
-
-            // when
-            final MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest(nameToUpdate);
-            memberService.updateMemberInformation(memberUpdateRequest, new MemberEmailDto(member.getEmail().getValue()));
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(member.getName().getValue()).isEqualTo(trimmedNameToUpdate);
-                softly.assertThat(member.getEmail()).isEqualTo(ROY().getEmail());
-                softly.assertThat(member.getProfileImageUrl()).isEqualTo(ROY().getProfileImageUrl());
-            });
-        }
-
         @Test
         @DisplayName("존재하지 않는 사용자 이메일로 정보 변경 요청 시 실패한다.")
         void failWithNotRegisteredMember() {
@@ -315,13 +295,11 @@ class MemberServiceTest extends ServiceTest {
         void failWithEmptyMemberNameToUpdate(final String memberNameToUpdate) {
             // given
             final Member member = testFixtureBuilder.buildMember(ROY());
-
-            // when
             final MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest(memberNameToUpdate);
 
             // then
             assertThatThrownBy(() -> memberService.updateMemberInformation(memberUpdateRequest, new MemberEmailDto(member.getEmail().getValue())))
-                    .isInstanceOf(MemberTeamPlaceException.MemberNameBlankException.class)
+                    .isInstanceOf(MemberException.NameBlankException.class)
                     .hasMessage("멤버 이름은 공백을 제외한 1자 이상이어야합니다.");
         }
 
@@ -337,7 +315,7 @@ class MemberServiceTest extends ServiceTest {
 
             // then
             assertThatThrownBy(() -> memberService.updateMemberInformation(memberUpdateRequest, new MemberEmailDto(member.getEmail().getValue())))
-                    .isInstanceOf(MemberTeamPlaceException.MemberDisplayNameLengthException.class)
+                    .isInstanceOf(MemberException.NameLengthException.class)
                     .hasMessageContaining("멤버 이름의 길이가 최대 이름 길이를 초과했습니다.");
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -321,7 +321,7 @@ class MemberServiceTest extends ServiceTest {
 
             // then
             assertThatThrownBy(() -> memberService.updateMemberInformation(memberUpdateRequest, new MemberEmailDto(member.getEmail().getValue())))
-                    .isInstanceOf(MemberException.NameBlankException.class)
+                    .isInstanceOf(MemberTeamPlaceException.MemberNameBlankException.class)
                     .hasMessage("멤버 이름은 공백을 제외한 1자 이상이어야합니다.");
         }
 
@@ -337,7 +337,7 @@ class MemberServiceTest extends ServiceTest {
 
             // then
             assertThatThrownBy(() -> memberService.updateMemberInformation(memberUpdateRequest, new MemberEmailDto(member.getEmail().getValue())))
-                    .isInstanceOf(MemberException.NameLengthException.class)
+                    .isInstanceOf(MemberTeamPlaceException.MemberDisplayNameLengthException.class)
                     .hasMessageContaining("멤버 이름의 길이가 최대 이름 길이를 초과했습니다.");
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/NameTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/NameTest.java
@@ -43,4 +43,16 @@ class NameTest {
                 .isInstanceOf(MemberException.NameBlankException.class)
                 .hasMessageContaining("멤버 이름은 공백을 제외한 1자 이상이어야합니다.");
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" roy", "roy ", " roy ", "  roy  "})
+    @DisplayName("멤버 이름의 앞뒤에 공백이 존재할 경우 해당 공백이 제거된다.")
+    void successWithTrimmedMemberName(final String untrimmedName) {
+        // given & when
+        final Name name = new Name(untrimmedName);
+        final String expectedTrimmedName = "roy";
+
+        // then
+        Assertions.assertThat(name.getValue()).isEqualTo(expectedTrimmedName);
+    }
 }


### PR DESCRIPTION
## 이슈번호
> #595 

## PR 내용
- 회원의 본인 정보(이름) 수정 기능 구현 및 테스트
  - 회원의 변경 전 이름과 DisplayName 일치 시 -> DisplayName을 새로운 이름으로 변경
  - 회원명의 앞뒤에 공백이 있을 경우 해당 공백을 제거(Trim)

## 참고자료

## 의논할 거리
- member 이름과 DisplayName의 일치할 경우 DisplayName을 변경하는 로직에서 indent Depth가 2임
```
for (final MemberTeamPlace memberTeamPlace : memberTeamPlaces) {
    if (memberTeamPlace.getDisplayMemberName().getValue().equals(member.getName().getValue())) {
        memberTeamPlace.changeDisplayMemberName(new DisplayMemberName(memberUpdateRequest.name()));
    }
}
```
- stream 사용할 경우 foreach로 메서드를 실행해야하는 문제가 있어 적용의 어려움 발생
- 해당 코드를 리팩터링 할 방법이 있을지?