### PR TITLE
[BE] 회원탈퇴 오류 수정 (회원 탈퇴 이벤트 구현)

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -2,10 +2,12 @@ package team.teamby.teambyteam.member.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.domain.IdOnly;
@@ -33,6 +35,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberTeamPlaceRepository memberTeamPlaceRepository;
     private final TeamPlaceInviteCodeRepository teamPlaceInviteCodeRepository;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional(readOnly = true)
     public TeamPlacesResponse getParticipatedTeamPlaces(final MemberEmailDto memberEmailDto) {
@@ -102,6 +105,8 @@ public class MemberService {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
         memberRepository.delete(member);
+
+        publisher.publishEvent(new MemberLeaveEvent(member));
 
         log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", memberEmailDto.email());
     }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -104,10 +104,7 @@ public class MemberService {
     public void leaveMember(final MemberEmailDto memberEmailDto) {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
-        memberRepository.delete(member);
 
         publisher.publishEvent(new MemberLeaveEvent(member));
-
-        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", memberEmailDto.email());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -101,10 +101,14 @@ public class MemberService {
         member.changeName(memberUpdateRequest.name());
     }
 
+
     public void leaveMember(final MemberEmailDto memberEmailDto) {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
-
         publisher.publishEvent(new MemberLeaveEvent(member));
+
+        memberRepository.delete(member);
+        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail().getValue());
+
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -105,7 +105,7 @@ public class MemberService {
     public void leaveMember(final MemberEmailDto memberEmailDto) {
         final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
-        publisher.publishEvent(new MemberLeaveEvent(member));
+        publisher.publishEvent(new MemberLeaveEvent(member.getId()));
 
         memberRepository.delete(member);
         log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail().getValue());

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/event/MemberLeaveEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/event/MemberLeaveEvent.java
@@ -1,6 +1,4 @@
 package team.teamby.teambyteam.member.application.event;
 
-import team.teamby.teambyteam.member.domain.Member;
-
-public record MemberLeaveEvent(Member member) {
+public record MemberLeaveEvent(Long memberId) {
 }

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/event/MemberLeaveEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/event/MemberLeaveEvent.java
@@ -1,0 +1,6 @@
+package team.teamby.teambyteam.member.application.event;
+
+import team.teamby.teambyteam.member.domain.Member;
+
+public record MemberLeaveEvent(Member member) {
+}

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
@@ -1,0 +1,29 @@
+package team.teamby.teambyteam.token.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.token.domain.TokenRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenEventListener {
+
+    private final TokenRepository tokenRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteToken(final MemberLeaveEvent memberLeaveEvent) {
+        Member member = memberLeaveEvent.member();
+        tokenRepository.deleteByMember(member);
+
+        log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail());
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
@@ -23,7 +23,7 @@ public class TokenEventListener {
         tokenRepository.deleteByMember(member);
         memberRepository.delete(member);
 
-        log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail());
-        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail());
+        log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail().getValue());
+        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail().getValue());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
@@ -19,7 +19,7 @@ public class TokenEventListener {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void deleteToken(final MemberLeaveEvent memberLeaveEvent) {
         Member member = memberLeaveEvent.member();
-        tokenRepository.deleteByMember(member);
+        tokenRepository.deleteByMemberId(member.getId());
 
         log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail().getValue());
     }

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
@@ -2,13 +2,11 @@ package team.teamby.teambyteam.token.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.token.domain.TokenRepository;
 
 @Slf4j
@@ -16,14 +14,16 @@ import team.teamby.teambyteam.token.domain.TokenRepository;
 @RequiredArgsConstructor
 public class TokenEventListener {
 
+    private final MemberRepository memberRepository;
     private final TokenRepository tokenRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @EventListener
     public void deleteToken(final MemberLeaveEvent memberLeaveEvent) {
         Member member = memberLeaveEvent.member();
         tokenRepository.deleteByMember(member);
+        memberRepository.delete(member);
 
         log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail());
+        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
@@ -2,11 +2,11 @@ package team.teamby.teambyteam.token.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
 import team.teamby.teambyteam.member.domain.Member;
-import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.token.domain.TokenRepository;
 
 @Slf4j
@@ -14,16 +14,13 @@ import team.teamby.teambyteam.token.domain.TokenRepository;
 @RequiredArgsConstructor
 public class TokenEventListener {
 
-    private final MemberRepository memberRepository;
     private final TokenRepository tokenRepository;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void deleteToken(final MemberLeaveEvent memberLeaveEvent) {
         Member member = memberLeaveEvent.member();
         tokenRepository.deleteByMember(member);
-        memberRepository.delete(member);
 
         log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail().getValue());
-        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail().getValue());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/application/TokenEventListener.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
-import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.token.domain.TokenRepository;
 
 @Slf4j
@@ -18,9 +17,9 @@ public class TokenEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void deleteToken(final MemberLeaveEvent memberLeaveEvent) {
-        Member member = memberLeaveEvent.member();
-        tokenRepository.deleteByMemberId(member.getId());
+        Long memberId = memberLeaveEvent.memberId();
+        tokenRepository.deleteByMemberId(memberId);
 
-        log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail().getValue());
+        log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 ID : {}", memberId);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
@@ -10,4 +10,6 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
     Optional<Token> findByRefreshToken(final String refreshToken);
 
     Optional<Token> findByMember(final Member member);
+
+    void deleteByMember(final Member member);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
@@ -13,7 +13,7 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByMember(final Member member);
 
-    @Query("DELETE from Token t where t.member = :member")
+    @Query("DELETE from Token t where t.member.id = :memberId")
     @Modifying
-    void deleteByMember(final Member member);
+    void deleteByMemberId(final Long memberId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/domain/TokenRepository.java
@@ -1,6 +1,8 @@
 package team.teamby.teambyteam.token.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import team.teamby.teambyteam.member.domain.Member;
 
 import java.util.Optional;
@@ -11,5 +13,7 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByMember(final Member member);
 
+    @Query("DELETE from Token t where t.member = :member")
+    @Modifying
     void deleteByMember(final Member member);
 }

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -24,11 +24,17 @@ import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static team.teamby.teambyteam.common.fixtures.MemberFixtures.*;
-import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.*;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ENDEL;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_ACCOUNT;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.DELETE_LEAVE_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_MY_INFORMATION;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.GET_PARTICIPATED_TEAM_PLACES;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.PARTICIPATE_TEAM_PLACE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptanceFixture.UPDATE_MEMBER_INFORMATION;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
-
 
     @Nested
     @DisplayName("내 정보 조회시")
@@ -423,10 +429,12 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         void success() {
             // given
             final Member PHILIP = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
-            final String PHILIP_TOKEN = jwtTokenProvider.generateAccessToken(PHILIP.getEmail().getValue());
+            final String PHILIP_ACCESS_TOKEN = jwtTokenProvider.generateAccessToken(PHILIP.getEmail().getValue());
+            final String PHILIP_REFRESH_TOKEN = jwtTokenProvider.generateRefreshToken(PHILIP.getEmail().getValue());
+            testFixtureBuilder.buildToken(TokenFixtures.TOKEN_ENTITY(PHILIP, PHILIP_REFRESH_TOKEN));
 
             // when
-            final ExtractableResponse<Response> response = DELETE_ACCOUNT(PHILIP_TOKEN);
+            final ExtractableResponse<Response> response = DELETE_ACCOUNT(PHILIP_ACCESS_TOKEN);
 
             //then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -14,6 +14,7 @@ import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
 import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlaceResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
+import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.domain.Member;
@@ -33,9 +34,13 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static team.teamby.teambyteam.common.fixtures.MemberFixtures.*;
-import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP_NAME;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.STATICS_TEAM_PLACE;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceInviteCodeFixtures.TEAM_PLACE_INVITE_CODE;
 
 class MemberServiceTest extends ServiceTest {
@@ -385,6 +390,21 @@ class MemberServiceTest extends ServiceTest {
             // when & then
             assertDoesNotThrow(() -> memberService.leaveMember(new MemberEmailDto(REGISTERED_MEMBER.getEmail().getValue())));
         }
+
+        @Test
+        @DisplayName("회원 탈퇴 이벤트가 발행된다.")
+        void publishMemberLeaveEvent() {
+            // given
+            final Member REGISTERED_MEMBER = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+
+            // when
+            memberService.leaveMember(new MemberEmailDto(REGISTERED_MEMBER.getEmail().getValue()));
+
+            // when & then
+            assertThat(applicationEvents.stream(MemberLeaveEvent.class).count()).isEqualTo(1);
+        }
+
+
 
         @Test
         @DisplayName("회원 탈퇴를 하면서 팀플레이스를 탈퇴한다.")

--- a/backend/src/test/java/team/teamby/teambyteam/token/domain/TokenRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/token/domain/TokenRepositoryTest.java
@@ -33,4 +33,18 @@ class TokenRepositoryTest extends RepositoryTest {
         assertThat(findToken).usingRecursiveComparison()
                 .isEqualTo(savedToken);
     }
+
+    @Test
+    @DisplayName("토큰을 멤버로 삭제한다.")
+    void deleteByMember() {
+        // given
+        final Member philip = memberRepository.save(PHILIP());
+        final Token savedToken = tokenRepository.save(new Token(philip, CORRECT_REFRESH_TOKEN));
+
+        // when
+        tokenRepository.deleteByMember(philip);
+
+        // then
+        assertThat(tokenRepository.findByMember(philip)).isEmpty();
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/token/domain/TokenRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/token/domain/TokenRepositoryTest.java
@@ -35,14 +35,14 @@ class TokenRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("토큰을 멤버로 삭제한다.")
+    @DisplayName("토큰을 멤버 ID로 삭제한다.")
     void deleteByMember() {
         // given
         final Member philip = memberRepository.save(PHILIP());
         final Token savedToken = tokenRepository.save(new Token(philip, CORRECT_REFRESH_TOKEN));
 
         // when
-        tokenRepository.deleteByMember(philip);
+        tokenRepository.deleteByMemberId(philip.getId());
 
         // then
         assertThat(tokenRepository.findByMember(philip)).isEmpty();


### PR DESCRIPTION
# [BE] 회원탈퇴 오류 수정 (회원 탈퇴 이벤트 구현)
## 이슈번호
> closed #692 

## PR 내용

## 문제 상황
* Member <-> Token 1:1 관계
  * 엔티티에서 Token이 연관관계 주인으로 설정 `@JoinColumn(name = "member_id", nullable = false)`
  * 따라서, DB에서 TOKEN 테이블에서 member_id를 FK로 가짐
  * 이때, 기존 회원 탈퇴 비즈니스 로직에서는 단순히 MEMBER 테이블의 회원만을 delete함
  * DB단에서 TOKEN 테이블에 member_id가 FK로 있으므로 데이터 정합성을 위한 제약으로 오류 발생
-> 따라서, 토큰 테이블의 해당 멤버의 토큰을 먼저 삭제 후에 멤버를 삭제해야 했다.

---

## 해결 방법 

먼저 크게 2가지 방법이 있었다.

1. JPA의 cascade 옵션 사용
2. 회원 탈퇴 비즈니스 로직에 Member Delete 전에 해당 멤버의 Token 먼저 Delete

### 1. JPA의 cascade 옵션 사용
Token Entity의 Member 필드는 다음과 같이 설정되어 있다.
```java
public class Token {
   ...
  
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
   
   ...
}
```

이때, 비즈니스 로직을 구현하기 위해 cascade 옵션을 설정해도 의미가 없다.
왜냐하면, Token 클래스에서 Member에 cascade 옵션을 설정하면 전이 주체가 Token이 되어서
Token이 삭제될 때 Member가 삭제될 것이기 때문이다.
물론 회원탈퇴 로직에서 Token만을 delete 하면 로직이 정상적으로 수행될 것이다.
하지만, RefreshToken을 만료시키는 상황도 있기 때문에 비정상적인 토큰 사용으로 인해
해당 토큰을 만료(row 삭제)시킬 때 멤버까지 삭제되는 상황이 발생할 수 있다.

따라서, 해당 방법은 좋지 않다고 판단했다.

### 2. 회원 탈퇴 비즈니스 로직에 Member Delete 전에 해당 멤버의 Token 먼저 Delete
해당 방법은 구현하기만 하면 정상적으로 작동했다.
하지만, 로직을 구현하기 위해서는 MemberService에서 TokenRepository를 참조해야 하기 때문에
Member <-> Token 간의 패키지 의존성 순환참조가 발생했다.
(MemberService -> TokenRepository / Token 엔티티 -> Member 엔티티)

따라서, 해당 방법도 보완이 필요했다.

1번 방법같은 경우는 문제 상황이 발생할 수 있으므로, 2번 방법에서 Member <-> Token 패키지 간의
의존성을 해결하는 방법으로 **스프링 이벤트**를 적용하여 해결하기로 결정했다!

---
## 스프링 이벤트 적용

결론부터 말하면 이벤트 리스너 클래스는 다음과 같다.
```java
@Slf4j
@Component
@RequiredArgsConstructor
public class TokenEventListener {

    private final MemberRepository memberRepository;
    private final TokenRepository tokenRepository;

    @EventListener
    public void deleteToken(final MemberLeaveEvent memberLeaveEvent) {
        Member member = memberLeaveEvent.member();
        tokenRepository.deleteByMember(member);
        memberRepository.delete(member);

        log.info("토큰 삭제 By 사용자 회원 탈퇴 이벤트 Listen - 회원 이메일 : {}", member.getEmail());
        log.info("사용자 회원 탈퇴 - 회원 이메일 : {}", member.getEmail());
    }
}

```

### 해당 설정 적용 이유
단순 `@EventLisnter`를 적용하고, 
토큰 Delete와 멤버 Delete를 모두 이벤트 리슨 로직에 넣어서 순서 보장 & 하나의 트랜잭션으로 처리

* A. 이벤트 발행 로직 -> 회원 탈퇴 로직
* B. 이벤트 리슨 로직 -> 토큰 삭제 로직

B -> A의 순서로 쿼리가 나가야 하고
그런데, B와 A는 하나의 트랜잭션으로 묶여야 한다.
(커밋, 롤백이 같이 되어야 함)

여기서 멤버 삭제 쿼리, 토큰 삭제 쿼리를 각각 발행, 리슨 메소드에 따로 넣어서 처리하기가 어려웠다.. 
그래서 저렇게 함

## 참고자료

## 의논할 거리

멤버 Delete와 토큰 Delete를 모두 EventListener 로직에서 처리하는게 괜찮을까?

근데 나눴을 때 실행 순서 처리, 트랜잭션 처리가 어렵다..
