### PR TITLE
[FE] ctrl,alt + enter로 개행기능 추가

### DIFF
--- a/frontend/src/hooks/team/useTeamFeedPage.ts
+++ b/frontend/src/hooks/team/useTeamFeedPage.ts
@@ -35,14 +35,14 @@ export const useTeamFeedPage = () => {
   };
 
   const handleEnterKeydown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
-    if ((e.key === 'Enter' && e.ctrlKey) || (e.key === 'Enter' && e.altKey)) {
-      setChatContent((prev) => prev + '\n');
-
+    // NOTE: 한글 입력 시 마지막 문자가 포함된 이벤트가 두 번 발생하는 문제를 해결하기 위해 isComposing을 체크한다.
+    if (e.nativeEvent.isComposing) {
       return;
     }
 
-    // NOTE: 한글 입력 시 마지막 문자가 포함된 이벤트가 두 번 발생하는 문제를 해결하기 위해 isComposing을 체크한다.
-    if (e.nativeEvent.isComposing) {
+    if ((e.key === 'Enter' && e.ctrlKey) || (e.key === 'Enter' && e.altKey)) {
+      setChatContent((prev) => prev + '\n');
+
       return;
     }
 

--- a/frontend/src/hooks/team/useTeamFeedPage.ts
+++ b/frontend/src/hooks/team/useTeamFeedPage.ts
@@ -35,6 +35,12 @@ export const useTeamFeedPage = () => {
   };
 
   const handleEnterKeydown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+    if ((e.key === 'Enter' && e.ctrlKey) || (e.key === 'Enter' && e.altKey)) {
+      setChatContent((prev) => prev + '\n');
+
+      return;
+    }
+
     // NOTE: 한글 입력 시 마지막 문자가 포함된 이벤트가 두 번 발생하는 문제를 해결하기 위해 isComposing을 체크한다.
     if (e.nativeEvent.isComposing) {
       return;

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -64,7 +64,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
             value={chatContent}
             onChange={handleChatContentChange}
             onKeyDown={handleEnterKeydown}
-            placeholder="여기에 채팅을 입력하세요. &#13;&#10; &#13;&#10;(Shift/Ctrl/Option) + Enter로 새 행을 추가합니다."
+            placeholder="여기에 채팅을 입력하세요. &#13;&#10; &#13;&#10;Shift + Enter로 새 행을 추가합니다."
             maxLength={10000}
             autoFocus
           />

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -64,7 +64,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
             value={chatContent}
             onChange={handleChatContentChange}
             onKeyDown={handleEnterKeydown}
-            placeholder="여기에 채팅을 입력하세요."
+            placeholder="여기에 채팅을 입력하세요. &#13;&#10; &#13;&#10;(Shift/Ctrl/Option) + Enter로 새 행을 추가합니다."
             maxLength={10000}
             autoFocus
           />


### PR DESCRIPTION

## 이슈번호
> close #708 close #707 

## PR 내용
<img width="389" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/02404a08-1d42-4fd6-bc69-6d025a399d6f">

shift/ctrl/alt +enter로 개행이 가능합니다.
맥에서 option +enter로 개행이 되는지 확인해주셔야합니다.
