### PR TITLE
[FE] 팀피드 스레드 크기 수정

### DIFF
--- a/frontend/src/components/feed/Thread/Thread.styled.ts
+++ b/frontend/src/components/feed/Thread/Thread.styled.ts
@@ -26,35 +26,21 @@ export const ContentContainer = styled.div<{ isMe: boolean; height: number }>`
 `;
 
 export const ContentWrapper = styled.div<{
-  threadSize: ThreadSize;
   isMe: boolean;
   isExpanded: boolean;
 }>`
   position: relative;
   overflow: hidden;
 
-  ${({ threadSize, isExpanded }) => {
-    if (threadSize === 'md') {
-      if (isExpanded)
-        return css`
-          padding: 28px 28px 80px;
-        `;
-
+  ${({ isExpanded }) => {
+    if (isExpanded)
       return css`
-        padding: 28px;
+        padding: 16px 28px 80px;
       `;
-    }
 
-    if (threadSize === 'sm') {
-      if (isExpanded)
-        return css`
-          padding: 16px 28px 80px;
-        `;
-
-      return css`
-        padding: 16px 28px;
-      `;
-    }
+    return css`
+      padding: 16px 28px;
+    `;
   }}
 
   ${({ isMe, theme }) => {
@@ -85,30 +71,19 @@ export const Author = styled.div`
   gap: 10px;
 `;
 
-export const ProfileImg = styled.img<{ threadSize: ThreadSize }>`
+export const ProfileImg = styled.img`
+  width: 30px;
+  height: 30px;
+
   border-radius: 50%;
-
-  ${({ threadSize }) => {
-    if (threadSize === 'md')
-      return css`
-        width: 40px;
-        height: 40px;
-      `;
-
-    if (threadSize === 'sm')
-      return css`
-        width: 30px;
-        height: 30px;
-      `;
-  }}
 
   object-fit: cover;
 `;
 
-export const threadInfoText = (threadSize: ThreadSize) => css`
+export const threadInfoText = css`
   white-space: pre-wrap;
 
-  font-size: ${threadSize === 'md' ? 16 : 14}px;
+  font-size: 14px;
   color: ${({ theme }) => theme.color.BLACK};
 `;
 
@@ -116,7 +91,7 @@ export const contentField = (threadSize: ThreadSize, isMe: boolean) => css`
   width: 100%;
   white-space: pre-wrap;
 
-  font-size: ${threadSize === 'md' ? 20 : 16}px;
+  font-size: ${threadSize === 'md' ? 18 : 16}px;
   color: ${({ theme }) => (isMe ? theme.color.WHITE : theme.color.BLACK)};
 
   word-break: break-all;

--- a/frontend/src/components/feed/Thread/Thread.tsx
+++ b/frontend/src/components/feed/Thread/Thread.tsx
@@ -43,12 +43,8 @@ const Thread = (props: ThreadProps) => {
       {!isMe && !isContinue && (
         <S.ThreadHeader>
           <S.Author>
-            <S.ProfileImg
-              threadSize={threadSize}
-              src={profileImageUrl}
-              alt={authorName}
-            />
-            <Text weight="semiBold" css={S.threadInfoText(threadSize)}>
+            <S.ProfileImg src={profileImageUrl} alt={authorName} />
+            <Text weight="semiBold" css={S.threadInfoText}>
               {authorName}
             </Text>
           </S.Author>
@@ -59,7 +55,6 @@ const Thread = (props: ThreadProps) => {
           <S.ContentWrapper
             ref={contentRef}
             isExpanded={isExpanded}
-            threadSize={threadSize}
             isMe={isMe}
           >
             <Text size="xl" css={S.contentField(threadSize, isMe)}>
@@ -71,7 +66,7 @@ const Thread = (props: ThreadProps) => {
           </S.ContentWrapper>
         </S.ContentContainer>
         <time>
-          <Text css={S.threadInfoText(threadSize)}>{createdTime}</Text>
+          <Text css={S.threadInfoText}>{createdTime}</Text>
         </time>
       </S.BodyContainer>
     </S.Container>


### PR DESCRIPTION
# [FE] 팀피드 스레드 크기 수정
## 이슈번호
> close #695 

## PR 내용
팀피드에서 스레드 크기가 너무 커서 조금 줄였습니다
<img width="1280" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/a80250b2-5964-47f5-b547-a561499bec4c">
글씨크기는 여전히 모아보기보단 조금 커요 (2px)
## 참고자료

## 의논할 거리
