### PR TITLE
[FE] 이미지를 로컬에 업로드할 수 있는 기능 구현

### DIFF
--- a/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.stories.tsx
+++ b/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.stories.tsx
@@ -25,27 +25,11 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     image: {
-      id: 1004,
-      isExpired: false,
-      name: 'rabbit.png',
+      uuid: '5095f36c-076b-4e7f-a782-299412cb06e1',
       url: 'https://images.unsplash.com/photo-1599169713100-120531cef331?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
     },
-    onDelete: (imageId: number) => {
-      alert(`onDelete(${imageId})`);
-    },
-  },
-};
-
-export const ExpiredThumbnail: Story = {
-  args: {
-    image: {
-      id: 1029,
-      isExpired: true,
-      name: '만료된 이미지',
-      url: '',
-    },
-    onDelete: (imageId: number) => {
-      alert(`onDelete(${imageId})`);
+    onDelete: (imageId) => {
+      alert(`onDelete('${imageId}')`);
     },
   },
 };

--- a/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.tsx
+++ b/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.tsx
@@ -1,27 +1,27 @@
 import * as S from './DeletableThumbnail.styled';
 import Button from '~/components/common/Button/Button';
-import type { ThreadImage } from '~/types/feed';
 import { CloseBoldIcon } from '~/assets/svg';
-import { thumbnailFallbackImage } from '~/assets/png';
+import type { PreviewImage } from '~/types/feed';
+import type { UUID } from 'crypto';
 
 interface DeletableThumbnailProps {
-  image: ThreadImage;
-  onDelete: (imageId: number) => void;
+  image: PreviewImage;
+  onDelete: (imageUuid: UUID) => void;
 }
 
 const DeletableThumbnail = (props: DeletableThumbnailProps) => {
   const { image, onDelete } = props;
-  const { id, isExpired, name, url } = image;
+  const { uuid, url } = image;
 
   return (
     <S.Container>
-      <S.Image src={isExpired ? thumbnailFallbackImage : url} alt={name} />
+      <S.Image src={url} alt="미리보기 이미지" />
       <Button
         variant="plain"
         type="button"
         css={S.deleteButton}
-        onClick={() => onDelete(id)}
-        aria-label={`${name} 이미지 삭제하기`}
+        onClick={() => onDelete(uuid)}
+        aria-label={`${url} 이미지 삭제하기`}
       >
         <CloseBoldIcon />
       </Button>

--- a/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.tsx
+++ b/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.tsx
@@ -2,11 +2,10 @@ import * as S from './DeletableThumbnail.styled';
 import Button from '~/components/common/Button/Button';
 import { CloseBoldIcon } from '~/assets/svg';
 import type { PreviewImage } from '~/types/feed';
-import type { UUID } from 'crypto';
 
 interface DeletableThumbnailProps {
   image: PreviewImage;
-  onDelete: (imageUuid: UUID) => void;
+  onDelete: (imageUuid: string) => void;
 }
 
 const DeletableThumbnail = (props: DeletableThumbnailProps) => {

--- a/frontend/src/components/feed/ImageAddButton/ImageAddButton.stories.tsx
+++ b/frontend/src/components/feed/ImageAddButton/ImageAddButton.stories.tsx
@@ -3,11 +3,18 @@ import ImageAddButton from './ImageAddButton';
 
 /**
  * `ImageAddButton` 은 채팅에서 이미지 등록을 위해 사용하는 버튼입니다.
+ *  클릭 시에 별도의 이벤트는 발생하지 않지만, 파일 업로드 프롬프트를 띄우며 선택된 파일이 변경되었을 경우 이벤트를 호출합니다.
  */
 const meta = {
   title: 'feed/ImageAddButton',
   component: ImageAddButton,
   tags: ['autodocs'],
+  argTypes: {
+    onChangeImage: {
+      description:
+        '사용자가 새로운 파일을 업로드하여 파일의 내용물에 변동사항이 생길 경우 호출되는 함수입니다. 여기에 파일을 업로드하기 위한 함수를 넣어 주세요.',
+    },
+  },
 } satisfies Meta<typeof ImageAddButton>;
 
 export default meta;
@@ -16,8 +23,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    onClick: () => {
-      alert('onClick()');
+    onChangeImage: () => {
+      alert('onChangeImage');
     },
   },
 };

--- a/frontend/src/components/feed/ImageAddButton/ImageAddButton.styled.ts
+++ b/frontend/src/components/feed/ImageAddButton/ImageAddButton.styled.ts
@@ -1,7 +1,7 @@
-import { css } from 'styled-components';
+import { styled } from 'styled-components';
 
-export const imageAddButton = css`
-  display: flex;
+export const FakeButton = styled.div`
+  display: inline-flex;
   justify-content: center;
   align-items: center;
 
@@ -13,6 +13,8 @@ export const imageAddButton = css`
 
   transition: 0.2s;
 
+  cursor: pointer;
+
   &:hover {
     background-color: #e8eaff;
   }
@@ -20,4 +22,8 @@ export const imageAddButton = css`
   & svg {
     color: #9792ff;
   }
+`;
+
+export const FileUploadInput = styled.input`
+  display: none;
 `;

--- a/frontend/src/components/feed/ImageAddButton/ImageAddButton.tsx
+++ b/frontend/src/components/feed/ImageAddButton/ImageAddButton.tsx
@@ -1,24 +1,26 @@
 import { PlusIcon } from '~/assets/svg';
 import * as S from './ImageAddButton.styled';
-import Button from '~/components/common/Button/Button';
+import type { ChangeEvent } from 'react';
 
 interface ImageAddButtonProps {
-  onClick: () => void;
+  onChangeImage: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const ImageAddButton = (props: ImageAddButtonProps) => {
-  const { onClick } = props;
+  const { onChangeImage } = props;
 
   return (
-    <Button
-      variant="plain"
-      type="button"
-      css={S.imageAddButton}
-      onClick={onClick}
-      aria-label="이미지 추가"
-    >
-      <PlusIcon />
-    </Button>
+    <label>
+      <S.FakeButton role="button" aria-label="이미지 추가">
+        <PlusIcon />
+      </S.FakeButton>
+      <S.FileUploadInput
+        type="file"
+        accept="image/*"
+        onChange={onChangeImage}
+        multiple
+      />
+    </label>
   );
 };
 

--- a/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.stories.tsx
+++ b/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.stories.tsx
@@ -29,10 +29,6 @@ const meta = {
       description:
         '서랍장이 열려 있는지의 여부입니다. 이 prop을 조작하여 서랍장을 열고 닫을 수 있습니다.',
     },
-    slideDistance: {
-      description:
-        '서랍장이 열리게 될 경우 얼마나 많은 거리를 위로 움직여야 할 지를 의미합니다. 단위는 `px`입니다.',
-    },
     children: {
       description:
         '랜더링할 자식 요소를 의미합니다. `ThumbnailList` 컴포넌트가 여기에 오면 됩니다.',
@@ -51,7 +47,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     isOpen: false,
-    slideDistance: 130,
     children: (
       <div style={{ fontSize: '32px', padding: '40px' }}>
         이 자리에 썸네일 리스트 컴포넌트가 올 것입니다.
@@ -66,7 +61,6 @@ export const Default: Story = {
 export const Opened: Story = {
   args: {
     isOpen: true,
-    slideDistance: 130,
     children: (
       <div style={{ fontSize: '32px', padding: '40px' }}>
         이 자리에 썸네일 리스트 컴포넌트가 올 것입니다.

--- a/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.styled.ts
+++ b/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.styled.ts
@@ -1,21 +1,24 @@
 import { styled, css } from 'styled-components';
 
-export const Container = styled.div<{ bottom: number }>`
+export const Container = styled.div<{ isOpen: boolean }>`
   display: flex;
   position: absolute;
-  bottom: 0;
+  bottom: 46px;
+  left: 30px;
 
-  width: 100%;
+  width: calc(100% - 60px);
   height: 136px;
 
   border-radius: 20px 20px 0 0;
   background: linear-gradient(30deg, #bfc3ff, #eaebff);
 
   transition: 0.35s;
-  transform: translateY(${({ bottom }) => `-${bottom}px`});
+  transform: translateY(${({ isOpen }) => (isOpen ? '-162px' : '0')});
 `;
 
 export const ContentWrapper = styled.div`
+  overflow-x: auto;
+  overflow-y: hidden;
   flex-grow: 1;
 `;
 

--- a/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.tsx
+++ b/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.tsx
@@ -5,17 +5,16 @@ import { CloseBoldIcon } from '~/assets/svg';
 
 interface ImageUploadDrawerProps {
   isOpen: boolean;
-  slideDistance: number;
   onClose: () => void;
 }
 
 const ImageUploadDrawer = (
   props: PropsWithChildren<ImageUploadDrawerProps>,
 ) => {
-  const { isOpen, slideDistance, onClose, children } = props;
+  const { isOpen, onClose, children } = props;
 
   return (
-    <S.Container bottom={isOpen ? slideDistance : 0}>
+    <S.Container isOpen={isOpen}>
       <S.ContentWrapper>{children}</S.ContentWrapper>
       <S.CloseButtonWrapper>
         <Button

--- a/frontend/src/components/feed/ThumbnailList/ThumbnailList.stories.tsx
+++ b/frontend/src/components/feed/ThumbnailList/ThumbnailList.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import type { PreviewImage, ThreadImage } from '~/types/feed';
 import ThumbnailList from './ThumbnailList';
-import type { ThreadImage } from '~/types/feed';
 
 /**
  * `ThumbnailList` 은 이미지 서랍, 또는 채팅에서 사용할 수 있는 썸네일 모음집입니다.
@@ -33,7 +33,26 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const images = [
+const deleteModeImages: PreviewImage[] = [
+  {
+    uuid: '69aaaf99-a02d-4800-a175-7314c64e2a84',
+    url: 'https://images.unsplash.com/photo-1508700115892-45ecd05ae2ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
+  },
+  {
+    uuid: 'aaf9a0de-8289-455e-8112-37eebc42944a',
+    url: 'https://images.unsplash.com/photo-1551106652-a5bcf4b29ab6?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1965&q=80',
+  },
+  {
+    uuid: 'ac49b5ed-11f4-468b-b278-5880fcf7bf16',
+    url: 'https://images.unsplash.com/photo-1591382386627-349b692688ff?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
+  },
+  {
+    uuid: '3e658b3c-5664-4225-b94a-25e6cece4ac5',
+    url: 'https://img.icons8.com/?size=256&id=VUoFEYkLOaMn&format=png&color=1A6DFF,C822FF',
+  },
+];
+
+const viewModeImages: ThreadImage[] = [
   {
     id: 9283,
     isExpired: false,
@@ -72,12 +91,12 @@ const images = [
 export const DeletableList: Story = {
   args: {
     mode: 'delete',
-    images,
-    onDelete: (imageId: number) => {
-      alert(`onDelete(${imageId});`);
+    images: [],
+    onDelete: (imageUuid) => {
+      alert(`onDelete(${imageUuid});`);
     },
-    onClickAddButton: () => {
-      alert('onClickAddButton()');
+    onChange: () => {
+      alert(`onChange()`);
     },
   },
 };
@@ -88,12 +107,12 @@ export const DeletableList: Story = {
 export const NotMaxDeletableList: Story = {
   args: {
     mode: 'delete',
-    images: images.slice(0, 2),
-    onDelete: (imageId: number) => {
-      alert(`onDelete(${imageId});`);
+    images: deleteModeImages.slice(0, 2),
+    onDelete: (imageUuid) => {
+      alert(`onDelete(${imageUuid});`);
     },
-    onClickAddButton: () => {
-      alert('onClickAddButton()');
+    onChange: () => {
+      alert(`onChange()`);
     },
   },
 };
@@ -102,11 +121,11 @@ export const EmptyDeletableList: Story = {
   args: {
     mode: 'delete',
     images: [],
-    onDelete: (imageId: number) => {
-      alert(`onDelete(${imageId});`);
+    onDelete: (imageUuid) => {
+      alert(`onDelete(${imageUuid});`);
     },
-    onClickAddButton: () => {
-      alert('onClickAddButton()');
+    onChange: () => {
+      alert(`onChange()`);
     },
   },
 };
@@ -117,7 +136,7 @@ export const EmptyDeletableList: Story = {
 export const ViewableList: Story = {
   args: {
     mode: 'view',
-    images,
+    images: viewModeImages,
     onClick: (images: ThreadImage[], selectedImage: number) => {
       alert(`onClick(${JSON.stringify(images)}, ${selectedImage});`);
     },

--- a/frontend/src/components/feed/ThumbnailList/ThumbnailList.styled.ts
+++ b/frontend/src/components/feed/ThumbnailList/ThumbnailList.styled.ts
@@ -1,8 +1,6 @@
 import { styled } from 'styled-components';
 
 export const Container = styled.ul`
-  overflow-x: auto;
-  overflow-y: hidden;
   display: flex;
   flex-direction: row;
   column-gap: 12px;

--- a/frontend/src/components/feed/ThumbnailList/ThumbnailList.tsx
+++ b/frontend/src/components/feed/ThumbnailList/ThumbnailList.tsx
@@ -1,17 +1,18 @@
 import * as S from './ThumbnailList.styled';
 import DeletableThumbnail from '~/components/feed/DeletableThumbnail/DeletableThumbnail';
 import ViewableThumbnail from '~/components/feed/ViewableThumbnail/ViewableThumbnail';
-import type { ThreadImage } from '~/types/feed';
-import { MAX_UPLOAD_IMAGE_COUNT } from '~/constants/feed';
+import type { ThreadImage, PreviewImage } from '~/types/feed';
+import type { ChangeEventHandler } from 'react';
 import ImageAddButton from '../ImageAddButton/ImageAddButton';
+import { MAX_UPLOAD_IMAGE_COUNT } from '~/constants/feed';
 
 type ThumbnailListProps = DeletableThumbnails | ViewableThumbnails;
 
 interface DeletableThumbnails {
   mode: 'delete';
-  images: ThreadImage[];
-  onDelete: (imageId: number) => void;
-  onClickAddButton: () => void;
+  images: PreviewImage[];
+  onDelete: (imageUuid: string) => void;
+  onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
 interface ViewableThumbnails {
@@ -25,23 +26,23 @@ const ThumbnailList = (props: ThumbnailListProps) => {
 
   return (
     <S.Container role="list">
-      {images.map((image, index) =>
-        mode === 'delete' ? (
-          <DeletableThumbnail
-            key={image.id}
-            image={image}
-            onDelete={props.onDelete}
-          />
-        ) : (
-          <ViewableThumbnail
-            key={image.id}
-            image={image}
-            onClick={() => props.onClick(images, index + 1)}
-          />
-        ),
-      )}
+      {mode === 'delete'
+        ? images.map((image) => (
+            <DeletableThumbnail
+              key={image.uuid}
+              image={image}
+              onDelete={props.onDelete}
+            />
+          ))
+        : images.map((image, index) => (
+            <ViewableThumbnail
+              key={image.id}
+              image={image}
+              onClick={() => props.onClick(images, index + 1)}
+            />
+          ))}
       {mode === 'delete' && images.length < MAX_UPLOAD_IMAGE_COUNT && (
-        <ImageAddButton onClick={props.onClickAddButton} />
+        <ImageAddButton onChangeImage={props.onChange} />
       )}
     </S.Container>
   );

--- a/frontend/src/constants/feed.ts
+++ b/frontend/src/constants/feed.ts
@@ -21,3 +21,5 @@ export const VALID_IMAGE_TYPES = [
   'image/webp',
   'image/x-icon',
 ];
+
+export const MAX_IMAGE_CAPACITY = 5_242_880;

--- a/frontend/src/constants/feed.ts
+++ b/frontend/src/constants/feed.ts
@@ -8,3 +8,16 @@ export const THREAD_TYPE = {
 export const THREAD_SIZE = 20;
 
 export const MAX_UPLOAD_IMAGE_COUNT = 4;
+
+export const VALID_IMAGE_TYPES = [
+  'image/apng',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/pjpeg',
+  'image/png',
+  'image/svg+xml',
+  'image/tiff',
+  'image/webp',
+  'image/x-icon',
+];

--- a/frontend/src/hooks/team/useTeamFeedPage.ts
+++ b/frontend/src/hooks/team/useTeamFeedPage.ts
@@ -21,11 +21,20 @@ export const useTeamFeedPage = () => {
   const [isNotice, setIsNotice] = useState(false);
   const [isShowScrollBottomButton, setIsShowScrollBottomButton] =
     useState(false);
+  const [isImageDrawerOpen, setIsImageDrawerOpen] = useState(false);
   const [chatContent, setChatContent] = useState('');
   const ref = useRef<HTMLDivElement>(null);
 
   const handleIsNoticeChange = () => {
     setIsNotice((prev) => !prev);
+  };
+
+  const handleImageDrawerClose = () => {
+    setIsImageDrawerOpen(() => false);
+  };
+
+  const handleImageToggleButtonClick = () => {
+    setIsImageDrawerOpen((prevIsImageDrawerOpen) => !prevIsImageDrawerOpen);
   };
 
   const handleChatContentChange: ChangeEventHandler<HTMLTextAreaElement> = (
@@ -144,12 +153,15 @@ export const useTeamFeedPage = () => {
     ref,
     noticeThread,
     isNotice,
+    isImageDrawerOpen,
     isShowScrollBottomButton,
     chatContent,
 
     handlers: {
       handleIsNoticeChange,
       handleChatContentChange,
+      handleImageDrawerClose,
+      handleImageToggleButtonClick,
       handleEnterKeydown,
       handleScrollBottomButtonClick,
       handleSubmit,

--- a/frontend/src/hooks/team/useTeamFeedPage.ts
+++ b/frontend/src/hooks/team/useTeamFeedPage.ts
@@ -29,11 +29,7 @@ export const useTeamFeedPage = () => {
     setIsNotice((prev) => !prev);
   };
 
-  const handleImageDrawerClose = () => {
-    setIsImageDrawerOpen(() => false);
-  };
-
-  const handleImageToggleButtonClick = () => {
+  const handleImageDrawerToggle = () => {
     setIsImageDrawerOpen((prevIsImageDrawerOpen) => !prevIsImageDrawerOpen);
   };
 
@@ -160,8 +156,7 @@ export const useTeamFeedPage = () => {
     handlers: {
       handleIsNoticeChange,
       handleChatContentChange,
-      handleImageDrawerClose,
-      handleImageToggleButtonClick,
+      handleImageDrawerToggle,
       handleEnterKeydown,
       handleScrollBottomButtonClick,
       handleSubmit,

--- a/frontend/src/hooks/team/useTeamFeedPage.ts
+++ b/frontend/src/hooks/team/useTeamFeedPage.ts
@@ -30,7 +30,7 @@ export const useTeamFeedPage = () => {
   };
 
   const handleImageDrawerToggle = () => {
-    setIsImageDrawerOpen((prevIsImageDrawerOpen) => !prevIsImageDrawerOpen);
+    setIsImageDrawerOpen((prev) => !prev);
   };
 
   const handleChatContentChange: ChangeEventHandler<HTMLTextAreaElement> = (

--- a/frontend/src/hooks/thread/useImageUpload.tsx
+++ b/frontend/src/hooks/thread/useImageUpload.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { ChangeEvent } from 'react';
+import type { ChangeEventHandler } from 'react';
 import type { FileWithUuid, PreviewImage } from '~/types/feed';
 import {
   MAX_IMAGE_CAPACITY,
@@ -14,7 +14,7 @@ import { generateUuid } from '~/utils/generateUuid';
  *
  * @returns {PreviewImage[]} previewImages - 미리보기 이미지의 `src`와 식별을 위한 `uuid`를 제공합니다.
  * @returns {File[]} imageFiles - 실제 업로드에 사용될 이미지 정보들을 `File` 객체로 된 배열로 제공합니다.
- * @returns {(e: ChangeEvent<HTMLInputElement>) => void} - updateImages 이미지 업로드 시 호출하는 함수입니다.
+ * @returns {ChangeEventHandler<HTMLInputElement>} - updateImages 이미지 업로드 시 호출하는 함수입니다.
  * @returns {deleteImageByUuid} deleteImageByUuid - `uuid`를 이용해 특정 이미지를 삭제할 시 호출하는 함수입니다.
  * @returns {deleteAllImages} deleteAllImages - 모든 이미지를 삭제할 때 호출하는 함수입니다.
  */
@@ -23,7 +23,7 @@ const useImageUpload = () => {
   const [previewImages, setPreviewImages] = useState<PreviewImage[]>([]);
   const { showToast } = useToast();
 
-  const updateImages = (e: ChangeEvent<HTMLInputElement>) => {
+  const updateImages: ChangeEventHandler<HTMLInputElement> = (e) => {
     if (!(e.target instanceof HTMLInputElement)) {
       return;
     }

--- a/frontend/src/hooks/thread/useImageUpload.tsx
+++ b/frontend/src/hooks/thread/useImageUpload.tsx
@@ -10,7 +10,7 @@ import { useToast } from '../useToast';
 import { generateUuid } from '~/utils/generateUuid';
 
 /**
- * `useImageUploader` 는 이미지를 로컬에 업로드하여 관리하기 위한 커스텀 훅입니다.
+ * `useImageUpload` 는 이미지를 로컬에 업로드하여 관리하기 위한 커스텀 훅입니다.
  *
  * @returns {PreviewImage[]} previewImages - 미리보기 이미지의 `src`와 식별을 위한 `uuid`를 제공합니다.
  * @returns {File[]} imageFiles - 실제 업로드에 사용될 이미지 정보들을 `File` 객체로 된 배열로 제공합니다.
@@ -18,7 +18,7 @@ import { generateUuid } from '~/utils/generateUuid';
  * @returns {deleteImageByUuid} deleteImageByUuid - `uuid`를 이용해 특정 이미지를 삭제할 시 호출하는 함수입니다.
  * @returns {deleteAllImages} deleteAllImages - 모든 이미지를 삭제할 때 호출하는 함수입니다.
  */
-const useImageUploader = () => {
+const useImageUpload = () => {
   const [filesWithUuid, setFilesWithUuid] = useState<FileWithUuid[]>([]);
   const [previewImages, setPreviewImages] = useState<PreviewImage[]>([]);
   const { showToast } = useToast();
@@ -131,4 +131,4 @@ const useImageUploader = () => {
   };
 };
 
-export default useImageUploader;
+export default useImageUpload;

--- a/frontend/src/hooks/thread/useImageUploader.tsx
+++ b/frontend/src/hooks/thread/useImageUploader.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react';
 import type { ChangeEvent } from 'react';
 import type { FileWithUuid, PreviewImage } from '~/types/feed';
-import { MAX_UPLOAD_IMAGE_COUNT, VALID_IMAGE_TYPES } from '~/constants/feed';
+import {
+  MAX_IMAGE_CAPACITY,
+  MAX_UPLOAD_IMAGE_COUNT,
+  VALID_IMAGE_TYPES,
+} from '~/constants/feed';
 import { useToast } from '../useToast';
 
 /**
@@ -44,6 +48,13 @@ const useImageUploader = () => {
     if ([...newFiles].some(({ type }) => !VALID_IMAGE_TYPES.includes(type))) {
       e.target.value = '';
       showToast('error', '이미지 파일만 업로드할 수 있습니다.');
+
+      return;
+    }
+
+    if ([...newFiles].some(({ size }) => size > MAX_IMAGE_CAPACITY)) {
+      e.target.value = '';
+      showToast('error', '각 이미지의 용량은 5MB을 넘을 수 없습니다.');
 
       return;
     }

--- a/frontend/src/hooks/thread/useImageUploader.tsx
+++ b/frontend/src/hooks/thread/useImageUploader.tsx
@@ -91,23 +91,6 @@ const useImageUploader = () => {
     });
   };
 
-  const updatePreviewImages = async () => {
-    const uuids = filesWithUuid.map(({ uuid }) => uuid);
-    const readResults = await Promise.allSettled(
-      filesWithUuid.map(({ file }) => readImage(file)),
-    );
-
-    const imageUrls = readResults.map((result, index) => {
-      if (result.status === 'fulfilled') {
-        return { uuid: uuids[index], url: result.value };
-      } else {
-        return { uuid: uuids[index], url: '' };
-      }
-    });
-
-    setPreviewImages(() => imageUrls);
-  };
-
   const deleteImageByUuid = (targetUuid: string) => {
     setFilesWithUuid((prevFilesWithUuid) =>
       prevFilesWithUuid.filter(({ uuid }) => uuid !== targetUuid),
@@ -119,8 +102,24 @@ const useImageUploader = () => {
   };
 
   useEffect(() => {
+    const updatePreviewImages = async () => {
+      const uuids = filesWithUuid.map(({ uuid }) => uuid);
+      const readResults = await Promise.allSettled(
+        filesWithUuid.map(({ file }) => readImage(file)),
+      );
+
+      const imageUrls = readResults.map((result, index) => {
+        if (result.status === 'fulfilled') {
+          return { uuid: uuids[index], url: result.value };
+        } else {
+          return { uuid: uuids[index], url: '' };
+        }
+      });
+
+      setPreviewImages(() => imageUrls);
+    };
+
     updatePreviewImages();
-    /* eslint-disable-next-line */
   }, [filesWithUuid]);
 
   return {

--- a/frontend/src/hooks/thread/useImageUploader.tsx
+++ b/frontend/src/hooks/thread/useImageUploader.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from 'react';
+import type { ChangeEvent } from 'react';
+import type { FileWithUuid, PreviewImage } from '~/types/feed';
+import { MAX_UPLOAD_IMAGE_COUNT } from '~/constants/feed';
+import { useToast } from '../useToast';
+
+/**
+ * `useImageUploader` 는 이미지를 로컬에 업로드하여 관리하기 위한 커스텀 훅입니다.
+ *
+ * @returns {PreviewImage[]} previewImages - 미리보기 이미지의 `src`와 식별을 위한 `uuid`를 제공합니다.
+ * @returns {File[]} imageFiles - 실제 업로드에 사용될 이미지 정보들을 `File` 객체로 된 배열로 제공합니다.
+ * @returns {(e: ChangeEvent<HTMLInputElement>) => void} - updateImages 이미지 업로드 시 호출하는 함수입니다.
+ * @returns {deleteImageByUuid} deleteImageByUuid - `uuid`를 이용해 특정 이미지를 삭제할 시 호출하는 함수입니다.
+ * @returns {deleteAllImages} deleteAllImages - 모든 이미지를 삭제할 때 호출하는 함수입니다.
+ */
+const useImageUploader = () => {
+  const [filesWithUuid, setFilesWithUuid] = useState<FileWithUuid[]>([]);
+  const [previewImages, setPreviewImages] = useState<PreviewImage[]>([]);
+  const { showToast } = useToast();
+
+  const updateImages = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!(e.target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    const newFiles = e.target.files;
+
+    if (!newFiles) {
+      e.target.value = '';
+
+      return;
+    }
+
+    if (filesWithUuid.length + newFiles.length > MAX_UPLOAD_IMAGE_COUNT) {
+      e.target.value = '';
+      showToast(
+        'error',
+        `이미지는 최대 ${MAX_UPLOAD_IMAGE_COUNT}장까지 업로드 가능합니다.`,
+      );
+
+      return;
+    }
+
+    const newFilesWithId = [...newFiles].map((file) => ({
+      uuid: crypto.randomUUID(),
+      file,
+    }));
+
+    setFilesWithUuid((prevFilesWithUuid) => [
+      ...prevFilesWithUuid,
+      ...newFilesWithId,
+    ]);
+
+    e.target.value = '';
+  };
+
+  const readImage = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const fileReader = new FileReader();
+
+      fileReader.onload = () => {
+        const resultUrl = fileReader.result;
+
+        if (typeof resultUrl === 'string') {
+          resolve(resultUrl);
+        }
+
+        reject();
+      };
+
+      fileReader.readAsDataURL(file);
+    });
+  };
+
+  const updatePreviewImages = async () => {
+    const uuids = filesWithUuid.map(({ uuid }) => uuid);
+    const readResults = await Promise.allSettled(
+      filesWithUuid.map(({ file }) => readImage(file)),
+    );
+
+    const imageUrls = readResults.map((result, index) => {
+      if (result.status === 'fulfilled') {
+        return { uuid: uuids[index], url: result.value };
+      } else {
+        return { uuid: uuids[index], url: '' };
+      }
+    });
+
+    setPreviewImages(() => imageUrls);
+  };
+
+  const deleteImageByUuid = (targetUuid: string) => {
+    setFilesWithUuid((prevFilesWithUuid) =>
+      prevFilesWithUuid.filter(({ uuid }) => uuid !== targetUuid),
+    );
+  };
+
+  const deleteAllImages = () => {
+    setFilesWithUuid(() => []);
+  };
+
+  useEffect(() => {
+    updatePreviewImages();
+    /* eslint-disable-next-line */
+  }, [filesWithUuid]);
+
+  return {
+    previewImages,
+    imageFiles: filesWithUuid.map(({ file }) => file),
+    updateImages,
+    deleteImageByUuid,
+    deleteAllImages,
+  };
+};
+
+export default useImageUploader;

--- a/frontend/src/hooks/thread/useImageUploader.tsx
+++ b/frontend/src/hooks/thread/useImageUploader.tsx
@@ -7,6 +7,7 @@ import {
   VALID_IMAGE_TYPES,
 } from '~/constants/feed';
 import { useToast } from '../useToast';
+import { generateUuid } from '~/utils/generateUuid';
 
 /**
  * `useImageUploader` 는 이미지를 로컬에 업로드하여 관리하기 위한 커스텀 훅입니다.
@@ -60,7 +61,7 @@ const useImageUploader = () => {
     }
 
     const newFilesWithId = [...newFiles].map((file) => ({
-      uuid: crypto.randomUUID(),
+      uuid: generateUuid(),
       file,
     }));
 

--- a/frontend/src/hooks/thread/useImageUploader.tsx
+++ b/frontend/src/hooks/thread/useImageUploader.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { ChangeEvent } from 'react';
 import type { FileWithUuid, PreviewImage } from '~/types/feed';
-import { MAX_UPLOAD_IMAGE_COUNT } from '~/constants/feed';
+import { MAX_UPLOAD_IMAGE_COUNT, VALID_IMAGE_TYPES } from '~/constants/feed';
 import { useToast } from '../useToast';
 
 /**
@@ -37,6 +37,13 @@ const useImageUploader = () => {
         'error',
         `이미지는 최대 ${MAX_UPLOAD_IMAGE_COUNT}장까지 업로드 가능합니다.`,
       );
+
+      return;
+    }
+
+    if ([...newFiles].some(({ type }) => !VALID_IMAGE_TYPES.includes(type))) {
+      e.target.value = '';
+      showToast('error', '이미지 파일만 업로드할 수 있습니다.');
 
       return;
     }

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.styled.ts
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.styled.ts
@@ -5,12 +5,15 @@ export const Container = styled.div<{
   threadSize: ThreadSize;
 }>`
   overflow: hidden;
+  position: relative;
 
   width: 100%;
   height: 100%;
   padding: 20px 30px 30px;
 
   background-color: ${({ theme }) => theme.color.GRAY100};
+
+  z-index: 0;
 `;
 
 export const Inner = styled.div`

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.styled.ts
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.styled.ts
@@ -106,6 +106,10 @@ export const MenuButtonWrapper = styled.div`
   }
 `;
 
+export const ThreadInputForm = styled.form`
+  z-index: 1;
+`;
+
 export const scrollBottomButton = css`
   background-color: ${({ theme }) => theme.color.WHITE};
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -6,7 +6,7 @@ import Checkbox from '~/components/common/Checkbox/Checkbox';
 import { useTeamFeedPage } from '~/hooks/team/useTeamFeedPage';
 import theme from '~/styles/theme';
 import { AirplaneIcon, ArrowExpandMoreIcon, ImageIcon } from '~/assets/svg';
-import useImageUploader from '~/hooks/thread/useImageUploader';
+import useImageUploader from '~/hooks/thread/useImageUpload';
 import ImageUploadDrawer from '~/components/feed/ImageUploadDrawer/ImageUploadDrawer';
 import ThumbnailList from '~/components/feed/ThumbnailList/ThumbnailList';
 import type { ThreadSize } from '~/types/size';

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -30,8 +30,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
     handlers: {
       handleIsNoticeChange,
       handleChatContentChange,
-      handleImageDrawerClose,
-      handleImageToggleButtonClick,
+      handleImageDrawerToggle,
       handleEnterKeydown,
       handleScrollBottomButtonClick,
       handleSubmit,
@@ -68,7 +67,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
         </S.ThreadContainer>
         <ImageUploadDrawer
           isOpen={isImageDrawerOpen}
-          onClose={handleImageDrawerClose}
+          onClose={handleImageDrawerToggle}
         >
           <ThumbnailList
             mode="delete"
@@ -91,7 +90,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
               type="button"
               variant="plain"
               aria-label="이미지 업로드하기"
-              onClick={handleImageToggleButtonClick}
+              onClick={handleImageDrawerToggle}
             >
               <ImageIcon />
             </Button>

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -77,7 +77,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
             onDelete={deleteImageByUuid}
           />
         </ImageUploadDrawer>
-        <form onSubmit={handleSubmit} style={{ zIndex: 1 }}>
+        <S.ThreadInputForm onSubmit={handleSubmit}>
           <S.Textarea
             value={chatContent}
             onChange={handleChatContentChange}
@@ -110,7 +110,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
               </Button>
             </div>
           </S.ButtonContainer>
-        </form>
+        </S.ThreadInputForm>
       </S.Inner>
     </S.Container>
   );

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -6,6 +6,9 @@ import Checkbox from '~/components/common/Checkbox/Checkbox';
 import { useTeamFeedPage } from '~/hooks/team/useTeamFeedPage';
 import theme from '~/styles/theme';
 import { AirplaneIcon, ArrowExpandMoreIcon, ImageIcon } from '~/assets/svg';
+import useImageUploader from '~/hooks/thread/useImageUploader';
+import ImageUploadDrawer from '~/components/feed/ImageUploadDrawer/ImageUploadDrawer';
+import ThumbnailList from '~/components/feed/ThumbnailList/ThumbnailList';
 import type { ThreadSize } from '~/types/size';
 import * as S from './TeamFeedPage.styled';
 
@@ -15,16 +18,20 @@ interface TeamFeedPageProps {
 
 const TeamFeedPage = (props: TeamFeedPageProps) => {
   const { threadSize = 'md' } = props;
+  const { previewImages, updateImages, deleteImageByUuid } = useImageUploader();
   const {
     ref,
     noticeThread,
     isNotice,
+    isImageDrawerOpen,
     isShowScrollBottomButton,
     chatContent,
 
     handlers: {
       handleIsNoticeChange,
       handleChatContentChange,
+      handleImageDrawerClose,
+      handleImageToggleButtonClick,
       handleEnterKeydown,
       handleScrollBottomButtonClick,
       handleSubmit,
@@ -59,7 +66,18 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
             )}
           </S.MenuButtonWrapper>
         </S.ThreadContainer>
-        <form onSubmit={handleSubmit}>
+        <ImageUploadDrawer
+          isOpen={isImageDrawerOpen}
+          onClose={handleImageDrawerClose}
+        >
+          <ThumbnailList
+            mode="delete"
+            images={previewImages}
+            onChange={updateImages}
+            onDelete={deleteImageByUuid}
+          />
+        </ImageUploadDrawer>
+        <form onSubmit={handleSubmit} style={{ zIndex: 1 }}>
           <S.Textarea
             value={chatContent}
             onChange={handleChatContentChange}
@@ -73,9 +91,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
               type="button"
               variant="plain"
               aria-label="이미지 업로드하기"
-              onClick={() => {
-                alert('이미지 업로드 기능을 준비중이에요! :)');
-              }}
+              onClick={handleImageToggleButtonClick}
             >
               <ImageIcon />
             </Button>

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -1,6 +1,5 @@
 import type { THREAD_TYPE } from '~/constants/feed';
 import type { YYYYMMDDHHMM } from '~/types/schedule';
-import type { UUID } from 'crypto';
 
 export interface Thread {
   id: number;
@@ -35,11 +34,11 @@ export interface ThreadImage {
 }
 
 export interface PreviewImage {
-  uuid: UUID;
+  uuid: string;
   url: string;
 }
 
 export interface FileWithUuid {
-  uuid: UUID;
+  uuid: string;
   file: File;
 }

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -1,5 +1,6 @@
 import type { THREAD_TYPE } from '~/constants/feed';
 import type { YYYYMMDDHHMM } from '~/types/schedule';
+import type { UUID } from 'crypto';
 
 export interface Thread {
   id: number;
@@ -31,4 +32,14 @@ export interface ThreadImage {
   isExpired: boolean;
   name: string;
   url: string;
+}
+
+export interface PreviewImage {
+  uuid: UUID;
+  url: string;
+}
+
+export interface FileWithUuid {
+  uuid: UUID;
+  file: File;
 }


### PR DESCRIPTION
# [FE] 이미지를 로컬에 업로드할 수 있는 기능 구현
## 이슈번호
> close #634, close #636, close #638

## PR 내용
본 PR에서는 이미지를 로컬에 업로드할 수 있는 기본적인 기능들을 구현하였다. 로컬에 업로드만 가능할 뿐, 실제로 서버로 이미지에 대한 정보를 보내는 기능은 포함하지 않음에 유의한다.
수행한 작업들은 아래와 같다.

### 1. 컴포넌트의 개선
- `AddImageButton` : 실제로 클릭을 했을 때 파일 선택 프롬프트가 뜨고, 파일 변경 시 이벤트가 실행되도록 구현하였다.
- `DeletableThumbnail` : 받는 `props` 가 변경되었다.
- `ImageUploadDrawer` : 피드 페이지와 결합하면서 필요없는 속성들을 지우고, `bottom` 속성 등을 추가해 메인 컴포넌트와 끼워 맞추었다 (피드 페이지의 채팅방이 `padding` 으로 감싸져 있어서 `absolute` / `width: 100%`를 썼음에도 정확히 맞지 않아서 위치를 맞추는 작업이 추가로 필요했음)

### 2. 피드 채팅방과 서랍장 컴포넌트를 결합
- `z-index` 를 사용해서 서랍장이 활성화되면 채팅창 위로 스르륵~ 나오게 하도록 구현했음

### 3. 이미지를 로컬에 등록할 수 있도록 구현 (커스텀 훅)
- 프롬프트가 열렸을 시 이미지 파일만 고르도록 자동으로 조정
- 여러 장의 이미지를 한꺼번에 올리는 것이 가능함
- 이미지를 여러 번 등록해도 덮어씌워지지 않도록 개선 (`File[]` 형태로 관리)
- 이미지가 추가되면 (`File[]` 의 내용물이 변동되면) 미리보기 이미지를 커스텀 훅에서 반환하여 보여줄 수 있도록 구현
- 이미지에 대응되는 `uuid` 를 이용해 원하는 이미지 하나를 삭제할 수 있음
- 모든 이미지를 삭제할 수 있음
- 새롭게 이미지를 등록했을 때 기존 이미지와 새로운 이미지의 수의 합이 `4` 를 넘길 경우 오류 토스트를 띄우면서 업로드를 막을 수 있음
- 이미지 형식의 파일이 아닐 경우 오류 토스트를 띄우면서 업로드를 막음
- 각 이미지의 용량이 `5MB` 를 하나라도 넘길 경우 오류 토스트를 띄우면서 업로드를 막음

본 PR의 핵심이라 할 수 있는 커스텀 훅의 각 리턴값에 대한 설명은 주석을 적어두었으니 참고하면 좋을듯!
```tsx
/**
 * `useImageUploader` 는 이미지를 로컬에 업로드하여 관리하기 위한 커스텀 훅입니다.
 *
 * @returns {PreviewImage[]} previewImages - 미리보기 이미지의 `src`와 식별을 위한 `uuid`를 제공합니다.
 * @returns {File[]} imageFiles - 실제 업로드에 사용될 이미지 정보들을 `File` 객체로 된 배열로 제공합니다.
 * @returns {(e: ChangeEvent<HTMLInputElement>) => void} - updateImages 이미지 업로드 시 호출하는 함수입니다.
 * @returns {deleteImageByUuid} deleteImageByUuid - `uuid`를 이용해 특정 이미지를 삭제할 시 호출하는 함수입니다.
 * @returns {deleteAllImages} deleteAllImages - 모든 이미지를 삭제할 때 호출하는 함수입니다.
 */
```

## 참고자료
#### 이 페이지에 있는 예제를 참고하면서 구현하였다.
- [MDN input type file](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file)

#### 스크린샷
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/d5f5a9cd-adf3-4797-9930-f529376317fe)

![녹화_2023_09_22_05_06_54_476](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/9b35861f-71d6-462c-b333-d5df87b79a87)

## 의논할 거리
#### 이미지 서랍장 컴포넌트를 피드 페이지에 연결시키려고 `z-index` 사용했는데 어떻게 생각해?
1. `z-index` 사용 전에는 이미지 서랍장 컴포넌트가 채팅 입력창 위로 올라오는 상태였음
2. `z-index` 를 채팅 입력창에 `z-index: 1` 로 적용했더니 의도했던 대로 채팅 입력창이 서랍장 컴포넌트 위로 올라왔음, 그러나 옆에 있는 링크 모달 위로 채팅 입력창이 올라옴
3. 피드 페이지의 최상위 컴포넌트에 `z-index: 0` 을 적용해 채팅 입력창이 모달을 가리지 않되 이미지 서랍장 컴포넌트는 가리도록 구현했음 (`z-index` 를 비교할 때는 부모 컴포넌트를 우선시해서 비교하는 성질이 있어 이를 이용)

너무 아니다 싶으면 애니메이션을 희생시키되 `z-index` 를 사용하지 않는 방향으로 갈 수도 있어 보이긴 해

#### "공지로 등록" 글씨로 인해 채팅창의 `height` 가 고정이 아닌 것 같은데, 이건 어떻게 해결할까?
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/d683baf1-860c-466e-8354-c5befa5a1a71)


채팅창의 `height` 가 고정일 것으로 생각하고 구현해서, 고정이 아닌 경우가 생기면 이미지 서랍장이 제대로 나오지 않을 수도 있어
