### PR TITLE
[FE] 팀 캘린더에 오늘 표시 추가

### DIFF
--- a/frontend/src/components/my_calendar/MyCalendar/MyCalendar.tsx
+++ b/frontend/src/components/my_calendar/MyCalendar/MyCalendar.tsx
@@ -23,13 +23,9 @@ const MyCalendar = (props: MyCalendarProps) => {
     year,
     month,
     calendar,
+    today,
     handlers: { handlePrevButtonClick, handleNextButtonClick },
   } = useCalendar();
-  const {
-    year: currentYear,
-    month: currentMonth,
-    date: currentDate,
-  } = parseDate(new Date());
 
   const schedules = useFetchMySchedules(year, month);
   const scheduleCircles = generateScheduleCirclesMatrix(year, month, schedules);
@@ -85,9 +81,9 @@ const MyCalendar = (props: MyCalendarProps) => {
                     } = parseDate(day);
 
                     const isToday =
-                      currentYear === renderYear &&
-                      currentMonth === renderMonth &&
-                      currentDate === renderDate;
+                      today.year === renderYear &&
+                      today.month === renderMonth &&
+                      today.date === renderDate;
 
                     return (
                       <div key={day.toISOString()}>

--- a/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
+++ b/frontend/src/components/team_calendar/TeamCalendar/TeamCalendar.tsx
@@ -29,6 +29,7 @@ import {
   PlusIcon,
 } from '~/assets/svg';
 import * as S from './TeamCalendar.styled';
+import { parseDate } from '~/utils/parseDate';
 
 interface TeamCalendarProps {
   calendarSize?: CalendarSize;
@@ -43,7 +44,7 @@ const TeamCalendar = (props: TeamCalendarProps) => {
     month,
     calendar,
     currentDate,
-
+    today,
     handlers: { handlePrevButtonClick, handleNextButtonClick },
   } = useCalendar();
   const { isModalOpen, openModal } = useModal();
@@ -279,11 +280,23 @@ const TeamCalendar = (props: TeamCalendarProps) => {
                   </S.ScheduleBarContainer>
                   <S.DateView calendarSize={calendarSize}>
                     {week.map((day, colIndex) => {
+                      const {
+                        year: renderYear,
+                        month: renderMonth,
+                        date: renderDate,
+                      } = parseDate(day);
+
+                      const isToday =
+                        today.year === renderYear &&
+                        today.month === renderMonth &&
+                        today.date === renderDate;
+
                       return (
                         <DateCell
                           key={day.toISOString()}
                           rawDate={day}
                           currentMonth={month}
+                          isToday={isToday}
                           onClick={() => {
                             handleDateCellClick(day);
                           }}

--- a/frontend/src/hooks/useCalendar.ts
+++ b/frontend/src/hooks/useCalendar.ts
@@ -7,6 +7,7 @@ const useCalendar = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
   const { year, month, date } = parseDate(currentDate);
   const { day: startDayOfMonth } = parseDate(new Date(year, month, 1));
+  const today = parseDate(new Date());
 
   const handlePrevButtonClick = () => {
     setCurrentDate(() => new Date(year, month - 1, date));
@@ -33,7 +34,7 @@ const useCalendar = () => {
     month,
     calendar,
     currentDate,
-
+    today,
     handlers: {
       handlePrevButtonClick,
       handleNextButtonClick,


### PR DESCRIPTION
 ## 이슈번호
> close #746 

## PR 내용
캘린더 사용하다보니 오늘 표시 없어서 불편했음

<img width="579" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/446ee47b-7858-4398-a0d8-19445b076a8d">
