### PR TITLE
[BE] S3업로드 후 배포 도메인 반환 오류 수정

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/S3Uploader.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/S3Uploader.java
@@ -63,6 +63,6 @@ public class S3Uploader implements FileCloudUploader {
                 .build();
 
         s3Client.putObject(putObjectRequest, requestBody);
-        return cloudFrontBaseDomain + "/" + uploadPath;
+        return cloudFrontBaseDomain + directoryPath;
     }
 }


### PR DESCRIPTION
## PR 내용

S3업로드 후 cloud-front 배포 url반환 오류 수정
-> url 에 s3 root directory가 추가됨. -> 해당 부분 제거

## 참고자료

## 의논할 거리
