### PR TITLE
[FE] 공지 md 사이즈에서 글 잘리는 현상

### DIFF
--- a/frontend/src/components/feed/NoticeThread/NoticeThread.stories.tsx
+++ b/frontend/src/components/feed/NoticeThread/NoticeThread.stories.tsx
@@ -38,6 +38,15 @@ export const Default: Story = {
   },
 };
 
+export const MiddleContent: Story = {
+  args: {
+    authorName: '루루',
+    createdAt: '2022-03-04 12:34',
+    content:
+      '안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.안녕하세요! 잘 부탁드립니다.',
+  },
+};
+
 export const TooLongContent: Story = {
   args: {
     authorName: '요술토끼',

--- a/frontend/src/components/feed/NoticeThread/NoticeThread.styled.ts
+++ b/frontend/src/components/feed/NoticeThread/NoticeThread.styled.ts
@@ -146,7 +146,7 @@ export const contentField = (noticeSize: NoticeSize) => {
   let height = '';
 
   if (noticeSize === 'sm') height = '24px';
-  if (noticeSize === 'md') height = '72px';
+  if (noticeSize === 'md') height = '66px';
   if (noticeSize === 'lg') height = '100%';
 
   return css`


### PR DESCRIPTION
 ## 이슈번호
> close #709 

## PR 내용
<img width="500" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/c6f70a40-35f0-4efd-9415-35b16ce38473">
스레드 높이 조정으로 해결했습니다.