### PR TITLE
[BE] 피드스레드 조회 api 응답 수정 및 이벤트 제거, 최적화

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -60,19 +60,19 @@ public class FeedThreadService {
     }
 
     @Transactional(readOnly = true)
-    public FeedsResponse firstRead(final Long teamPlaceId, final Integer size) {
+    public FeedsResponse firstRead(final Long teamPlaceId, final MemberEmailDto memberEmailDto, final Integer size) {
         final Pageable pageSize = getPageableInitSize(size);
         final List<Feed> list = feedRepository.findByTeamPlaceId(teamPlaceId, pageSize);
-        final List<FeedResponse> feedResponses = mapFeedResponses(list);
+        final List<FeedResponse> feedResponses = mapFeedResponses(list, memberEmailDto.email());
 
         return FeedsResponse.of(feedResponses);
     }
 
     @Transactional(readOnly = true)
-    public FeedsResponse reRead(final Long teamPlaceId, final Long feedId, final Integer size) {
+    public FeedsResponse reRead(final Long teamPlaceId, final MemberEmailDto memberEmailDto, final Long feedId, final Integer size) {
         final Pageable pageSize = getPageableInitSize(size);
         final List<Feed> list = feedRepository.findByTeamPlaceIdAndIdLessThan(teamPlaceId, feedId, pageSize);
-        final List<FeedResponse> feedResponses = mapFeedResponses(list);
+        final List<FeedResponse> feedResponses = mapFeedResponses(list, memberEmailDto.email());
 
         return FeedsResponse.of(feedResponses);
     }
@@ -81,15 +81,18 @@ public class FeedThreadService {
         return PageRequest.of(FIRST_PAGE, size, SORT_DIRECTION, SORT_CRITERIA);
     }
 
-    private List<FeedResponse> mapFeedResponses(final List<Feed> feeds) {
-        return feeds.stream().map(this::mapToResponse).toList();
+    private List<FeedResponse> mapFeedResponses(final List<Feed> feeds, final String loginMemberEmail) {
+        return feeds.stream()
+                .map(feed -> mapToResponse(feed, loginMemberEmail))
+                .toList();
     }
 
-    private FeedResponse mapToResponse(final Feed feed) {
+    private FeedResponse mapToResponse(final Feed feed, final String loginMemberEmail) {
         if (FeedType.THREAD == feed.getType()) {
-            final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(feed.getTeamPlaceId(), feed.getAuthorId())
+            final MemberTeamPlace memberTeamPlace = memberTeamPlaceRepository
+                    .findByTeamPlaceIdAndMemberId(feed.getTeamPlaceId(), feed.getAuthorId())
                     .orElse(MemberTeamPlace.UNKNOWN_MEMBER_TEAM_PLACE);
-            return FeedResponse.from(feed, memberTeamPlace);
+            return FeedResponse.from(feed, memberTeamPlace, loginMemberEmail);
         }
         if (FeedType.NOTIFICATION == feed.getType()) {
             return FeedResponse.from(feed, AUTHOR_NAME_SCHEDULE, BLANK_PROFILE_IMAGE_URL);

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/NotificationService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/NotificationService.java
@@ -16,6 +16,7 @@ import team.teamby.teambyteam.sharedlink.application.event.SharedLinkEvent;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Deprecated
 public class NotificationService {
 
     private final FeedRepository feedRepository;

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
@@ -1,0 +1,9 @@
+package team.teamby.teambyteam.feed.application.dto;
+
+public record FeedImageResponse(
+        Long id,
+        Boolean isExpired,
+        String name,
+        String url
+) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -4,6 +4,7 @@ import team.teamby.teambyteam.feed.domain.Feed;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
 
 public record FeedResponse(
@@ -31,7 +32,7 @@ public record FeedResponse(
                 profileImageUrl,
                 createdAt,
                 feed.getContent().getValue(),
-                List.of(),
+                Collections.emptyList(),
                 false
         );
     }
@@ -48,7 +49,7 @@ public record FeedResponse(
                 threadAuthorInfo.findMemberProfileImageUrl(),
                 createdAt,
                 feed.getContent().getValue(),
-                List.of(),
+                Collections.emptyList(),
                 threadAuthorInfo.isEmailEqual(loginMemberEmail)
         );
     }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -49,7 +49,7 @@ public record FeedResponse(
                 createdAt,
                 feed.getContent().getValue(),
                 List.of(),
-                threadAuthorInfo.isEmail(loginMemberEmail)
+                threadAuthorInfo.isEmailEqual(loginMemberEmail)
         );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -12,7 +12,8 @@ public record FeedResponse(
         String authorName,
         String profileImageUrl,
         String createdAt,
-        String content
+        String content,
+        Boolean isMe
 ) {
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
 
@@ -27,11 +28,12 @@ public record FeedResponse(
                 authorName,
                 profileImageUrl,
                 createdAt,
-                feed.getContent().getValue()
+                feed.getContent().getValue(),
+                false
         );
     }
 
-    public static FeedResponse from(final Feed feed, final MemberTeamPlace threadAuthorInfo) {
+    public static FeedResponse from(final Feed feed, final MemberTeamPlace threadAuthorInfo, final String loginMemberEmail) {
         final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
         String createdAt = feed.getCreatedAt().format(dateTimeFormatter);
 
@@ -42,7 +44,8 @@ public record FeedResponse(
                 threadAuthorInfo.getDisplayMemberName().getValue(),
                 threadAuthorInfo.findMemberProfileImageUrl(),
                 createdAt,
-                feed.getContent().getValue()
+                feed.getContent().getValue(),
+                threadAuthorInfo.isEmail(loginMemberEmail)
         );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -4,6 +4,7 @@ import team.teamby.teambyteam.feed.domain.Feed;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 public record FeedResponse(
         Long id,
@@ -13,6 +14,7 @@ public record FeedResponse(
         String profileImageUrl,
         String createdAt,
         String content,
+        List<FeedImageResponse> images,
         Boolean isMe
 ) {
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
@@ -29,6 +31,7 @@ public record FeedResponse(
                 profileImageUrl,
                 createdAt,
                 feed.getContent().getValue(),
+                List.of(),
                 false
         );
     }
@@ -45,6 +48,7 @@ public record FeedResponse(
                 threadAuthorInfo.findMemberProfileImageUrl(),
                 createdAt,
                 feed.getContent().getValue(),
+                List.of(),
                 threadAuthorInfo.isEmail(loginMemberEmail)
         );
     }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/presentation/FeedThreadController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/presentation/FeedThreadController.java
@@ -15,10 +15,10 @@ import team.teamby.teambyteam.aws.s3.application.S3UploadService;
 import team.teamby.teambyteam.feed.application.FeedThreadService;
 import team.teamby.teambyteam.feed.application.dto.FeedThreadWritingRequest;
 import team.teamby.teambyteam.feed.application.dto.FeedsResponse;
-import team.teamby.teambyteam.member.configuration.AuthPrincipal;
-import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.feed.application.dto.PresignedUrlsRequest;
 import team.teamby.teambyteam.feed.application.dto.PresignedUrlsResponse;
+import team.teamby.teambyteam.member.configuration.AuthPrincipal;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
@@ -46,9 +46,10 @@ public class FeedThreadController {
     @GetMapping(value = "/{teamPlaceId}/feed/threads", params = {"size"})
     public ResponseEntity<FeedsResponse> read(
             @PathVariable final Long teamPlaceId,
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
             @RequestParam final Integer size
     ) {
-        FeedsResponse feeds = feedThreadService.firstRead(teamPlaceId, size);
+        FeedsResponse feeds = feedThreadService.firstRead(teamPlaceId, memberEmailDto, size);
 
         return ResponseEntity.ok(feeds);
     }
@@ -56,10 +57,11 @@ public class FeedThreadController {
     @GetMapping(value = "/{teamPlaceId}/feed/threads", params = {"last-thread-id", "size"})
     public ResponseEntity<FeedsResponse> read(
             @PathVariable final Long teamPlaceId,
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
             @RequestParam("last-thread-id") final Long threadId,
             @RequestParam final Integer size
     ) {
-        FeedsResponse feeds = feedThreadService.reRead(teamPlaceId, threadId, size);
+        FeedsResponse feeds = feedThreadService.reRead(teamPlaceId, memberEmailDto, threadId, size);
 
         return ResponseEntity.ok(feeds);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -113,4 +113,8 @@ public class Member extends BaseEntity {
             }
         }
     }
+
+    public String getEmailValue() {
+        return email.getValue();
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -136,7 +136,7 @@ public class MemberTeamPlace extends BaseEntity {
         return this.displayMemberName.getValue().equals(member.getName().getValue());
     }
 
-    public Boolean isEmail(final String loginMemberEmail) {
+    public Boolean isEmailEqual(final String loginMemberEmail) {
         return member.getEmailValue().equals(loginMemberEmail);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -135,4 +135,8 @@ public class MemberTeamPlace extends BaseEntity {
     public boolean isDefaultDisplayName() {
         return this.displayMemberName.getValue().equals(member.getName().getValue());
     }
+
+    public Boolean isEmail(final String loginMemberEmail) {
+        return member.getEmailValue().equals(loginMemberEmail);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
@@ -33,7 +33,6 @@ public class TeamCalendarScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final TeamPlaceRepository teamPlaceRepository;
-    private final ApplicationEventPublisher eventPublisher;
 
     public Long register(final ScheduleRegisterRequest scheduleRegisterRequest, final Long teamPlaceId) {
         checkTeamPlaceExist(teamPlaceId);
@@ -44,9 +43,6 @@ public class TeamCalendarScheduleService {
 
         final Schedule savedSchedule = scheduleRepository.save(schedule);
         log.info("일정 등록 - 팀플레이스 아이디 : {}, 일정 아이디 : {}", teamPlaceId, savedSchedule.getId());
-
-        eventPublisher.publishEvent(new ScheduleCreateEvent(savedSchedule.getId(), teamPlaceId, title, span));
-        log.info("일정 등록 이벤트 발행 - 일정 아이디 : {}", savedSchedule.getId());
 
         return savedSchedule.getId();
     }
@@ -128,10 +124,6 @@ public class TeamCalendarScheduleService {
 
         final ScheduleUpdateEventDto scheduleUpdateEventDto =
                 ScheduleUpdateEventDto.of(titleToUpdate, startDateTimeToUpdate, endDateTimeToUpdate);
-
-        eventPublisher.publishEvent(new ScheduleUpdateEvent(scheduleId, teamPlaceId,
-                previousTitle, previousSpan, scheduleUpdateEventDto));
-        log.info("일정 수정 이벤트 발행 - 일정 아이디 : {}", scheduleId);
     }
 
     public void delete(final Long teamPlaceId, final Long scheduleId) {
@@ -143,9 +135,5 @@ public class TeamCalendarScheduleService {
 
         scheduleRepository.deleteById(scheduleId);
         log.info("일정 삭제 - 팀플레이스 아이디 : {}, 일정 아이디 : {}", teamPlaceId, scheduleId);
-
-        eventPublisher.publishEvent(new ScheduleDeleteEvent(scheduleId, teamPlaceId,
-                schedule.getTitle(), schedule.getSpan()));
-        log.info("일정 삭제 이벤트 발행 - 일정 아이디 : {}", scheduleId);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleCreateEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleCreateEvent.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.schedule.application.event;
 import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;
 
+@Deprecated
 public class ScheduleCreateEvent extends ScheduleEvent {
 
     public ScheduleCreateEvent(final Long scheduleId, final Long teamPlaceId, final Title title, final Span span) {

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleDeleteEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleDeleteEvent.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.schedule.application.event;
 import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;
 
+@Deprecated
 public class ScheduleDeleteEvent extends ScheduleEvent {
 
     public ScheduleDeleteEvent(final Long scheduleId, final Long teamPlaceId, final Title title, final Span span) {

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleEvent.java
@@ -5,6 +5,7 @@ import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;
 
 @Getter
+@Deprecated
 public abstract class ScheduleEvent {
 
     private final Long scheduleId;

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleUpdateEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/event/ScheduleUpdateEvent.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.schedule.application.event;
 import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;
 
+@Deprecated
 public class ScheduleUpdateEvent extends ScheduleEvent {
 
     private final ScheduleUpdateEventDto scheduleUpdateEventDto;

--- a/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/SharedLinkService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/SharedLinkService.java
@@ -2,7 +2,6 @@ package team.teamby.teambyteam.sharedlink.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
@@ -15,8 +14,6 @@ import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.sharedlink.application.dto.SharedLinkCreateRequest;
 import team.teamby.teambyteam.sharedlink.application.dto.SharedLinkResponse;
 import team.teamby.teambyteam.sharedlink.application.dto.SharedLinksResponse;
-import team.teamby.teambyteam.sharedlink.application.event.SharedLinkCreateEvent;
-import team.teamby.teambyteam.sharedlink.application.event.SharedLinkDeleteEvent;
 import team.teamby.teambyteam.sharedlink.domain.SharedLink;
 import team.teamby.teambyteam.sharedlink.domain.SharedLinkRepository;
 import team.teamby.teambyteam.sharedlink.domain.vo.SharedURL;
@@ -34,7 +31,6 @@ public class SharedLinkService {
     private final MemberRepository memberRepository;
     private final SharedLinkRepository sharedLinkRepository;
     private final MemberTeamPlaceRepository memberTeamPlaceRepository;
-    private final ApplicationEventPublisher eventPublisher;
 
     public Long create(final MemberEmailDto memberEmailDto, final Long teamPlaceId, final SharedLinkCreateRequest sharedLinkCreateRequest) {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
@@ -42,9 +38,6 @@ public class SharedLinkService {
         final SharedLink sharedLink = new SharedLink(teamPlaceId, member.getId(), new Title(sharedLinkCreateRequest.title()), new SharedURL(sharedLinkCreateRequest.url()));
         final SharedLink saved = sharedLinkRepository.save(sharedLink);
         log.info("공유 링크 등록 - 팀플레이스 아이디 : {}, 공유 링크 아이디 : {}", teamPlaceId, saved.getId());
-
-        eventPublisher.publishEvent(new SharedLinkCreateEvent(saved.getId(), teamPlaceId, saved.getTitle(), saved.getSharedURL()));
-        log.info("공유 링크 등록 이벤트 발행 - 공유 링크 아이디 : {}", saved.getId());
 
         return saved.getId();
     }
@@ -72,8 +65,5 @@ public class SharedLinkService {
         sharedLink.validateOwnerTeamPlace(teamPlaceId);
         sharedLinkRepository.delete(sharedLink);
         log.info("공유 링크 삭제 - 팀플레이스 아이디 : {}, 공유 링크 아이디 : {}", teamPlaceId, sharedLinkId);
-
-        eventPublisher.publishEvent(new SharedLinkDeleteEvent(sharedLinkId, teamPlaceId, sharedLink.getTitle(), sharedLink.getSharedURL()));
-        log.info("공유 링크 삭제 이벤트 발행 - 공유 링크 아이디 : {}", sharedLinkId);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/event/SharedLinkCreateEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/event/SharedLinkCreateEvent.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.sharedlink.application.event;
 import team.teamby.teambyteam.sharedlink.domain.vo.SharedURL;
 import team.teamby.teambyteam.sharedlink.domain.vo.Title;
 
+@Deprecated
 public class SharedLinkCreateEvent extends SharedLinkEvent {
 
     public SharedLinkCreateEvent(final Long sharedLinkId, final Long teamPlaceId, final Title title, final SharedURL sharedURL) {

--- a/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/event/SharedLinkDeleteEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/event/SharedLinkDeleteEvent.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.sharedlink.application.event;
 import team.teamby.teambyteam.sharedlink.domain.vo.SharedURL;
 import team.teamby.teambyteam.sharedlink.domain.vo.Title;
 
+@Deprecated
 public class SharedLinkDeleteEvent extends SharedLinkEvent {
 
     public SharedLinkDeleteEvent(final Long sharedLinkId, final Long teamPlaceId, final Title title, final SharedURL sharedURL) {

--- a/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/event/SharedLinkEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sharedlink/application/event/SharedLinkEvent.java
@@ -5,6 +5,7 @@ import team.teamby.teambyteam.sharedlink.domain.vo.SharedURL;
 import team.teamby.teambyteam.sharedlink.domain.vo.Title;
 
 @Getter
+@Deprecated
 public abstract class SharedLinkEvent {
 
     private final Long sharedLinkId;

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/NotificationServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/NotificationServiceTest.java
@@ -34,7 +34,6 @@ import static team.teamby.teambyteam.common.fixtures.SharedLinkEventFixtures.SHA
 import static team.teamby.teambyteam.common.fixtures.SharedLinkFixtures.TEAM_BY_TEAM_LINK;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 
-@Disabled
 class NotificationServiceTest extends ServiceTest {
 
     @Autowired
@@ -45,6 +44,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("일정 등록 시 일정 등록 알림 생성")
+    @Disabled(value = "일정 피드 알림기능 제거로 인한 테스트 disable - 추후 다른형식으로 부활 가능성 있음")
     class CreateScheduleNotificationWhenCreateSchedule {
 
         @Test
@@ -93,6 +93,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("일정 삭제 시 일정 삭제 알림 생성")
+    @Disabled(value = "일정 피드 알림기능 제거로 인한 테스트 disable - 추후 다른형식으로 부활 가능성 있음")
     class CreateScheduleNotificationWhenDeleteSchedule {
 
         @Test
@@ -117,6 +118,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("공유 링크 등록 시 등록 알림 생성")
+    @Disabled(value = "공유링크 피드 알림기능 제거로 인한 테스트 disable - 추후 다른형식으로 부활 가능성 있음")
     class CreateSharedLinkNotificationWhenCreateSharedLink {
 
         @Test
@@ -141,6 +143,7 @@ class NotificationServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("공유 링크 삭제 시 삭제 알림 생성")
+    @Disabled(value = "공유링크 피드 알림기능 제거로 인한 테스트 disable - 추후 다른형식으로 부활 가능성 있음")
     class CreateSharedLinkNotificationWhenDeleteSharedLink {
 
         @Test

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/NotificationServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.feed.application;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import static team.teamby.teambyteam.common.fixtures.SharedLinkEventFixtures.SHA
 import static team.teamby.teambyteam.common.fixtures.SharedLinkFixtures.TEAM_BY_TEAM_LINK;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 
+@Disabled
 class NotificationServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
@@ -20,6 +20,7 @@ import team.teamby.teambyteam.feed.application.dto.FeedThreadWritingRequest;
 import team.teamby.teambyteam.feed.application.dto.FeedsResponse;
 import team.teamby.teambyteam.feed.domain.FeedType;
 import team.teamby.teambyteam.feed.presentation.FeedThreadController;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.util.List;
@@ -202,9 +203,9 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final int size = 3;
             final Long authorId = 1L;
 
-            FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello");
+            FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello", false);
             final FeedsResponse feedsResponse = new FeedsResponse(List.of(feedResponse));
-            given(feedThreadService.firstRead(teamPlaceId, size))
+            given(feedThreadService.firstRead(any(), any(), any()))
                     .willReturn(feedsResponse);
 
             // when & then
@@ -304,9 +305,9 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final Long authorId = 1L;
 
 
-            final FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello");
+            final FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello", false);
             final FeedsResponse feedsResponse = new FeedsResponse(List.of(feedResponse));
-            given(feedThreadService.reRead(teamPlaceId, lastThreadId, size))
+            given(feedThreadService.reRead(any(), any(), any(), any()))
                     .willReturn(feedsResponse);
 
             // when & then

--- a/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
@@ -203,7 +203,7 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final int size = 3;
             final Long authorId = 1L;
 
-            FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello", false);
+            FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello", List.of(), false);
             final FeedsResponse feedsResponse = new FeedsResponse(List.of(feedResponse));
             given(feedThreadService.firstRead(any(), any(), any()))
                     .willReturn(feedsResponse);
@@ -305,7 +305,7 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
             final Long authorId = 1L;
 
 
-            final FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello", false);
+            final FeedResponse feedResponse = new FeedResponse(1L, FeedType.THREAD.name(), authorId, "author", "/", "created", "hello", List.of(), false);
             final FeedsResponse feedsResponse = new FeedsResponse(List.of(feedResponse));
             given(feedThreadService.reRead(any(), any(), any(), any()))
                     .willReturn(feedsResponse);

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.schedule.application;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -321,6 +322,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("일정 생성 Event가 발행된다.")
+        @Disabled
         void publishScheduleCreateEvent() {
             // given
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
@@ -391,6 +393,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("일정 수정 Event가 발행된다.")
+        @Disabled
         void publishScheduleUpdateEvent() {
             // given
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
@@ -499,6 +502,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("일정 Event가 발행된다.")
+        @Disabled
         void publishScheduleDeleteEvent() {
             // given
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
@@ -1,6 +1,5 @@
 package team.teamby.teambyteam.schedule.application;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,9 +12,6 @@ import team.teamby.teambyteam.schedule.application.dto.ScheduleRegisterRequest;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleResponse;
 import team.teamby.teambyteam.schedule.application.dto.ScheduleUpdateRequest;
 import team.teamby.teambyteam.schedule.application.dto.SchedulesResponse;
-import team.teamby.teambyteam.schedule.application.event.ScheduleCreateEvent;
-import team.teamby.teambyteam.schedule.application.event.ScheduleDeleteEvent;
-import team.teamby.teambyteam.schedule.application.event.ScheduleUpdateEvent;
 import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
@@ -321,21 +317,6 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("일정 생성 Event가 발행된다.")
-        @Disabled
-        void publishScheduleCreateEvent() {
-            // given
-            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            final ScheduleRegisterRequest request = ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_REGISTER_REQUEST;
-
-            // when
-            teamCalendarScheduleService.register(request, ENGLISH_TEAM_PLACE.getId());
-
-            // then
-            assertThat(applicationEvents.stream(ScheduleCreateEvent.class).count()).isEqualTo(1);
-        }
-
-        @Test
         @DisplayName("일정 등록 시 Span 순서가 맞지 않으면 예외가 발생한다.")
         void failSpanWrongOrder() {
             // given
@@ -382,33 +363,12 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final LocalDateTime startTimeToUpdate = DATE_2023_07_12_00_00_00;
             final ScheduleUpdateRequest request = new ScheduleUpdateRequest(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_TITLE, startTimeToUpdate, MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getSpan().getEndDateTime());
 
-
             // when
             teamCalendarScheduleService.update(request, ENGLISH_TEAM_PLACE_ID, MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_ID);
             final Schedule updatedSchedule = scheduleRepository.findById(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_ID).get();
 
             // then
             assertThat(updatedSchedule.getSpan().getStartDateTime()).isEqualTo(startTimeToUpdate);
-        }
-
-        @Test
-        @DisplayName("일정 수정 Event가 발행된다.")
-        @Disabled
-        void publishScheduleUpdateEvent() {
-            // given
-            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            final Long ENGLISH_TEAM_PLACE_ID = ENGLISH_TEAM_PLACE.getId();
-            final Schedule MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE_ID));
-            final Long MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_ID = MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getId();
-
-            final LocalDateTime startTimeToUpdate = DATE_2023_07_12_00_00_00;
-            final ScheduleUpdateRequest request = new ScheduleUpdateRequest(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_TITLE, startTimeToUpdate, MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getSpan().getEndDateTime());
-
-            // when
-            teamCalendarScheduleService.update(request, ENGLISH_TEAM_PLACE_ID, MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE_ID);
-
-            // then
-            assertThat(applicationEvents.stream(ScheduleUpdateEvent.class).count()).isEqualTo(1);
         }
 
         @ParameterizedTest
@@ -495,25 +455,8 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             // when
             teamCalendarScheduleService.delete(ENGLISH_TEAM_PLACE_ID, MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getId());
 
-
             // then
             assertThat(scheduleRepository.findById(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getId()).isEmpty()).isTrue();
-        }
-
-        @Test
-        @DisplayName("일정 Event가 발행된다.")
-        @Disabled
-        void publishScheduleDeleteEvent() {
-            // given
-            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            final Long ENGLISH_TEAM_PLACE_ID = ENGLISH_TEAM_PLACE.getId();
-            final Schedule MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE_ID));
-
-            // when
-            teamCalendarScheduleService.delete(ENGLISH_TEAM_PLACE_ID, MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getId());
-
-            // then
-            assertThat(applicationEvents.stream(ScheduleDeleteEvent.class).count()).isEqualTo(1);
         }
 
         @Test

--- a/backend/src/test/java/team/teamby/teambyteam/sharedlink/application/SharedLinkServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sharedlink/application/SharedLinkServiceTest.java
@@ -70,24 +70,6 @@ class SharedLinkServiceTest extends ServiceTest {
             });
         }
 
-        @Test
-        @DisplayName("공유 링크 Event가 발행된다.")
-        @Disabled
-        void publishSharedLinkCreateEvent() {
-            // given
-            final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
-            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            final MemberEmailDto memberEmailDto = new MemberEmailDto(member.getEmail().getValue());
-            final SharedLink sharedLink = TEAM_BY_TEAM_LINK(ENGLISH_TEAM_PLACE.getId(), member.getId());
-            final SharedLinkCreateRequest sharedLinkCreateRequest = new SharedLinkCreateRequest(sharedLink.getTitle().getValue(), sharedLink.getSharedURL().getValue());
-
-            // when
-            sharedLinkService.create(memberEmailDto, ENGLISH_TEAM_PLACE.getId(), sharedLinkCreateRequest);
-
-            // then
-            assertThat(applicationEvents.stream(SharedLinkCreateEvent.class).count()).isEqualTo(1);
-        }
-
         @ParameterizedTest
         @DisplayName("빈 제목으로 생성 시 실패한다..")
         @ValueSource(strings = {"", " ", "          "})
@@ -198,22 +180,6 @@ class SharedLinkServiceTest extends ServiceTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(beforeSize - 1).isEqualTo(afterSize);
             });
-        }
-
-        @Test
-        @DisplayName("공유 링크 Event가 발행된다.")
-        @Disabled
-        void publishSharedLinkDeleteEvent() {
-            // given
-            final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
-            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
-            final SharedLink sharedLink = testFixtureBuilder.buildSharedLink(TEAM_BY_TEAM_LINK(ENGLISH_TEAM_PLACE.getId(), member.getId()));
-
-            // when
-            sharedLinkService.deleteLink(ENGLISH_TEAM_PLACE.getId(), sharedLink.getId());
-
-            // then
-            assertThat(applicationEvents.stream(SharedLinkDeleteEvent.class).count()).isEqualTo(1);
         }
 
         @Test

--- a/backend/src/test/java/team/teamby/teambyteam/sharedlink/application/SharedLinkServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sharedlink/application/SharedLinkServiceTest.java
@@ -1,6 +1,7 @@
 package team.teamby.teambyteam.sharedlink.application;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -71,6 +72,7 @@ class SharedLinkServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("공유 링크 Event가 발행된다.")
+        @Disabled
         void publishSharedLinkCreateEvent() {
             // given
             final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
@@ -200,6 +202,7 @@ class SharedLinkServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("공유 링크 Event가 발행된다.")
+        @Disabled
         void publishSharedLinkDeleteEvent() {
             // given
             final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());


### PR DESCRIPTION
## 이슈번호
> close #658 close #659

## PR 내용

- 스레드 조회시 필요 필드 추가
  - isMe 필드 추가 (작성자인지 확인)
    - 알림의 경우 모든 isMe필드는 `false`
  -images필드 추가
    - 기능구현은 안함
    - 일단 무조건 빈 배열 반환
    - 기능추가시 관련 테스트 추가 및 변환 로직 추가 필요

- 일정 추가/변경/제거시 알림 제거
  - 관련 `Event`, `Service`에 `@Deprecated` 추가
  - 관련 테스트에 `@Disabled` 추가
  - event publish 제거

- 피드조회시 나가는 쿼리 변경
  - 기존 : `select ~~ from member_team_place where member.id = ? and teamplace.id = ?`
    - 조회 타입 : `index_merge`
    - 해당 쿼리를 매 스레드마다 조회 (만약 20개의 스레드 조회시 20회 `select`)
  - 변경 : `select ~~ from memeber_team_place where teamplace.id = ?`
    - 조회 타입 : `ref`
    - 피드조회시 최초만 조회하여 `Map`으로 팀원들 정보 캐싱

## 참고자료

## 의논할 거리

피드조회시 피드와 알림간의 관계, 피드 도메인 -> response로의 맵핑 과정에서 레거시라고 불리만한 맘에 안드는 코드들이 많이 생김..

해당 부분은 프런트와 알림에 대한 비지니스적인 회의를 지속해서 하고, 해당 내용이 결정되면 추가적일 알림피드를 구현하며 리펙터링을 하는것이 좋을것이라고 생각합니다..
