### PR TITLE
[BE] FeedThreadImage PK 전략 IDENTITY (AUTO_INCREMENT)로 수정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/image/FeedThreadImage.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/image/FeedThreadImage.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -20,7 +21,7 @@ import team.teamby.teambyteam.feed.domain.image.vo.ImageUrl;
 public class FeedThreadImage {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 이슈번호
> 긴급이라 이슈 X

## PR 내용

FeedThreadImage PK 전략 IDENTITY (AUTO_INCREMENT)로 수정
기존에는 
```java
  @Id
  @GeneratedValue
  private Long id;
```
이렇게 @GeneratedValue의 전략을 지정하지 않아서 
스프링 애플리케이션 실행했을 때 다음과 같은 테이블이 추가로 생성되는 걸 확인함!
(지정하지 않으면 AUTO로 되는데, SEQUENCE 전략이 사용되는 거 같음)

```java
    create table feed_thread_image_seq (
        next_val bigint
    ) engine=InnoDB
```

그래서 IDENTITY로 전략 변경하여 AUTO_INCREMENT 사용

그래서 아래와 같은 에러가 떴음
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/95729738/9ebf3814-40d5-47dd-b317-80598db86511)


## 참고자료

## 의논할 거리
그런데, @GeneratedValue 전략을 지정하지 않아서 AUTO로 되면, DB Dialect에 따라서 기본 전략이 사용된다고 하는데
MySQL은 기본이 IDENTITY를 사용한다고 하는데 왜 SEQUENCE로 되는지 모르겠음

