### PR TITLE
[BE] S3파일 업로드 후  cloud-front 캐시 제거 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation platform('software.amazon.awssdk:bom:2.20.56')
     implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:cloudfront'
 
     implementation('org.mnode.ical4j:ical4j:4.0.0-beta9') {
         exclude group: 'org.codehaus.groovy', module: 'groovy'

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/CloudfrontCacheInvalidator.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/CloudfrontCacheInvalidator.java
@@ -1,0 +1,66 @@
+package team.teamby.teambyteam.filesystem.awss3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+import software.amazon.awssdk.services.cloudfront.model.CreateInvalidationRequest;
+import software.amazon.awssdk.services.cloudfront.model.CreateInvalidationResponse;
+import software.amazon.awssdk.services.cloudfront.model.Invalidation;
+import software.amazon.awssdk.services.cloudfront.model.InvalidationBatch;
+import software.amazon.awssdk.services.cloudfront.model.Paths;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CloudfrontCacheInvalidator {
+
+    private static final String COMPLETED = "Completed";
+    private static final String CREATE_INVALIDATION_RESULT_LOG_FORMAT = "CloudFront create invalidation - id : {} , status : {}";
+
+    private final CloudFrontClient cloudFrontClient;
+
+    @Value("${aws.cloud-front.asset-distribution-id}")
+    private String distributionId;
+
+    public void createInvalidation(final String... paths) {
+
+        final InvalidationBatch invalidationBatch = createInvalidationBatch(paths);
+        final CreateInvalidationRequest request = createInvalidationRequest(invalidationBatch);
+        final CreateInvalidationResponse response = cloudFrontClient.createInvalidation(request);
+
+        logResult(response);
+    }
+
+    private CreateInvalidationRequest createInvalidationRequest(InvalidationBatch invalidationBatch) {
+        return CreateInvalidationRequest.builder()
+                .distributionId(distributionId)
+                .invalidationBatch(invalidationBatch)
+                .build();
+    }
+
+    private InvalidationBatch createInvalidationBatch(String[] paths) {
+        final List<String> items = List.of(paths);
+        return InvalidationBatch.builder()
+                .paths(
+                        Paths.builder()
+                                .items(items)
+                                .quantity(items.size())
+                                .build()
+                )
+                .callerReference(UUID.randomUUID().toString())
+                .build();
+    }
+
+    private void logResult(CreateInvalidationResponse response) {
+        final Invalidation invalidation = response.invalidation();
+        final String status = invalidation.status();
+        if (status.equals(COMPLETED)) {
+            log.info(CREATE_INVALIDATION_RESULT_LOG_FORMAT, invalidation.id(), status);
+            return;
+        }
+        log.error(CREATE_INVALIDATION_RESULT_LOG_FORMAT, invalidation.id(), status);
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/CloudfrontCacheInvalidator.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/CloudfrontCacheInvalidator.java
@@ -34,14 +34,14 @@ public class CloudfrontCacheInvalidator {
         logResult(response);
     }
 
-    private CreateInvalidationRequest createInvalidationRequest(InvalidationBatch invalidationBatch) {
+    private CreateInvalidationRequest createInvalidationRequest(final InvalidationBatch invalidationBatch) {
         return CreateInvalidationRequest.builder()
                 .distributionId(distributionId)
                 .invalidationBatch(invalidationBatch)
                 .build();
     }
 
-    private InvalidationBatch createInvalidationBatch(String[] paths) {
+    private InvalidationBatch createInvalidationBatch(final String[] paths) {
         final List<String> items = List.of(paths);
         return InvalidationBatch.builder()
                 .paths(
@@ -54,7 +54,7 @@ public class CloudfrontCacheInvalidator {
                 .build();
     }
 
-    private void logResult(CreateInvalidationResponse response) {
+    private void logResult(final CreateInvalidationResponse response) {
         final Invalidation invalidation = response.invalidation();
         final String status = invalidation.status();
         if (status.equals(COMPLETED)) {

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/CloudfrontCacheInvalidator.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/CloudfrontCacheInvalidator.java
@@ -57,7 +57,7 @@ public class CloudfrontCacheInvalidator {
     private void logResult(final CreateInvalidationResponse response) {
         final Invalidation invalidation = response.invalidation();
         final String status = invalidation.status();
-        if (status.equals(COMPLETED)) {
+        if (COMPLETED.equals(status)) {
             log.info(CREATE_INVALIDATION_RESULT_LOG_FORMAT, invalidation.id(), status);
             return;
         }

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/S3Uploader.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/S3Uploader.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.MultipartUpload;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import team.teamby.teambyteam.filesystem.FileCloudUploader;
 
@@ -28,6 +27,7 @@ public class S3Uploader implements FileCloudUploader {
     private String cloudFrontBaseDomain;
 
     private final S3Client s3Client;
+    private final CloudfrontCacheInvalidator cloudfrontCacheInvalidator;
 
     @Override
     public String upload(final MultipartFile multipartFile, final String directoryPath) {
@@ -63,6 +63,9 @@ public class S3Uploader implements FileCloudUploader {
                 .build();
 
         s3Client.putObject(putObjectRequest, requestBody);
+
+        cloudfrontCacheInvalidator.createInvalidation(directoryPath);
+
         return cloudFrontBaseDomain + directoryPath;
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/configuration/S3Configuration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/configuration/S3Configuration.java
@@ -25,7 +25,7 @@ public class S3Configuration {
 
     @Bean
     public FileCloudUploader fileCloudUploader() {
-        return new S3Uploader(s3Client());
+        return new S3Uploader(s3Client(), cloudfrontCacheInvalidator());
     }
 
     @Bean

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/configuration/S3Configuration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/configuration/S3Configuration.java
@@ -14,12 +14,15 @@ import team.teamby.teambyteam.filesystem.awss3.S3Uploader;
 public class S3Configuration {
 
     @Value("${aws.s3.region}")
-    private String region;
+    private String s3Region;
+
+    @Value("${aws.cloud-front.region}")
+    private String cloudFrontRegion;
 
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .region(Region.of(region))
+                .region(Region.of(s3Region))
                 .build();
     }
 
@@ -30,7 +33,10 @@ public class S3Configuration {
 
     @Bean
     public CloudfrontCacheInvalidator cloudfrontCacheInvalidator() {
-        return new CloudfrontCacheInvalidator(CloudFrontClient.builder()
-                .build());
+        return new CloudfrontCacheInvalidator(
+                CloudFrontClient.builder()
+                        .region(Region.of(cloudFrontRegion))
+                        .build()
+        );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/configuration/S3Configuration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/configuration/S3Configuration.java
@@ -4,8 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import team.teamby.teambyteam.filesystem.FileCloudUploader;
+import team.teamby.teambyteam.filesystem.awss3.CloudfrontCacheInvalidator;
 import team.teamby.teambyteam.filesystem.awss3.S3Uploader;
 
 @Configuration
@@ -24,5 +26,11 @@ public class S3Configuration {
     @Bean
     public FileCloudUploader fileCloudUploader() {
         return new S3Uploader(s3Client());
+    }
+
+    @Bean
+    public CloudfrontCacheInvalidator cloudfrontCacheInvalidator() {
+        return new CloudfrontCacheInvalidator(CloudFrontClient.builder()
+                .build());
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -44,6 +44,7 @@ aws:
     ical-directory: /i/c
   cloud-front:
     domain: abcd
+    asset-distribution-id: asdf
 
 
 oauth:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -43,6 +43,7 @@ aws:
     image-directory: /a/b
     ical-directory: /i/c
   cloud-front:
+    region: aws-global
     domain: abcd
     asset-distribution-id: asdf
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -43,6 +43,7 @@ aws:
     image-directory: /a/b
     ical-directory: /i/c
   cloud-front:
+    region: aws-global
     domain: abcd
     asset-distribution-id: asdf
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -44,6 +44,7 @@ aws:
     ical-directory: /i/c
   cloud-front:
     domain: abcd
+    asset-distribution-id: asdf
 
 oauth:
   google:


### PR DESCRIPTION
## 이슈번호
> closed #736

## PR 내용

- cloudfront 의존성 추가
- CloudFrontCacheInvalidator 빈 생성

캐시제거 위치 : S3FileUploader
이유
- 케시제거에 대한 내용은 aws + cloud front라는 특수한 상황이깅에 생긴 일이라고 생각
- 다른 서비스를 이용한다면 케시제거가 그때도 무조건 필요하다는 보장 없음
- 그래서 추상화하여 비지니스 서비스에서 사용하지 않고 s3업로더에서 사용할 수 있도록 구현

## 참고자료

## 의논할 거리
