### PR TITLE
[BE] 팀플래이스에서 보일 내 별명 변경 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -112,7 +112,9 @@ public class GlobalExceptionHandler {
             TeamPlaceInviteCodeException.LengthException.class,
             TeamPlaceException.NameLengthException.class,
             TeamPlaceException.NameBlankException.class,
-            MemberTeamPlaceException.TeamPlaceColorNotExistException.class
+            MemberTeamPlaceException.TeamPlaceColorNotExistException.class,
+            MemberTeamPlaceException.MemberNameBlankException.class,
+            MemberTeamPlaceException.MemberDisplayNameLengthException.class
     })
     public ResponseEntity<ErrorResponse> handleCustomBadRequestException(final RuntimeException exception) {
         final String message = exception.getMessage();

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -120,6 +120,10 @@ public class MemberTeamPlace extends BaseEntity {
         return member.getName().getValue();
     }
 
+    public String getDisplayMemberNameValue() {
+        return displayMemberName.getValue();
+    }
+
     public String findMemberProfileImageUrl() {
        return member.getProfileImageUrl().getValue();
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberName.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberName.java
@@ -22,14 +22,19 @@ public class DisplayMemberName {
     private String value;
 
     public DisplayMemberName(final String value) {
-        validate(value);
-        this.value = value;
+        validateNullValue(value);
+        final String trimmedValue = value.trim();
+        validate(trimmedValue);
+        this.value = trimmedValue;
     }
 
-    private void validate(final String value) {
+    private void validateNullValue(final String value) {
         if (Objects.isNull(value)) {
             throw new NullPointerException("멤버 이름은 null일 수 없습니다.");
         }
+    }
+
+    private void validate(final String value) {
         if (value.length() > MAX_LENGTH) {
             throw new MemberTeamPlaceException.MemberDisplayNameLengthException(MAX_LENGTH, value);
         }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/TeamPlaceService.java
@@ -11,9 +11,11 @@ import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.TeamPlaceColor;
+import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+import team.teamby.teambyteam.teamplace.application.dto.DisplayMemberNameChangeRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
@@ -111,5 +113,20 @@ public class TeamPlaceService {
 
         final TeamPlaceColor findTeamPlaceColor = TeamPlaceColor.findTeamPlaceColor(request.teamPlaceColor());
         memberTeamPlace.changeTeamPlaceColor(findTeamPlaceColor);
+    }
+
+    public void changeDisplayMemberName(
+            final Long teamPlaceId,
+            final DisplayMemberNameChangeRequest request,
+            final MemberEmailDto memberEmailDto
+    ) {
+        final String memberEmail = memberEmailDto.email();
+
+        final IdOnly memberId = memberRepository.findIdByEmail(new Email(memberEmail))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmail));
+        final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, memberId.id())
+                .orElseThrow(() -> new MemberTeamPlaceException.NotFoundParticipatedTeamPlaceException(memberEmail, teamPlaceId));
+
+        memberTeamPlace.changeDisplayMemberName(new DisplayMemberName(request.name()));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/DisplayMemberNameChangeRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/DisplayMemberNameChangeRequest.java
@@ -1,4 +1,9 @@
 package team.teamby.teambyteam.teamplace.application.dto;
 
-public record DisplayMemberNameChangeRequest(String name) {
+import jakarta.validation.constraints.NotBlank;
+
+public record DisplayMemberNameChangeRequest(
+        @NotBlank(message = "사용자의 이름은 공백일 수 없습니다.")
+        String name
+) {
 }

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/DisplayMemberNameChangeRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/DisplayMemberNameChangeRequest.java
@@ -1,0 +1,4 @@
+package team.teamby.teambyteam.teamplace.application.dto;
+
+public record DisplayMemberNameChangeRequest(String name) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMemberResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/application/dto/TeamPlaceMemberResponse.java
@@ -8,7 +8,7 @@ public record TeamPlaceMemberResponse(Long id, String name, String profileImageU
     public static TeamPlaceMemberResponse of(final MemberTeamPlace memberTeamPlace, final Member loginMember) {
         return new TeamPlaceMemberResponse(
                 memberTeamPlace.findMemberId(),
-                memberTeamPlace.findMemberName(),
+                memberTeamPlace.getDisplayMemberNameValue(),
                 memberTeamPlace.findMemberProfileImageUrl(),
                 memberTeamPlace.isOwnedBy(loginMember)
         );

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
@@ -71,7 +71,7 @@ public class TeamPlaceController {
     public ResponseEntity<Void> changeDisplayMemberName(
             @AuthPrincipal final MemberEmailDto memberEmailDto,
             @PathVariable final Long teamPlaceId,
-            @RequestBody final DisplayMemberNameChangeRequest request
+            @RequestBody @Valid final DisplayMemberNameChangeRequest request
     ) {
         teamPlaceService.changeDisplayMemberName(teamPlaceId, request, memberEmailDto);
 

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/presentation/TeamPlaceController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.teamplace.application.TeamPlaceService;
+import team.teamby.teambyteam.teamplace.application.dto.DisplayMemberNameChangeRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
@@ -62,6 +63,17 @@ public class TeamPlaceController {
             @PathVariable final Long teamPlaceId,
             @RequestBody final TeamPlaceChangeColorRequest teamPlaceChangeColorRequest) {
         teamPlaceService.changeMemberTeamPlaceColor(memberEmailDto, teamPlaceId, teamPlaceChangeColorRequest);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{teamPlaceId}/members/me")
+    public ResponseEntity<Void> changeDisplayMemberName(
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
+            @PathVariable final Long teamPlaceId,
+            @RequestBody final DisplayMemberNameChangeRequest request
+    ) {
+        teamPlaceService.changeDisplayMemberName(teamPlaceId, request, memberEmailDto);
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamPlaceAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamPlaceAcceptanceFixture.java
@@ -6,6 +6,7 @@ import io.restassured.response.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
+import team.teamby.teambyteam.teamplace.application.dto.DisplayMemberNameChangeRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 
 public class TeamPlaceAcceptanceFixture {
@@ -48,6 +49,20 @@ public class TeamPlaceAcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .patch("/api/team-places/{teamPlaceId}/color", teamPlaceId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> PATCH_DISPLAY_MEMBER_NAME_CHANGE(
+            final String token,
+            final Long teamPlaceId,
+            final DisplayMemberNameChangeRequest request
+    ) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .patch("/api/team-places/{teamPlaceId}/members/me", teamPlaceId)
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberNameTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/domain/vo/DisplayMemberNameTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class DisplayMemberNameTest {
 
     @Test
@@ -38,5 +40,19 @@ class DisplayMemberNameTest {
         Assertions.assertThatThrownBy(() -> new DisplayMemberName(".".repeat(21)))
                 .isInstanceOf(MemberTeamPlaceException.MemberDisplayNameLengthException.class)
                 .hasMessageContaining("멤버 이름의 길이가 최대 이름 길이를 초과했습니다.");
+    }
+
+    @Test
+    @DisplayName("이름 등록시 좌우 공백을 제거하고 등록한다.")
+    void trimSpaces() {
+        // given
+        final String inputValue = " display name ";
+
+        // when
+        final DisplayMemberName displayMemberName = new DisplayMemberName(inputValue);
+
+        //then
+        final String trimmedValue = "display name";
+        assertThat(displayMemberName.getValue()).isEqualTo(trimmedValue);
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -494,5 +494,62 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
                 softly.assertThat(changedMyInfo.get().name()).isEqualTo(NEW_NAME);
             });
         }
+
+        @Test
+        @DisplayName("소속되어있지 않은 팀플레이스에스로 이름 변경 요청을 하면 실패한다.")
+        void failWithUnparticipatedTeamPlace() {
+            // given
+            final String NEW_NAME = "새로온 필립";
+            final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
+            final long WRONG_TEAM_PLACE_ID = -1L;
+
+            // when
+            final ExtractableResponse<Response> response = PATCH_DISPLAY_MEMBER_NAME_CHANGE(PHILIP_ACCESS_TOKEN, WRONG_TEAM_PLACE_ID, requestBody);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        }
+
+        @Test
+        @DisplayName("공백문자로 이름변경 요청시 실패한다.")
+        void failWithBlankNewName() {
+            // given
+            final String NEW_NAME = "  ";
+            final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
+
+            // when
+            final ExtractableResponse<Response> response = PATCH_DISPLAY_MEMBER_NAME_CHANGE(PHILIP_ACCESS_TOKEN, STATICS_TEAM_PLACE.getId(), requestBody);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
+        @Test
+        @DisplayName("20자 이상의 이름변경 요청시 실패한다.")
+        void failWithNameLengthOver20() {
+            // given
+            final String NEW_NAME = "a".repeat(21);
+            final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
+
+            // when
+            final ExtractableResponse<Response> response = PATCH_DISPLAY_MEMBER_NAME_CHANGE(PHILIP_ACCESS_TOKEN, STATICS_TEAM_PLACE.getId(), requestBody);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰으로 이름 변경 요청을 하면 실패한다.")
+        void failWithWrongAccessToken() {
+            // given
+            final String NEW_NAME = "새로온 필립";
+            final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
+
+            // when
+            final ExtractableResponse<Response> response = PATCH_DISPLAY_MEMBER_NAME_CHANGE(MISSING_CLAIM_ACCESS_TOKEN, STATICS_TEAM_PLACE.getId(), requestBody);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -540,7 +540,7 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
 
         @Test
         @DisplayName("잘못된 토큰으로 이름 변경 요청을 하면 실패한다.")
-        void failWithWrongAccessToken() {
+        void failWithWrongAccessTokenClaimMissing() {
             // given
             final String NEW_NAME = "새로온 필립";
             final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
@@ -550,6 +550,20 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰으로 이름 변경 요청을 하면 실패한다.")
+        void failWithWrognAccessTokenUnauthorized() {
+            final String NEW_NAME = "새로온 필립";
+            final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
+            final String UNAUTHORIZED_MEMBER_TOKEN = jwtTokenProvider.generateAccessToken(MemberFixtures.ENDEL_EMAIL);
+
+            // when
+            final ExtractableResponse<Response> response = PATCH_DISPLAY_MEMBER_NAME_CHANGE(UNAUTHORIZED_MEMBER_TOKEN, STATICS_TEAM_PLACE.getId(), requestBody);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/application/TeamPlaceServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import team.teamby.teambyteam.common.ServiceTest;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
 import team.teamby.teambyteam.common.fixtures.TeamPlaceInviteCodeFixtures;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
@@ -16,6 +17,7 @@ import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.DisplayTeamPlaceName;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
+import team.teamby.teambyteam.teamplace.application.dto.DisplayMemberNameChangeRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceChangeColorRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateRequest;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceCreateResponse;
@@ -245,7 +247,7 @@ class TeamPlaceServiceTest extends ServiceTest {
             final Member member = testFixtureBuilder.buildMember(PHILIP());
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
 
-            final  MemberEmailDto memberEmailDto = new MemberEmailDto(member.getEmail().getValue());
+            final MemberEmailDto memberEmailDto = new MemberEmailDto(member.getEmail().getValue());
             final Long teamPlaceId = teamPlace.getId();
             final int teamPlaceColorToChange = 9;
             final TeamPlaceChangeColorRequest request = new TeamPlaceChangeColorRequest(teamPlaceColorToChange);
@@ -257,6 +259,52 @@ class TeamPlaceServiceTest extends ServiceTest {
                             "해당 팀 플레이스에 가입되어 있지 않습니다. - request info { member_email : %s, team_place_id : %d }",
                             memberEmailDto.email(),
                             teamPlaceId));
+        }
+    }
+
+    @Nested
+    @DisplayName("팀플레이스 내 사용자 명 변경 요청시")
+    class ChangeDisplayMemberName {
+
+        @Test
+        @DisplayName("사용자 명 변경에 성공한다.")
+        void success() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
+            final TeamPlace DYNAMICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.DYNAMICS_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(PHILIP, DYNAMICS_TEAM_PLACE);
+            final String CHANGED_NAME = "새로 태어난 필립";
+
+            // when
+            teamPlaceService.changeDisplayMemberName(DYNAMICS_TEAM_PLACE.getId(), new DisplayMemberNameChangeRequest(CHANGED_NAME), new MemberEmailDto(PHILIP.getEmail().getValue()));
+
+            // then
+            final Optional<MemberTeamPlace> changedResult = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(DYNAMICS_TEAM_PLACE.getId(), PHILIP.getId());
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(changedResult).isPresent();
+                softly.assertThat(changedResult.get().getDisplayMemberName()).isEqualTo(new DisplayMemberName(CHANGED_NAME));
+            });
+        }
+
+        @Test
+        @DisplayName("소속되지 않은 팀플레이스의 이름 변경 요청시 실패한다.")
+        void failWithUnparticipatedTeamPlaceRequest() {
+            // given
+            final Member PHILIP = testFixtureBuilder.buildMember(PHILIP());
+            final TeamPlace DYNAMICS_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.DYNAMICS_TEAM_PLACE());
+            testFixtureBuilder.buildMemberTeamPlace(PHILIP, DYNAMICS_TEAM_PLACE);
+            final String CHANGED_NAME = "새로 태어난 필립";
+            final long WRONG_TEAM_PLACE_ID = -1;
+
+            // when & then
+            Assertions.assertThatThrownBy(() ->
+                            teamPlaceService.changeDisplayMemberName(
+                                    WRONG_TEAM_PLACE_ID,
+                                    new DisplayMemberNameChangeRequest(CHANGED_NAME),
+                                    new MemberEmailDto(PHILIP.getEmail().getValue())
+                            ))
+                    .isInstanceOf(MemberTeamPlaceException.NotFoundParticipatedTeamPlaceException.class)
+                    .hasMessageContaining("해당 팀 플레이스에 가입되어 있지 않습니다.");
         }
     }
 }


### PR DESCRIPTION
## 이슈번호
> close #593

## PR 내용

- 팀 내에서 보일 내 별명 수정 기능 추가

- 팀플래이스 참여자들 정보 조회시 displayName이 아닌 사용자 기본 이름이 조회되는 오류 수정

## 참고자료

## 의논할 거리
