### PR TITLE
[BE] MemberInterceptor 예외 401로 변경 + 인증 예외 로깅 리팩토링

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/auth/exception/AuthenticationException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/exception/AuthenticationException.java
@@ -7,8 +7,8 @@ public class AuthenticationException extends RuntimeException {
     }
 
     public static class FailAuthenticationException extends AuthenticationException {
-        public FailAuthenticationException() {
-            super("인증이 실패했습니다.");
+        public FailAuthenticationException(final String logMessage) {
+            super(logMessage);
         }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenExtractor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenExtractor.java
@@ -18,7 +18,8 @@ public class JwtTokenExtractor {
         if (StringUtils.hasText(accessToken) && accessToken.startsWith(PREFIX_BEARER)) {
             return accessToken.substring(PREFIX_BEARER.length());
         }
-        throw new AuthenticationException.FailAuthenticationException();
+        String logMessage = "인증 실패(액세스 토큰 추출 실패) - 토큰 : " + accessToken;
+        throw new AuthenticationException.FailAuthenticationException(logMessage);
     }
 
     public String extractRefreshToken(final HttpServletRequest request) {
@@ -26,6 +27,7 @@ public class JwtTokenExtractor {
         if (StringUtils.hasText(refreshToken) && refreshToken.startsWith(PREFIX_BEARER)) {
             return refreshToken.substring(PREFIX_BEARER.length());
         }
-        throw new AuthenticationException.FailAuthenticationException();
+        String logMessage = "인증 실패(리프레시 토큰 추출 실패) - 토큰 : " + refreshToken;
+        throw new AuthenticationException.FailAuthenticationException(logMessage);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenExtractor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenExtractor.java
@@ -18,7 +18,7 @@ public class JwtTokenExtractor {
         if (StringUtils.hasText(accessToken) && accessToken.startsWith(PREFIX_BEARER)) {
             return accessToken.substring(PREFIX_BEARER.length());
         }
-        String logMessage = "인증 실패(액세스 토큰 추출 실패) - 토큰 : " + accessToken;
+        final String logMessage = "인증 실패(액세스 토큰 추출 실패) - 토큰 : " + accessToken;
         throw new AuthenticationException.FailAuthenticationException(logMessage);
     }
 
@@ -27,7 +27,7 @@ public class JwtTokenExtractor {
         if (StringUtils.hasText(refreshToken) && refreshToken.startsWith(PREFIX_BEARER)) {
             return refreshToken.substring(PREFIX_BEARER.length());
         }
-        String logMessage = "인증 실패(리프레시 토큰 추출 실패) - 토큰 : " + refreshToken;
+        final String logMessage = "인증 실패(리프레시 토큰 추출 실패) - 토큰 : " + refreshToken;
         throw new AuthenticationException.FailAuthenticationException(logMessage);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenProvider.java
@@ -54,7 +54,7 @@ public class JwtTokenProvider {
         final Jws<Claims> claimsJws = getAccessTokenParser().parseClaimsJws(token);
         String extractedEmail = claimsJws.getBody().get(EMAIL_KEY, String.class);
         if (extractedEmail == null) {
-            String logMessage = "인증 실패(JWT 액세스 토큰 Payload 이메일 누락) - 토큰 : " + token;
+            final String logMessage = "인증 실패(JWT 액세스 토큰 Payload 이메일 누락) - 토큰 : " + token;
 
             throw new AuthenticationException.FailAuthenticationException(logMessage);
         }
@@ -71,7 +71,7 @@ public class JwtTokenProvider {
         try {
             final Claims claims = getAccessTokenParser().parseClaimsJws(token).getBody();
         } catch (MalformedJwtException | UnsupportedJwtException e) {
-            String logMessage = "인증 실패(잘못된 액세스 토큰) - 토큰 : " + token;
+            final String logMessage = "인증 실패(잘못된 액세스 토큰) - 토큰 : " + token;
 
             throw new AuthenticationException.FailAuthenticationException(logMessage);
         } catch (ExpiredJwtException e) {
@@ -97,7 +97,7 @@ public class JwtTokenProvider {
         final Jws<Claims> claimsJws = getRefreshTokenParser().parseClaimsJws(token);
         String extractedEmail = claimsJws.getBody().get(EMAIL_KEY, String.class);
         if (extractedEmail == null) {
-            String logMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + token;
+            final String logMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + token;
 
             throw new AuthenticationException.FailAuthenticationException(logMessage);
         }
@@ -114,7 +114,7 @@ public class JwtTokenProvider {
         try {
             final Claims claims = getRefreshTokenParser().parseClaimsJws(token).getBody();
         } catch (MalformedJwtException | UnsupportedJwtException e) {
-            String logMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : " + token;
+            final String logMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : " + token;
 
             throw new AuthenticationException.FailAuthenticationException(logMessage);
         } catch (ExpiredJwtException e) {

--- a/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import team.teamby.teambyteam.auth.exception.AuthenticationException;
@@ -18,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     private static final String EXPIRED_ACCESS_TOKEN_MESSAGE = "EXPIRED_ACCESS_TOKEN";
@@ -52,7 +54,9 @@ public class JwtTokenProvider {
         final Jws<Claims> claimsJws = getAccessTokenParser().parseClaimsJws(token);
         String extractedEmail = claimsJws.getBody().get(EMAIL_KEY, String.class);
         if (extractedEmail == null) {
-            throw new AuthenticationException.FailAuthenticationException();
+            String logMessage = "인증 실패(JWT 액세스 토큰 Payload 이메일 누락) - 토큰 : " + token;
+
+            throw new AuthenticationException.FailAuthenticationException(logMessage);
         }
         return extractedEmail;
     }
@@ -67,7 +71,9 @@ public class JwtTokenProvider {
         try {
             final Claims claims = getAccessTokenParser().parseClaimsJws(token).getBody();
         } catch (MalformedJwtException | UnsupportedJwtException e) {
-            throw new AuthenticationException.FailAuthenticationException();
+            String logMessage = "인증 실패(잘못된 액세스 토큰) - 토큰 : " + token;
+
+            throw new AuthenticationException.FailAuthenticationException(logMessage);
         } catch (ExpiredJwtException e) {
             throw new ExpiredJwtException(null, null, EXPIRED_ACCESS_TOKEN_MESSAGE);
         }
@@ -91,7 +97,9 @@ public class JwtTokenProvider {
         final Jws<Claims> claimsJws = getRefreshTokenParser().parseClaimsJws(token);
         String extractedEmail = claimsJws.getBody().get(EMAIL_KEY, String.class);
         if (extractedEmail == null) {
-            throw new AuthenticationException.FailAuthenticationException();
+            String logMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + token;
+
+            throw new AuthenticationException.FailAuthenticationException(logMessage);
         }
         return extractedEmail;
     }
@@ -106,7 +114,9 @@ public class JwtTokenProvider {
         try {
             final Claims claims = getRefreshTokenParser().parseClaimsJws(token).getBody();
         } catch (MalformedJwtException | UnsupportedJwtException e) {
-            throw new AuthenticationException.FailAuthenticationException();
+            String logMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : " + token;
+
+            throw new AuthenticationException.FailAuthenticationException(logMessage);
         } catch (ExpiredJwtException e) {
             throw new ExpiredJwtException(null, null, EXPIRED_REFRESH_TOKEN_MESSAGE);
         }

--- a/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/jwt/JwtTokenProvider.java
@@ -8,7 +8,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import team.teamby.teambyteam.auth.exception.AuthenticationException;
@@ -19,7 +18,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
-@Slf4j
 public class JwtTokenProvider {
 
     private static final String EXPIRED_ACCESS_TOKEN_MESSAGE = "EXPIRED_ACCESS_TOKEN";

--- a/backend/src/main/java/team/teamby/teambyteam/auth/presentation/MemberInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/presentation/MemberInterceptor.java
@@ -3,16 +3,18 @@ package team.teamby.teambyteam.auth.presentation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import team.teamby.teambyteam.auth.exception.AuthenticationException;
 import team.teamby.teambyteam.auth.jwt.JwtTokenExtractor;
 import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
-import team.teamby.teambyteam.member.exception.MemberException;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public final class MemberInterceptor implements HandlerInterceptor {
 
     private final JwtTokenExtractor jwtTokenExtractor;
@@ -29,7 +31,8 @@ public final class MemberInterceptor implements HandlerInterceptor {
 
     private void validateMemberExist(final String email) {
         if (notExistsByEmail(email)) {
-            throw new MemberException.MemberNotFoundException(email);
+            String logMessage = "인증 실패(존재하지 않는 멤버) - 회원 이메일 : " + email;
+            throw new AuthenticationException.FailAuthenticationException(logMessage);
         }
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/auth/presentation/MemberInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/auth/presentation/MemberInterceptor.java
@@ -3,7 +3,6 @@ package team.teamby.teambyteam.auth.presentation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import team.teamby.teambyteam.auth.exception.AuthenticationException;
@@ -14,7 +13,6 @@ import team.teamby.teambyteam.member.domain.vo.Email;
 
 @RequiredArgsConstructor
 @Component
-@Slf4j
 public final class MemberInterceptor implements HandlerInterceptor {
 
     private final JwtTokenExtractor jwtTokenExtractor;

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -81,16 +81,26 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = {
-            AuthenticationException.FailAuthenticationException.class,
             ExpiredJwtException.class,
             TokenException.TokenNotFoundException.class
     })
-    public ResponseEntity<ErrorResponse> handleAuthenticationException(final RuntimeException exception) {
+    public ResponseEntity<ErrorResponse> handleVariousCaseAuthenticationException(final RuntimeException exception) {
         final String message = exception.getMessage();
         log.warn(message);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(
+            value = AuthenticationException.FailAuthenticationException.class
+    )
+    public ResponseEntity<ErrorResponse> handleVariousCaseAuthenticationException(final AuthenticationException exception) {
+        final String logMessage = exception.getMessage();
+        log.warn(logMessage);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse("인증이 실패했습니다."));
     }
 
     @ExceptionHandler(value = {

--- a/backend/src/test/java/team/teamby/teambyteam/auth/jwt/JwtTokenProviderTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/auth/jwt/JwtTokenProviderTest.java
@@ -10,7 +10,9 @@ import team.teamby.teambyteam.auth.exception.AuthenticationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP_EMAIL;
-import static team.teamby.teambyteam.common.fixtures.TokenFixtures.*;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MALFORMED_JWT_TOKEN;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MISSING_CLAIM_ACCESS_TOKEN;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MISSING_CLAIM_REFRESH_TOKEN;
 
 @SpringBootTest
 class JwtTokenProviderTest {
@@ -58,7 +60,7 @@ class JwtTokenProviderTest {
             // when & then
             assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromAccessToken(malFormedJwtToken))
                     .isInstanceOf(AuthenticationException.FailAuthenticationException.class)
-                    .hasMessage("인증이 실패했습니다.");
+                    .hasMessageContaining("인증 실패(잘못된 액세스 토큰) - 토큰 : ");
         }
 
         @Test
@@ -70,7 +72,7 @@ class JwtTokenProviderTest {
             // when & then
             assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromAccessToken(missingClaimToken))
                     .isInstanceOf(AuthenticationException.FailAuthenticationException.class)
-                    .hasMessage("인증이 실패했습니다.");
+                    .hasMessageContaining("인증 실패(JWT 액세스 토큰 Payload 이메일 누락) - 토큰 : " + missingClaimToken);
         }
     }
 
@@ -114,7 +116,7 @@ class JwtTokenProviderTest {
             // when & then
             assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(malFormedJwtToken))
                     .isInstanceOf(AuthenticationException.FailAuthenticationException.class)
-                    .hasMessage("인증이 실패했습니다.");
+                    .hasMessageContaining("인증 실패(잘못된 리프레시 토큰) - 토큰 : " + malFormedJwtToken);
         }
 
         @Test
@@ -126,7 +128,7 @@ class JwtTokenProviderTest {
             // when & then
             assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(missingClaimToken))
                     .isInstanceOf(AuthenticationException.FailAuthenticationException.class)
-                    .hasMessage("인증이 실패했습니다.");
+                    .hasMessage("인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + missingClaimToken);
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/feed/acceptance/FeedThreadAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/acceptance/FeedThreadAcceptanceTest.java
@@ -2,7 +2,6 @@ package team.teamby.teambyteam.feed.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +30,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
@@ -70,7 +70,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = POST_FEED_THREAD_REQUEST(authToken, participatedTeamPlace, request);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
                 softly.assertThat(response.header(HttpHeaders.LOCATION)).contains("/api/team-place/" + participatedMemberTeamPlace.getTeamPlace().getId() + "/feed/threads");
             });
@@ -87,7 +87,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = POST_FEED_THREAD_REQUEST(authToken, participatedTeamPlace, request);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
                 softly.assertThat(response.body().asString()).contains("스레드 내용이 있어야 합니다.");
             });
@@ -105,7 +105,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = POST_FEED_THREAD_REQUEST(authToken, UN_PARTICIPATED_TEAM_PLACE, request);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
                 softly.assertThat(response.body().asString()).contains("접근할 수 없는 팀플레이스입니다.");
             });
@@ -122,9 +122,9 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = POST_FEED_THREAD_REQUEST(unauthorizedToken, participatedTeamPlace, request);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(response.body().asString()).contains("조회한 멤버가 존재하지 않습니다.");
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
         }
     }
@@ -158,7 +158,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads()).isEmpty();
             });
@@ -185,7 +185,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads().size()).isEqualTo(size);
             });
@@ -211,7 +211,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads().size()).isEqualTo(1);
                 softly.assertThat(feedsResponse.threads().get(0).authorId()).isNull();
@@ -239,7 +239,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads().size()).isEqualTo(size);
                 softly.assertThat(feedsResponse.threads().get(0).id()).isEqualTo(5);
@@ -270,7 +270,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads().size()).isEqualTo(insertFeeds.size());
             });
@@ -297,7 +297,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads().size()).isEqualTo(size);
             });
@@ -324,7 +324,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads().size()).isEqualTo(2);
             });
@@ -350,7 +350,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             FeedsResponse feedsResponse = response.as(FeedsResponse.class);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(feedsResponse.threads()).isEmpty();
             });
@@ -371,7 +371,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_FEED_THREAD_FIRST("invalidToken", teamPlaceId, size);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
             });
         }
@@ -392,7 +392,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_FEED_THREAD_REPEAT("invalidToken", teamPlaceId, lastThreadId, size);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
             });
         }
@@ -412,7 +412,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_FEED_THREAD_FIRST(authToken, invalidTeamPlaceId, size);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
             });
         }
@@ -433,7 +433,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_FEED_THREAD_REPEAT(authToken, invalidTeamPlaceId, lastThreadId, size);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
             });
         }

--- a/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
@@ -160,7 +160,7 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final Long teamPlaceId = 1L;
             final FeedThreadWritingRequest request = FeedThreadFixtures.HELLO_WRITING_REQUEST;
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(post("/api/team-place/{teamPlaceId}/feed/threads", teamPlaceId)
@@ -233,7 +233,7 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final Long teamPlaceId = 1L;
             final int size = 3;
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(get("/api/team-place/{teamPlaceId}/feed/threads", teamPlaceId)
@@ -340,7 +340,7 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final Long lastThreadId = 5L;
             final int size = 3;
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -2,7 +2,6 @@ package team.teamby.teambyteam.member.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import team.teamby.teambyteam.teamplace.domain.TeamPlaceInviteCode;
 import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_ACCOUNT;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_LEAVE_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_MY_INFORMATION;
@@ -43,7 +43,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_MY_INFORMATION(TOKEN);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(response.jsonPath().getLong("id")).isEqualTo(AUTHORIZED_MEMBER.getId());
                 softly.assertThat(response.jsonPath().getString("name")).isEqualTo(AUTHORIZED_MEMBER.getName().getValue());
@@ -61,7 +61,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_MY_INFORMATION(TokenFixtures.MALFORMED_JWT_TOKEN);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
@@ -92,7 +92,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             final TeamPlacesResponse teamPlacesResponse = response.body().as(TeamPlacesResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(3);
                 softly.assertThat(teamPlacesResponse.teamPlaces().get(0).id()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
@@ -124,7 +124,10 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = GET_PARTICIPATED_TEAM_PLACES(UNAUTHORIZED_TOKEN);
 
             //then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
+            });
         }
     }
 
@@ -147,7 +150,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             final TeamPlacesResponse teamPlacesResponse = GET_PARTICIPATED_TEAM_PLACES(ENDEL_TOKEN).body().as(TeamPlacesResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
                 softly.assertThat(teamPlacesResponse.teamPlaces()).hasSize(0);
             });
@@ -166,7 +169,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             // when
             final ExtractableResponse<Response> response = DELETE_LEAVE_TEAM_PLACE(UNAUTHORIZED_TOKEN, ENGLISH_TEAM_PLACE.getId());
 
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
@@ -187,7 +190,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = DELETE_LEAVE_TEAM_PLACE(ENDEL_TOKEN, JAPANESE_TEAM_PLACE.getId());
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
                 softly.assertThat(response.body().asString()).contains("접근할 수 없는 팀플레이스입니다.");
             });
@@ -213,7 +216,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
                 softly.assertThat(teamPlaceParticipantResponse.teamPlaceId()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
             });
@@ -235,7 +238,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
             //then
             TeamPlaceParticipantResponse teamPlaceParticipantResponse = response.body().as(TeamPlaceParticipantResponse.class);
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
                 softly.assertThat(teamPlaceParticipantResponse.teamPlaceId()).isEqualTo(ENGLISH_TEAM_PLACE.getId());
             });
@@ -254,7 +257,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, invalidInviteCode);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
             });
         }
@@ -272,7 +275,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(PHILIP_TOKEN, invalidInviteCode);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
             });
         }
@@ -290,7 +293,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PARTICIPATE_TEAM_PLACE_REQUEST(WRONG_TOKEN, inviteCode);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
@@ -326,7 +329,10 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = DELETE_ACCOUNT(NOT_REGISTERED_MEMBER_TOKEN);
 
             //then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
+            });
         }
 
         @Test
@@ -339,7 +345,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = DELETE_ACCOUNT(WRONG_TOKEN);
 
             //then
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
                 softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });

--- a/backend/src/test/java/team/teamby/teambyteam/member/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/docs/MemberApiDocsTest.java
@@ -80,7 +80,7 @@ public final class MemberApiDocsTest extends ApiDocsTest {
         void failIfUnAuthorized() throws Exception {
             // given
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(get("/api/me")
@@ -135,7 +135,7 @@ public final class MemberApiDocsTest extends ApiDocsTest {
         void failIfUnAuthentication() throws Exception {
             // given
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(get("/api/me/team-places")
@@ -191,7 +191,7 @@ public final class MemberApiDocsTest extends ApiDocsTest {
             // given
             final Long teamPlaceId = 1L;
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(delete("/api/me/team-places/{teamPlaceId}", teamPlaceId)
@@ -337,7 +337,7 @@ public final class MemberApiDocsTest extends ApiDocsTest {
             // given
             final String inviteCode = "aaaa1234";
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(post("/api/me/team-places/{inviteCode}", inviteCode)
@@ -414,7 +414,7 @@ public final class MemberApiDocsTest extends ApiDocsTest {
         void failIfNotAuthenticated() throws Exception {
             // given
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(delete("/api/me/account")

--- a/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
@@ -127,7 +127,7 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자로 요청 시 등록이 실패한다.")
-        void fail() {
+        void failUnAuthorizedMember() {
             // given
             final NoticeRegisterRequest request = NoticeFixtures.FIRST_NOTICE_REGISTER_REQUEST;
             final String unauthorizedToken = jwtTokenProvider.generateAccessToken(ROY().getEmail().getValue());
@@ -137,8 +137,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(response.body().asString()).contains("조회한 멤버가 존재하지 않습니다.");
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
         }
     }

--- a/backend/src/test/java/team/teamby/teambyteam/sharedlink/docs/SharedLinkApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sharedlink/docs/SharedLinkApiDocsTest.java
@@ -164,7 +164,7 @@ public final class SharedLinkApiDocsTest extends ApiDocsTest {
             final Long teamPlaceId = 1L;
             final SharedLinkCreateRequest sharedLinkCreateRequest = new SharedLinkCreateRequest("title", "url");
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(post("/api/team-place/{teamPlaceId}/team-links", teamPlaceId)
@@ -266,7 +266,7 @@ public final class SharedLinkApiDocsTest extends ApiDocsTest {
             // given
             final Long teamPlaceId = 1L;
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(get("/api/team-place/{teamPlaceId}/team-links", teamPlaceId)
@@ -387,7 +387,7 @@ public final class SharedLinkApiDocsTest extends ApiDocsTest {
             final Long teamPlaceId = 1L;
             final Long teamLinkId = 1L;
             given(memberInterceptor.preHandle(any(), any(), any()))
-                    .willThrow(new AuthenticationException.FailAuthenticationException());
+                    .willThrow(new AuthenticationException.FailAuthenticationException("잘못된 액세스 토큰"));
 
             // when & then
             mockMvc.perform(delete("/api/team-place/{teamPlaceId}/team-links/{teamLinkId}", teamPlaceId, teamLinkId)

--- a/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/teamplace/acceptance/TeamPlaceAcceptanceTest.java
@@ -2,6 +2,7 @@ package team.teamby.teambyteam.teamplace.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,7 +48,7 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
 
     @Nested
     @DisplayName("팀플레이스 생성시")
-    public class CreateTeamPlaceTest {
+    class CreateTeamPlaceTest {
 
         @Test
         @DisplayName("생성에 성공하고, 요청한 사용자가 생성된 팀플레이스에 소속된다.")
@@ -130,7 +131,7 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
 
     @Nested
     @DisplayName("팀플레이스 초대코드 조회시")
-    public class TeamPlaceInviteCodeTest {
+    class TeamPlaceInviteCodeTest {
 
         @Test
         @DisplayName("팀플레이스에 초대코드가 이미 있는 경우 해당 초대코드를 가져온다.")
@@ -350,9 +351,9 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = CHANGE_MEMBER_TEAM_PLACE_COLOR(notExistMemberToken, teamPlaceId, request);
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-                softly.assertThat(response.jsonPath().getString("error")).contains("조회한 멤버가 존재하지 않습니다.");
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
             });
         }
 
@@ -554,7 +555,7 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
 
         @Test
         @DisplayName("잘못된 토큰으로 이름 변경 요청을 하면 실패한다.")
-        void failWithWrognAccessTokenUnauthorized() {
+        void failWithWrongAccessTokenUnauthorized() {
             final String NEW_NAME = "새로온 필립";
             final DisplayMemberNameChangeRequest requestBody = new DisplayMemberNameChangeRequest(NEW_NAME);
             final String UNAUTHORIZED_MEMBER_TOKEN = jwtTokenProvider.generateAccessToken(MemberFixtures.ENDEL_EMAIL);
@@ -563,7 +564,10 @@ public class TeamPlaceAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> response = PATCH_DISPLAY_MEMBER_NAME_CHANGE(UNAUTHORIZED_MEMBER_TOKEN, STATICS_TEAM_PLACE.getId(), requestBody);
 
             // then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                softly.assertThat(response.body().asString()).contains("인증이 실패했습니다.");
+            });
         }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/token/application/TokenServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/token/application/TokenServiceTest.java
@@ -14,7 +14,11 @@ import team.teamby.teambyteam.token.exception.TokenException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
-import static team.teamby.teambyteam.common.fixtures.TokenFixtures.*;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.CORRECT_REFRESH_TOKEN;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.EXPIRED_REFRESH_TOKEN;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MALFORMED_JWT_TOKEN;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.MISSING_CLAIM_REFRESH_TOKEN;
+import static team.teamby.teambyteam.common.fixtures.TokenFixtures.TOKEN_ENTITY;
 
 class TokenServiceTest extends ServiceTest {
 
@@ -65,7 +69,7 @@ class TokenServiceTest extends ServiceTest {
         // when & then
         assertThatThrownBy(() -> tokenService.reissueToken(missingClaimRefreshToken))
                 .isInstanceOf(AuthenticationException.FailAuthenticationException.class)
-                .hasMessage("인증이 실패했습니다.");
+                .hasMessage("인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + token.getRefreshToken());
     }
 
     @Test
@@ -79,7 +83,7 @@ class TokenServiceTest extends ServiceTest {
         // when & then
         assertThatThrownBy(() -> tokenService.reissueToken(malformedJwtToken))
                 .isInstanceOf(AuthenticationException.FailAuthenticationException.class)
-                .hasMessage("인증이 실패했습니다.");
+                .hasMessage("인증 실패(잘못된 리프레시 토큰) - 토큰 : " + token.getRefreshToken());
     }
 
     @Test

--- a/backend/src/test/java/team/teamby/teambyteam/token/docs/TokenApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/token/docs/TokenApiDocsTest.java
@@ -130,7 +130,7 @@ public class TokenApiDocsTest extends ApiDocsTest {
             // given
             final String malFormedRefreshToken = MALFORMED_JWT_TOKEN;
             given(jwtTokenExtractor.extractRefreshToken(any())).willReturn(malFormedRefreshToken);
-            willThrow(new AuthenticationException.FailAuthenticationException())
+            willThrow(new AuthenticationException.FailAuthenticationException("잘못된 리프레시 토큰"))
                     .given(tokenService)
                     .reissueToken(malFormedRefreshToken);
 
@@ -153,7 +153,7 @@ public class TokenApiDocsTest extends ApiDocsTest {
             // given
             final String missingClaimRefreshToken = MISSING_CLAIM_REFRESH_TOKEN;
             given(jwtTokenExtractor.extractRefreshToken(any())).willReturn(missingClaimRefreshToken);
-            willThrow(new AuthenticationException.FailAuthenticationException())
+            willThrow(new AuthenticationException.FailAuthenticationException("JWT 리프레시 토큰 Payload 이메일 누락"))
                     .given(tokenService)
                     .reissueToken(missingClaimRefreshToken);
 


### PR DESCRIPTION
## 이슈번호
> 해당되는 모든 번호를 태그해주세요

## PR 내용
* MemberInterceptor 예외 401로 변경 + 인증 예외 로깅 리팩토링
  * MemberInterceptor 404 -> 401로 변경
  * 모든 인증 예외 : '인증이 실패했습니다.' 로깅이었던 것 -> 로깅 정보 추가해서 로깅되도록 수정
    * AuthenticationException에서 message로 logMessage를 받아서 Handler에서 로깅 시 사용하도록 리팩토링
    * 사용자에게 나갈 ErrorResponse는 Handler에서 직접 설정("인증이 실패했습니다.")   


## 참고자료

## 의논할 거리
