### PR TITLE
[ALL] 잘못된 CODEOWNERS 파일 수정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Automatically set front-end reviewers when front-end files are changed
-/frontend/* @wzrabbit @hafnium1923 @suyoungj
+/frontend/ @wzrabbit @hafnium1923 @suyoungj
 
 # Automatically set back-end reviewers when back-end files are changed
-/backend/* @pilyang @sh111-coder @SproutMJ @the9kim
+/backend/ @pilyang @sh111-coder @SproutMJ @the9kim


### PR DESCRIPTION
# [ALL] 잘못된 CODEOWNERS 파일 수정

## PR 내용
본 PR에서는 잘못된 CODEOWNERS 파일을 올바르게 수정하였다.
- 문법이 잘못된 것은 아니지만, 범위가 잘못되어 해당 분야의 파일이 변경되었을 때 **하위** 파일이 변경되면 성공적으로 리뷰어가 배정되지만 **하위의 하위** 파일이 변경되었을 때 리뷰어가 배정되지 않는 문제가 있었다.
- 이에 경로 범위를 `/frontend/*` 에서 `/frontend/` 와 같이 변경하였다.

## 참고 사항
`CODEOWNERS` 파일에서, `/path/*` 와 `/path/` 가 의미하는 바가 다른데,
- `/path/*` 는 `/path/` 경로의 **직접적인 하위 파일** 들만 해당해. `/path/abcd.txt` 는 해당하지만 `/path/path2/abcd.txt` 는 해당되지 않음.
- `/path/` 는 `/path/` 경로의 **모든 depth의 하위 파일** 들이 모두 해당돼. `/path/abcd.txt` 는 물론 `/path/path2/abcd.txt` 또한 해당됨.

이러한 차이가 있는듯.