### PR TITLE
[FE]일정 제목이 길때 등록안되는 버그

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -43,7 +43,11 @@ export const http = {
       body: JSON.stringify(body),
     });
 
-    if (response.status === 401 || response.status === 404) {
+    if (
+      response.status === 401 ||
+      response.status === 404 ||
+      response.status === 500
+    ) {
       throw response;
     }
 
@@ -66,7 +70,7 @@ export const http = {
       body: JSON.stringify(body),
     });
 
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 500) {
       throw response;
     }
 

--- a/frontend/src/components/team_calendar/ScheduleAddModal/ScheduleAddModal.tsx
+++ b/frontend/src/components/team_calendar/ScheduleAddModal/ScheduleAddModal.tsx
@@ -64,6 +64,7 @@ const ScheduleAddModal = (props: ScheduleAddModalProps) => {
               placeholder="일정 제목을 입력해주세요."
               css={S.title}
               name="title"
+              maxLength={250}
               value={schedule['title']}
               ref={titleInputRef}
               required

--- a/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.styled.ts
+++ b/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.styled.ts
@@ -98,7 +98,7 @@ export const modalLocation = (
   calendarWidth: number,
   calendarLeft: number,
   calendarSize: CalendarSize,
-) =>  {
+) => {
   if (calendarSize === 'md')
     return css`
       position: absolute;
@@ -119,3 +119,11 @@ export const modalLocation = (
       left: 12%;
     `;
 };
+
+export const scheduleTitleText = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  width: 100%;
+`;

--- a/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.tsx
+++ b/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.tsx
@@ -100,7 +100,9 @@ const ScheduleModal = (props: ScheduleModalProps) => {
             </Button>
           </S.MenuContainer>
         </S.Header>
-        <Text as="h4">{title}</Text>
+        <Text as="h4" css={S.scheduleTitleText}>
+          {title}
+        </Text>
         <S.PeriodWrapper>
           <time>
             <Text size="lg">{formatDateTime(startDateTime)}</Text>

--- a/frontend/src/hooks/schedule/useScheduleAddModal.ts
+++ b/frontend/src/hooks/schedule/useScheduleAddModal.ts
@@ -122,6 +122,11 @@ const useScheduleAddModal = (clickedDate: Date) => {
           showToast('success', '일정이 등록되었습니다.');
           closeModal();
         },
+        onError: (error) => {
+          const response = error as Response;
+          if (response.status === 500)
+            showToast('error', '일정 제목이 최대 글자(200자)를 초과했습니다.');
+        },
       },
     );
   };

--- a/frontend/src/hooks/schedule/useScheduleAddModal.ts
+++ b/frontend/src/hooks/schedule/useScheduleAddModal.ts
@@ -125,7 +125,7 @@ const useScheduleAddModal = (clickedDate: Date) => {
         onError: (error) => {
           const response = error as Response;
           if (response.status === 500)
-            showToast('error', '일정 제목이 최대 글자(200자)를 초과했습니다.');
+            showToast('error', '일정 제목이 최대 글자(250자)를 초과했습니다.');
         },
       },
     );

--- a/frontend/src/hooks/schedule/useScheduleEditModal.ts
+++ b/frontend/src/hooks/schedule/useScheduleEditModal.ts
@@ -124,6 +124,11 @@ const useScheduleEditModal = (
           showToast('success', '일정이 수정되었습니다.');
           closeModal();
         },
+        onError: (error) => {
+          const response = error as Response;
+          if (response.status === 500)
+            showToast('error', '일정 제목이 최대 글자(250자)를 초과했습니다.');
+        },
       },
     );
   };

--- a/frontend/src/mocks/fixtures/schedules.ts
+++ b/frontend/src/mocks/fixtures/schedules.ts
@@ -67,6 +67,12 @@ export const schedules: Schedule[] = [
     startDateTime: '2023-07-31 05:00',
     endDateTime: '2023-08-02 05:00',
   },
+  {
+    id: 11,
+    title: 'longlonglonglonglonglonglonglonglonglonglonglonglonglongSchedule',
+    startDateTime: '2023-09-30 05:00',
+    endDateTime: '2023-10-02 05:00',
+  },
 ];
 
 export const mySchedules: ScheduleWithTeamPlaceId[] = [

--- a/frontend/src/mocks/handlers/calendar.ts
+++ b/frontend/src/mocks/handlers/calendar.ts
@@ -75,6 +75,7 @@ export const calendarHandlers = [
       );
 
       if (index === -1) return res(ctx.status(403));
+      if (title.length > 250) return res(ctx.status(500));
 
       schedules.push(newSchedule);
       mySchedules.push({ ...newSchedule, teamPlaceId: 1 });
@@ -104,6 +105,7 @@ export const calendarHandlers = [
       );
 
       if (index === -1) return res(ctx.status(404));
+      if (title.length > 250) return res(ctx.status(500));
 
       schedules[index] = {
         id: scheduleId,


### PR DESCRIPTION
## 이슈번호
> close #352 close #354 
## PR 내용
캡쳐할 때는 toast 문구가 200자 제한인데 실제로 DB제한이 255자라고 해서 250자 제한으로 문구 바꿨습니ㅏㄷ.

전
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/5721c1e8-6720-4ae4-9480-475cb8d719ed)

후
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/d88c737c-2226-40dc-a0be-43f3eab18a99)

![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/6cfa7048-1d76-454f-9304-2ac5681a61a5)


## 참고자료

## 의논할 거리
