### PR TITLE
[BE] Icalendar 테스트 수정

### DIFF
--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/acceptance/IcalendarAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/acceptance/IcalendarAcceptanceTest.java
@@ -50,8 +50,8 @@ public class IcalendarAcceptanceTest extends AcceptanceTest {
                 countDownLatch = new CountDownLatch(1);
             }
 
-            @After("@annotation(org.springframework.scheduling.annotation.Async)")
-            public void afterAsync() {
+            @After("execution(* team.teamby.teambyteam.icalendar.application.IcalendarEventListener.createIcalendar(*))")
+            public void afterIcalendarCreation() {
                 countDownLatch.countDown();
             }
 

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/application/IcalendarEventListenerTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/application/IcalendarEventListenerTest.java
@@ -1,16 +1,13 @@
 package team.teamby.teambyteam.icalendar.application;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.test.context.transaction.TestTransaction;
 import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.common.fixtures.ScheduleFixtures;
 import team.teamby.teambyteam.icalendar.application.event.CreateIcalendarEvent;
@@ -22,7 +19,6 @@ import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
 import java.util.concurrent.Executor;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
@@ -42,11 +38,6 @@ class IcalendarEventListenerTest extends ServiceTest {
         public Executor executor() {
             return new SyncTaskExecutor();
         }
-    }
-
-    @BeforeEach
-    void setup() {
-        Mockito.reset(icalendarPublishService);
     }
 
     @Test
@@ -69,9 +60,6 @@ class IcalendarEventListenerTest extends ServiceTest {
         // given
         final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
 
-        TestTransaction.flagForCommit();
-        TestTransaction.end();
-
         final CreateIcalendarEvent createIcalendarEvent = new CreateIcalendarEvent(ENGLISH_TEAM_PLACE.getId());
 
         // when
@@ -87,9 +75,6 @@ class IcalendarEventListenerTest extends ServiceTest {
         // given
         final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
         final Schedule schedule = testFixtureBuilder.buildSchedule(ScheduleFixtures.MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
-
-        TestTransaction.flagForCommit();
-        TestTransaction.end();
 
         final ScheduleEvent scheduleEvent = new ScheduleCreateEvent(schedule.getId(), ENGLISH_TEAM_PLACE.getId(), schedule.getTitle(), schedule.getSpan());
 


### PR DESCRIPTION
## PR 내용

Icalendar 테스트 코드 수정

### Listener 테스트

- 이벤트 발행이 아닌 테스트 메서드 직접 실행 기반으로 테스트
  - 이유 : 혹시 동일 이벤트를 listen하는 다른 리스너가 생길 경우 테스트에 영향을 미칠 수 있다고 생각
- 메서드 직접 호출이기에 TestTransaction을 커밋하는 부분 제거

### Acceptance 테스트

AOP 실행 조건 변경
기존 : Async 어노테이션이 붙은 메서드 이후
변경 : 실행할 특정 메서드 직접 지정

이유 : 이후에 다른 Async 메서드가 생기더라도 테스트에 영향을 미치지 않게 하기 위해서

ps 드디어 블로그 작성함
테스트 관련 내용은 본 글에서 정리되어있음!!!
[블로그](https://pilyang.github.io/posts/test-async-method/)

## 참고자료

## 의논할 거리
