### PR TITLE
[BE] 파일 업로드 시 content-type 추가

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -1,5 +1,12 @@
 package team.teamby.teambyteam.feed.application;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,14 +41,6 @@ import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
-
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -121,9 +120,10 @@ public class FeedThreadService {
 
     private void saveImages(final List<MultipartFile> images, final FeedThread savedFeedThread) {
         images.forEach(image -> {
-            final String generatedImageUrl = fileCloudUploader.upload(image, imageDirectory + "/" + UUID.randomUUID());
+            final String originalFilename = image.getOriginalFilename();
+            final String generatedImageUrl = fileCloudUploader.upload(image, imageDirectory + "/" + UUID.randomUUID(), originalFilename);
             final ImageUrl imageUrl = new ImageUrl(generatedImageUrl);
-            final ImageName imageName = new ImageName(image.getOriginalFilename());
+            final ImageName imageName = new ImageName(originalFilename);
             final FeedThreadImage feedThreadImage = new FeedThreadImage(imageUrl, imageName);
             feedThreadImage.confirmFeedThread(savedFeedThread);
             feedThreadImageRepository.save(feedThreadImage);

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/ImageUploadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/ImageUploadService.java
@@ -43,7 +43,7 @@ public class ImageUploadService {
         for (final MultipartFile image : uploadImageRequest.images()) {
             validateImage(image);
             final String customKey = imageDirectory + "/" + UUID.randomUUID() + hashedEmail;
-            final String uploadedFileUrl = fileCloudUploader.upload(image, customKey);
+            final String uploadedFileUrl = fileCloudUploader.upload(image, customKey, image.getOriginalFilename());
             responses.add(new ImageUrlResponse(image.getOriginalFilename(), uploadedFileUrl));
         }
 

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/FileCloudUploader.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/FileCloudUploader.java
@@ -2,11 +2,9 @@ package team.teamby.teambyteam.filesystem;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.InputStream;
-
 public interface FileCloudUploader {
 
-    String upload(final MultipartFile multipartFile, final String directoryPath);
+    String upload(final MultipartFile multipartFile, final String directoryPath, final String originalFileName);
 
-    String upload(final byte[] content, final String directoryPath);
+    String upload(final byte[] content, final String directoryPath, final String originalFileName);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/S3Uploader.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/awss3/S3Uploader.java
@@ -1,17 +1,19 @@
 package team.teamby.teambyteam.filesystem.awss3;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import team.teamby.teambyteam.filesystem.FileCloudUploader;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,10 +32,11 @@ public class S3Uploader implements FileCloudUploader {
     private final CloudfrontCacheInvalidator cloudfrontCacheInvalidator;
 
     @Override
-    public String upload(final MultipartFile multipartFile, final String directoryPath) {
+    public String upload(final MultipartFile multipartFile, final String directoryPath, final String originalFileName) {
         try {
             final RequestBody requestBody = RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize());
-            final String uploadedUrl = uploadFile(directoryPath, requestBody);
+            final MediaType mediaType = MediaType.parseMediaType(Files.probeContentType(Paths.get(originalFileName)));
+            final String uploadedUrl = uploadFile(directoryPath, requestBody, mediaType);
             log.info("file uploaded : {} , published : {}", assetRootDirectory + directoryPath, uploadedUrl);
             return uploadedUrl;
         } catch (IOException e) {
@@ -43,10 +46,11 @@ public class S3Uploader implements FileCloudUploader {
     }
 
     @Override
-    public String upload(final byte[] content, final String directoryPath) {
+    public String upload(final byte[] content, final String directoryPath, final String originalFileName) {
         try (InputStream inputStream = new ByteArrayInputStream(content)) {
             final RequestBody requestBody = RequestBody.fromInputStream(inputStream, content.length);
-            final String uploadedUrl = uploadFile(directoryPath, requestBody);
+            final MediaType mediaType = MediaType.parseMediaType(Files.probeContentType(Paths.get(originalFileName)));
+            final String uploadedUrl = uploadFile(directoryPath, requestBody, mediaType);
             log.info("file uploaded : {} , published : {}", assetRootDirectory + directoryPath, uploadedUrl);
             return uploadedUrl;
         } catch (IOException e) {
@@ -55,10 +59,11 @@ public class S3Uploader implements FileCloudUploader {
         }
     }
 
-    private String uploadFile(final String directoryPath, final RequestBody requestBody) {
+    private String uploadFile(final String directoryPath, final RequestBody requestBody, final MediaType mediaType) {
         final String uploadPath = assetRootDirectory + directoryPath;
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .key(uploadPath)
+                .contentType(mediaType.toString())
                 .bucket(bucket)
                 .build();
 

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishService.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.icalendar.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +16,6 @@ import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -55,7 +54,7 @@ public class IcalendarPublishService {
     private String uploadIcalendarFile(final TeamPlace teamPlace, final IcalendarFileName icalendarFileName) {
         final List<Schedule> schedules = scheduleRepository.findAllByTeamPlaceId(teamPlace.getId());
         final String icalString = icalendarParser.parse(teamPlace, schedules);
-        return fileCloudUploader.upload(icalString.getBytes(), icalDirectory + "/" + icalendarFileName.getValue());
+        return fileCloudUploader.upload(icalString.getBytes(), icalDirectory + "/" + icalendarFileName.getValue(), icalendarFileName.getValue());
     }
 
     public void updateIcalendar(Long teamPlaceId) {

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -119,9 +119,10 @@ public class NoticeService {
 
     private void saveImages(final List<MultipartFile> images, final Notice savedNotice) {
         images.forEach(image -> {
-            final String generatedImageUrl = fileCloudUploader.upload(image, imageDirectory + "/" + UUID.randomUUID());
+            final String originalFilename = image.getOriginalFilename();
+            final String generatedImageUrl = fileCloudUploader.upload(image, imageDirectory + "/" + UUID.randomUUID(), originalFilename);
             final ImageUrl imageUrl = new ImageUrl(generatedImageUrl);
-            final ImageName imageName = new ImageName(image.getOriginalFilename());
+            final ImageName imageName = new ImageName(originalFilename);
             final NoticeImage noticeImage = new NoticeImage(imageUrl, imageName);
             noticeImage.confirmNotice(savedNotice);
             noticeImageRepository.save(noticeImage);

--- a/backend/src/test/java/team/teamby/teambyteam/feed/acceptance/FeedThreadAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/acceptance/FeedThreadAcceptanceTest.java
@@ -22,6 +22,13 @@ import static team.teamby.teambyteam.common.fixtures.acceptance.MemberAcceptance
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -49,14 +56,6 @@ import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 public class FeedThreadAcceptanceTest extends AcceptanceTest {
 
     @MockBean
@@ -80,7 +79,7 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             participatedTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             participatedMemberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(authedMember, participatedTeamPlace);
             authToken = jwtTokenProvider.generateAccessToken(authedMember.getEmail().getValue());
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
+            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
                     .willReturn("https://s3://seongha-seeik");
         }
 
@@ -243,6 +242,8 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
             participatedTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             participatedMemberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(authedMember, participatedTeamPlace);
             authToken = jwtTokenProvider.generateAccessToken(authedMember.getEmail().getValue());
+            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
+                    .willReturn("https://s3://seongha-seeik");
         }
 
         @Test
@@ -267,9 +268,6 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
         @DisplayName("스레드 조회를 처음한다.")
         void firstReadSuccess() {
             // given
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-
             POST_FEED_THREAD_ONLY_IMAGE_REQUEST(authToken, participatedTeamPlace.getId(), List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2));
             POST_FEED_THREAD_IMAGE_AND_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(), List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2), FeedThreadFixtures.CONTENT_AND_IMAGE);
             POST_FEED_THREAD_ONLY_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(), FeedThreadFixtures.CONTENT_ONLY_AND_IMAGE_EMPTY);
@@ -297,9 +295,6 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
         @DisplayName("이미지가 만료되는 경우에 조회한다.")
         void readIfImageExpired() {
             // given
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-
             POST_FEED_THREAD_ONLY_IMAGE_REQUEST(authToken, participatedTeamPlace.getId(), List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2));
 
             final Instant expiredDate = LocalDateTime.now().plusDays(FeedThreadImageFixtures.IMAGE_EXPIRATION_DATE).plusNanos(1).toInstant(ZoneOffset.systemDefault().getRules().getOffset(LocalDateTime.now()));
@@ -327,9 +322,6 @@ public class FeedThreadAcceptanceTest extends AcceptanceTest {
         @DisplayName("탈퇴한 소속되지 않은 사용자의 스레드는 (알수없음) 작성자로 생성된다.")
         void successWithUnknownMember() {
             // given
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-
             final Member otherMember = testFixtureBuilder.buildMember(MemberFixtures.SEONGHA());
             final MemberTeamPlace otherMemberTeamPlace = otherMember.participate(participatedTeamPlace);
             testFixtureBuilder.buildMemberTeamPlace(otherMemberTeamPlace);

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
@@ -1,5 +1,30 @@
 package team.teamby.teambyteam.feed.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.CONTENT_AND_IMAGE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.CONTENT_ONLY_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.EMPTY_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.IMAGE_ONLY_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.NOT_ALLOWED_IMAGE_EXTENSION_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.OVER_IMAGE_COUNT_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.OVER_IMAGE_SIZE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP_EMAIL;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
+import static team.teamby.teambyteam.common.fixtures.MemberTeamPlaceFixtures.PHILIP_ENGLISH_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,32 +59,6 @@ import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.CONTENT_AND_IMAGE_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.CONTENT_ONLY_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.EMPTY_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.IMAGE_ONLY_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.NOT_ALLOWED_IMAGE_EXTENSION_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.OVER_IMAGE_COUNT_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.OVER_IMAGE_SIZE_REQUEST;
-import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
-import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP_EMAIL;
-import static team.teamby.teambyteam.common.fixtures.MemberFixtures.ROY;
-import static team.teamby.teambyteam.common.fixtures.MemberTeamPlaceFixtures.PHILIP_ENGLISH_TEAM_PLACE;
-import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
-import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.JAPANESE_TEAM_PLACE;
-
 class FeedThreadServiceTest extends ServiceTest {
 
     @Autowired
@@ -77,7 +76,7 @@ class FeedThreadServiceTest extends ServiceTest {
 
         @BeforeEach
         void setup() {
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
+            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
                     .willReturn("https://s3://seongha-seeik");
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/docs/FeedThreadApiDocsTest.java
@@ -62,7 +62,7 @@ public final class FeedThreadApiDocsTest extends ApiDocsTest {
 
     @BeforeEach
     void setUp() {
-        given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
+        given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
                 .willReturn("https://s3://seongha-seeik");
     }
 

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/acceptance/IcalendarAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/acceptance/IcalendarAcceptanceTest.java
@@ -1,7 +1,11 @@
 package team.teamby.teambyteam.icalendar.acceptance;
 
+import static org.mockito.ArgumentMatchers.any;
+import static team.teamby.teambyteam.common.fixtures.acceptance.IcalendarAcceptanceFixtures.GET_ICALENDAR_PUBLISHED_URL;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.concurrent.CountDownLatch;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.assertj.core.api.SoftAssertions;
@@ -23,11 +27,6 @@ import team.teamby.teambyteam.filesystem.FileCloudUploader;
 import team.teamby.teambyteam.icalendar.domain.PublishedIcalendar;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-
-import java.util.concurrent.CountDownLatch;
-
-import static org.mockito.ArgumentMatchers.any;
-import static team.teamby.teambyteam.common.fixtures.acceptance.IcalendarAcceptanceFixtures.GET_ICALENDAR_PUBLISHED_URL;
 
 public class IcalendarAcceptanceTest extends AcceptanceTest {
 
@@ -98,7 +97,7 @@ public class IcalendarAcceptanceTest extends AcceptanceTest {
         void failWhenNotPublished() throws InterruptedException {
             // given
             final String generatedUrl = "https://assets.test.teamby.team/asset/path/icalendar.ics";
-            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class)))
+            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class), any(String.class)))
                     .willAnswer(invocation -> generatedUrl);
 
             // when

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishServiceTest.java
@@ -1,5 +1,12 @@
 package team.teamby.teambyteam.icalendar.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static team.teamby.teambyteam.common.fixtures.PublishedIcalendarFixtures.TEST_ICALENDAR;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
+
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,14 +21,6 @@ import team.teamby.teambyteam.filesystem.FileCloudUploader;
 import team.teamby.teambyteam.icalendar.domain.PublishedIcalendar;
 import team.teamby.teambyteam.icalendar.domain.PublishedIcalendarRepository;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static team.teamby.teambyteam.common.fixtures.PublishedIcalendarFixtures.TEST_ICALENDAR;
-import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 
 class IcalendarPublishServiceTest extends ServiceTest {
 
@@ -42,7 +41,7 @@ class IcalendarPublishServiceTest extends ServiceTest {
         @DisplayName("Ical생성에 성공한다")
         void successCreatingIcalendar() {
             // given
-            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class)))
+            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class), any(String.class)))
                     .willAnswer(invocation -> {
                         Thread.sleep(500L);
                         return "https://test.com/test.ics";
@@ -67,7 +66,7 @@ class IcalendarPublishServiceTest extends ServiceTest {
         @DisplayName("이미 생성이되어있으면 새롭게 생성하지 않는다.")
         void doesNotGenerateNewFileIfAlreadyExist() {
             // given
-            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class)))
+            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class), any(String.class)))
                     .willAnswer(invocation -> {
                         Thread.sleep(500L);
                         return "https://test.com/changed-test.ics";
@@ -96,7 +95,7 @@ class IcalendarPublishServiceTest extends ServiceTest {
         @DisplayName("이미 ical배포중인 팀플레이스에서 uploadFile이 잘 실행이 된다.")
         void successWithAlreadyPublishedIcs() {
             // given
-            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class)))
+            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class), any(String.class)))
                     .willAnswer(invocation -> {
                         Thread.sleep(500L);
                         return "https://test.com/test.ics";
@@ -112,7 +111,7 @@ class IcalendarPublishServiceTest extends ServiceTest {
             // then
             ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
             ArgumentCaptor<byte[]> icalBytesCaptor = ArgumentCaptor.forClass(byte[].class);
-            verify(fileCloudUploader).upload(icalBytesCaptor.capture(), fileNameCaptor.capture());
+            verify(fileCloudUploader).upload(icalBytesCaptor.capture(), fileNameCaptor.capture(), fileNameCaptor.capture());
 
             final String actualUploadedFileName = fileNameCaptor.getValue();
             assertThat(actualUploadedFileName).endsWith(publishedIcalendar.getIcalendarFileNameValue());
@@ -122,7 +121,7 @@ class IcalendarPublishServiceTest extends ServiceTest {
         @DisplayName("ical이 배포중이지 않은 팀플레이스에서 일정변동시 생성과 초기화를 진행한다.")
         void successWithNewIcs() {
             // given
-            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class)))
+            BDDMockito.given(fileCloudUploader.upload(any(byte[].class), any(String.class), any(String.class)))
                     .willAnswer(invocation -> {
                         Thread.sleep(500L);
                         return "https://test.com/test.ics";
@@ -137,9 +136,9 @@ class IcalendarPublishServiceTest extends ServiceTest {
             // then
             ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
             ArgumentCaptor<byte[]> icalBytesCaptor = ArgumentCaptor.forClass(byte[].class);
-            verify(fileCloudUploader).upload(icalBytesCaptor.capture(), fileNameCaptor.capture());
+            verify(fileCloudUploader).upload(icalBytesCaptor.capture(), fileNameCaptor.capture(), fileNameCaptor.capture());
 
-            final String actualUploadedFileName = fileNameCaptor.getValue();
+            final String actualUploadedFileName = fileNameCaptor.getAllValues().get(0);
             final String expectedFileNamePatter = "^.+[/]" + ENGLISH_TEAM_PLACE.getId() + ".+[.]ics$";
             assertThat(actualUploadedFileName).matches(expectedFileNamePatter);
         }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/acceptance/NoticeAcceptanceTest.java
@@ -71,7 +71,7 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
             participatedTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             participatedMemberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(authedMember, participatedTeamPlace);
             authToken = jwtTokenProvider.generateAccessToken(authedMember.getEmail().getValue());
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
+            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
                     .willReturn("https://s3://seongha-seeik");
         }
 
@@ -253,6 +253,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
             participatedTeamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             participatedMemberTeamPlace = testFixtureBuilder.buildMemberTeamPlace(authedMember, participatedTeamPlace);
             authToken = jwtTokenProvider.generateAccessToken(authedMember.getEmail().getValue());
+            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
+                    .willReturn("https://s3://seongha-seeik");
         }
 
         @Test
@@ -261,8 +263,6 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
             // given
             final Long recentNoticeId = 3L;
             final String recentNoticeContent = THIRD_CONTENT;
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
             POST_NOTICE_ONLY_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(), FIRST_CONTENT);
             POST_NOTICE_ONLY_IMAGE_REQUEST(authToken, participatedTeamPlace.getId(),
                     List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2));
@@ -292,9 +292,6 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
             // given
             final Long recentNoticeId = 1L;
             final String recentNoticeContent = THIRD_CONTENT;
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-
             POST_NOTICE_IMAGE_AND_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(),
                     List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2), recentNoticeContent);
 
@@ -327,13 +324,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
         @DisplayName("팀 내 다른 사용자가 등록한 공지를 조회한다.")
         void successFindingNoticeWrittenByOtherMember() {
             //given
-            final Long recentNoticeId = 3L;
+            final Long recentNoticeId = 1L;
             final String recentNoticeContent = THIRD_CONTENT;
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-            POST_NOTICE_ONLY_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(), FIRST_CONTENT);
-            POST_NOTICE_ONLY_IMAGE_REQUEST(authToken, participatedTeamPlace.getId(),
-                    List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2));
             POST_NOTICE_IMAGE_AND_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(),
                     List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2), recentNoticeContent);
 
@@ -385,13 +377,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
         @DisplayName("팀플레이스를 탈퇴한 사용자가 작성한 공지를 조회한다.")
         void getRecentNoticeWhichWrittenByLeavedTeamPlaceMember() {
             // given
-            final Long recentNoticeId = 3L;
+            final Long recentNoticeId = 1L;
             final String recentNoticeContent = THIRD_CONTENT;
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-            POST_NOTICE_ONLY_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(), FIRST_CONTENT);
-            POST_NOTICE_ONLY_IMAGE_REQUEST(authToken, participatedTeamPlace.getId(),
-                    List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2));
             POST_NOTICE_IMAGE_AND_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(),
                     List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2), recentNoticeContent);
 
@@ -422,13 +409,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
         @DisplayName("탈퇴한 사용자가 작성한 공지를 조회한다.")
         void getRecentNoticeWhichWrittenByLeavedServiceMember() {
             // given
-            final Long recentNoticeId = 3L;
+            final Long recentNoticeId = 1L;
             final String recentNoticeContent = THIRD_CONTENT;
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
-                    .willReturn("https://s3://seongha-seeik");
-            POST_NOTICE_ONLY_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(), FIRST_CONTENT);
-            POST_NOTICE_ONLY_IMAGE_REQUEST(authToken, participatedTeamPlace.getId(),
-                    List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2));
             POST_NOTICE_IMAGE_AND_CONTENT_REQUEST(authToken, participatedTeamPlace.getId(),
                     List.of(UNDER_SIZE_PNG_FILE1, UNDER_SIZE_PNG_FILE2), recentNoticeContent);
 

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -79,7 +79,7 @@ class NoticeServiceTest extends ServiceTest {
                     NoticeFixtures.FIRST_CONTENT,
                     List.of(UNDER_SIZE_PNG_MOCK_MULTIPART_FILE1, UNDER_SIZE_PNG_MOCK_MULTIPART_FILE2)
             );
-            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
+            given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
                     .willReturn("https://s3://seongha-seeik");
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/notice/docs/NoticeApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/docs/NoticeApiDocsTest.java
@@ -65,7 +65,7 @@ public class NoticeApiDocsTest extends ApiDocsTest {
 
     @BeforeEach
     void setUp() {
-        given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class)))
+        given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
                 .willReturn("https://s3://seongha-seeik");
     }
 


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> 이슈 X

## PR 내용

- S3 파일 업로드 시 content-type을 지정하지 않고 요청을 보내서 기본 `application/octet-stream`이 사용됨
  - 그래서 아마 S3(CloudFront) URL로 접근 시 파일이 뜨는게 아닌 다운로드가 된 것 같음.

- upload 파라미터에 originalFileName을 받아서 다음과 같은 로직으로 MediaType추출
`final MediaType mediaType = MediaType.parseMediaType(Files.probeContentType(Paths.get(originalFileName)));`

## 참고자료

## 의논할 거리
