### PR TITLE
[FE] 잘못된 팀플레이스 ID로 요청하는 것 막는 기능 추가

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -16,6 +16,10 @@ export const http = {
       throw response;
     }
 
+    if (response.status === 403) {
+      throw response;
+    }
+
     if (!response.ok) {
       throw new Error('네트워크 통신 중 에러가 발생했습니다.');
     }

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -14,7 +14,7 @@ interface TeamPlaceMembersResponse {
   members: Omit<UserInfo, 'email'>[];
 }
 
-export const fetchTeamPlaces = async () => {
+export const fetchTeamPlaces = () => {
   return http.get<TeamPlacesResponse>('/api/me/team-places');
 };
 

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -14,18 +14,8 @@ interface TeamPlaceMembersResponse {
   members: Omit<UserInfo, 'email'>[];
 }
 
-let teamPlacePromise: Promise<TeamPlacesResponse> | null = null;
-
 export const fetchTeamPlaces = async () => {
-  if (teamPlacePromise !== null) {
-    return teamPlacePromise;
-  }
-
-  teamPlacePromise = http.get<TeamPlacesResponse>('/api/me/team-places');
-
-  const response = await teamPlacePromise;
-  teamPlacePromise = null;
-  return response;
+  return http.get<TeamPlacesResponse>('/api/me/team-places');
 };
 
 export const fetchTeamPlaceInviteCode = (teamPlaceId: number) => {

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -14,8 +14,18 @@ interface TeamPlaceMembersResponse {
   members: Omit<UserInfo, 'email'>[];
 }
 
-export const fetchTeamPlaces = () => {
-  return http.get<TeamPlacesResponse>('/api/me/team-places');
+let teamPlacePromise: Promise<TeamPlacesResponse> | null = null;
+
+export const fetchTeamPlaces = async () => {
+  if (teamPlacePromise !== null) {
+    return teamPlacePromise;
+  }
+
+  teamPlacePromise = http.get<TeamPlacesResponse>('/api/me/team-places');
+
+  const response = await teamPlacePromise;
+  teamPlacePromise = null;
+  return response;
 };
 
 export const fetchTeamPlaceInviteCode = (teamPlaceId: number) => {

--- a/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
+++ b/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
@@ -1,18 +1,15 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { LOCAL_STORAGE_KEY } from '~/constants/localStorage';
 import { PATH_NAME } from '~/constants/routes';
 import { TeamPlaceProvider } from '~/contexts/TeamPlaceContext';
 import { useSendTokenReissue } from '~/hooks/queries/useSendTokenReissue';
-import { useToast } from '~/hooks/useToast';
 
 const ProtectRoute = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { showToast } = useToast();
   const { mutateSendTokenReissue } = useSendTokenReissue();
-  const [isWrongTeam, setIsWrongTeam] = useState(false);
 
   useEffect(() => {
     const accessToken = localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);

--- a/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
+++ b/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
@@ -41,6 +41,11 @@ const ProtectRoute = () => {
       resetAccessToken();
       throw new Error('유효한 사용자 정보가 아닙니다.');
     }
+
+    if (response.status === 403) {
+      localStorage.removeItem(LOCAL_STORAGE_KEY.TEAM_PLACE_ID);
+      await queryClient.invalidateQueries(['teamPlaces']);
+    }
   };
 
   queryClient.setDefaultOptions({

--- a/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
+++ b/frontend/src/components/common/ProtectRoute/ProtectRoute.tsx
@@ -1,15 +1,18 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { LOCAL_STORAGE_KEY } from '~/constants/localStorage';
 import { PATH_NAME } from '~/constants/routes';
 import { TeamPlaceProvider } from '~/contexts/TeamPlaceContext';
 import { useSendTokenReissue } from '~/hooks/queries/useSendTokenReissue';
+import { useToast } from '~/hooks/useToast';
 
 const ProtectRoute = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const { mutateSendTokenReissue } = useSendTokenReissue();
+  const [isWrongTeam, setIsWrongTeam] = useState(false);
 
   useEffect(() => {
     const accessToken = localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
@@ -44,7 +47,7 @@ const ProtectRoute = () => {
 
     if (response.status === 403) {
       localStorage.removeItem(LOCAL_STORAGE_KEY.TEAM_PLACE_ID);
-      await queryClient.invalidateQueries(['teamPlaces']);
+      navigate(PATH_NAME.TEAM_SELECT);
     }
   };
 

--- a/frontend/src/contexts/TeamPlaceContext.tsx
+++ b/frontend/src/contexts/TeamPlaceContext.tsx
@@ -49,13 +49,15 @@ export const TeamPlaceProvider = (props: PropsWithChildren) => {
 
   useEffect(() => {
     if (!isFetched) return;
-    console.log('a');
+
     if (teamPlaces.length === 0) return;
-    console.log('b');
+
     const id = localStorage.getItem(LOCAL_STORAGE_KEY.TEAM_PLACE_ID);
-    console.log('id' + id);
-    const initTeamPlaceId = id === null ? teamPlaces[0].id : Number(id);
-    console.log('initTeamPlaceId' + initTeamPlaceId);
+    const teamPlaceIdIndex = teamPlaces.findIndex(
+      (teamPlace) => teamPlace.id === Number(id),
+    );
+    const initTeamPlaceId =
+      teamPlaceIdIndex === -1 ? teamPlaces[0].id : Number(id);
 
     changeTeamPlace(initTeamPlaceId);
   }, [isFetched, changeTeamPlace, teamPlaces]);

--- a/frontend/src/contexts/TeamPlaceContext.tsx
+++ b/frontend/src/contexts/TeamPlaceContext.tsx
@@ -41,18 +41,21 @@ export const TeamPlaceProvider = (props: PropsWithChildren) => {
   );
 
   const resetTeamPlace = () => {
+    localStorage.removeItem(LOCAL_STORAGE_KEY.TEAM_PLACE_ID);
     setTeamPlaceId(() => 0);
     setDisplayName(() => '');
     setTeamPlaceColor(() => 100);
-    localStorage.removeItem('teamPlaceId');
   };
 
   useEffect(() => {
     if (!isFetched) return;
-
+    console.log('a');
     if (teamPlaces.length === 0) return;
+    console.log('b');
     const id = localStorage.getItem(LOCAL_STORAGE_KEY.TEAM_PLACE_ID);
+    console.log('id' + id);
     const initTeamPlaceId = id === null ? teamPlaces[0].id : Number(id);
+    console.log('initTeamPlaceId' + initTeamPlaceId);
 
     changeTeamPlace(initTeamPlaceId);
   }, [isFetched, changeTeamPlace, teamPlaces]);

--- a/frontend/src/mocks/handlers/calendar.ts
+++ b/frontend/src/mocks/handlers/calendar.ts
@@ -3,6 +3,7 @@ import {
   schedules as scheduleData,
   mySchedules as myScheduleData,
 } from '~/mocks/fixtures/schedules';
+import { teamPlaces } from '~/mocks/fixtures/team';
 
 let schedules = [...scheduleData];
 let mySchedules = [...myScheduleData];
@@ -19,14 +20,24 @@ export const calendarHandlers = [
   }),
 
   //팀플레이스 일정 기간 조회
-  rest.get(`/api/team-place/:teamPlaceId/calendar/schedules`, (_, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({
-        schedules,
-      }),
-    );
-  }),
+  rest.get(
+    `/api/team-place/:teamPlaceId/calendar/schedules`,
+    (req, res, ctx) => {
+      const teamPlaceId = Number(req.params.teamPlaceId);
+      const index = teamPlaces.findIndex(
+        (teamPlace) => teamPlace.id === teamPlaceId,
+      );
+
+      if (index === -1) return res(ctx.status(403));
+
+      return res(
+        ctx.status(200),
+        ctx.json({
+          schedules,
+        }),
+      );
+    },
+  ),
 
   //팀플레이스 특정 일정 조회
   rest.get(
@@ -34,6 +45,13 @@ export const calendarHandlers = [
     (req, res, ctx) => {
       const scheduleId = Number(req.params.scheduleId);
       const data = schedules.find((schedule) => schedule.id === scheduleId);
+
+      const teamPlaceId = Number(req.params.teamPlaceId);
+      const index = teamPlaces.findIndex(
+        (teamPlace) => teamPlace.id === teamPlaceId,
+      );
+
+      if (index === -1) return res(ctx.status(403));
 
       if (data === undefined) return res(ctx.status(404));
       return res(ctx.status(200), ctx.json(data));
@@ -52,6 +70,11 @@ export const calendarHandlers = [
         endDateTime,
       };
       const teamPlaceId = Number(req.params.teamPlaceId);
+      const index = teamPlaces.findIndex(
+        (teamPlace) => teamPlace.id === teamPlaceId,
+      );
+
+      if (index === -1) return res(ctx.status(403));
 
       schedules.push(newSchedule);
       mySchedules.push({ ...newSchedule, teamPlaceId: 1 });

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -1,6 +1,8 @@
 import { rest } from 'msw';
 import { threads as threadData } from '~/mocks/fixtures/threads';
 import { noticeThread as noticeData } from '~/mocks/fixtures/threads';
+import { teamPlaces } from '~/mocks/fixtures/team';
+
 import type { YYYYMMDDHHMM } from '~/types/schedule';
 
 const threads = [...threadData];
@@ -13,6 +15,12 @@ export const feedHandlers = [
     async (req, res, ctx) => {
       const lastThreadId = Number(req.url.searchParams.get('last-thread-id'));
       const size = Number(req.url.searchParams.get('size'));
+      const teamPlaceId = Number(req.params.teamPlaceId);
+      const teamIndex = teamPlaces.findIndex(
+        (teamPlace) => teamPlace.id === teamPlaceId,
+      );
+
+      if (teamIndex === -1) return res(ctx.status(403));
 
       const index = threads.findIndex((thread) => thread.id === lastThreadId);
 
@@ -29,6 +37,13 @@ export const feedHandlers = [
   rest.get(
     '/api/team-place/:teamPlaceId/feed/notice/recent',
     async (req, res, ctx) => {
+      const teamPlaceId = Number(req.params.teamPlaceId);
+      const teamIndex = teamPlaces.findIndex(
+        (teamPlace) => teamPlace.id === teamPlaceId,
+      );
+
+      if (teamIndex === -1) return res(ctx.status(403));
+
       return res(ctx.status(200), ctx.json(noticeThread));
     },
   ),

--- a/frontend/src/mocks/handlers/link.ts
+++ b/frontend/src/mocks/handlers/link.ts
@@ -1,5 +1,6 @@
 import { rest } from 'msw';
 import { teamLinks } from '../fixtures/link';
+import { teamPlaces } from '~/mocks/fixtures/team';
 
 let incrementalId = 1;
 
@@ -28,6 +29,13 @@ export const LinkHandlers = [
 
   // 팀 링크목록 조회
   rest.get('/api/team-place/:teamPlaceId/team-links', async (req, res, ctx) => {
+    const teamPlaceId = Number(req.params.teamPlaceId);
+    const index = teamPlaces.findIndex(
+      (teamPlace) => teamPlace.id === teamPlaceId,
+    );
+
+    if (index === -1) return res(ctx.status(403));
+
     return res(ctx.status(200), ctx.json({ teamLinks }));
   }),
 


### PR DESCRIPTION
# [FE] 잘못된 팀플레이스 ID로 요청하는 것 막는 기능 추가
## 이슈번호
> close #620 


## PR 내용
초기 teamPlaceId가 유효한 값인지 확인하는 로직 추가.
이외의 상황에서 403에러가 발생할경우 team select 페이지로 이동하도록 수정

## 참고자료

## 의논할 거리
