### PR TITLE
[BE] 피드 실시간 적용 - SSE

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/TeamByTeamApplication.java
+++ b/backend/src/main/java/team/teamby/teambyteam/TeamByTeamApplication.java
@@ -3,7 +3,9 @@ package team.teamby.teambyteam;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class TeamByTeamApplication {

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedWriteEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedWriteEvent.java
@@ -1,0 +1,32 @@
+package team.teamby.teambyteam.feed.application.event;
+
+import team.teamby.teambyteam.feed.application.dto.FeedResponse;
+import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
+
+public class FeedWriteEvent implements TeamPlaceSseEvent {
+
+    private static final String EVENT_NAME = "new_thread";
+
+    private final Long teamPlaceId;
+    private final FeedResponse feedResponse;
+
+    public FeedWriteEvent(final Long teamPlaceId, final FeedResponse feedResponse) {
+        this.teamPlaceId = teamPlaceId;
+        this.feedResponse = feedResponse;
+    }
+
+    @Override
+    public Long getTeamPlaceId() {
+        return teamPlaceId;
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public Object getEvent() {
+        return feedResponse;
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
@@ -82,6 +82,7 @@ public class SseSubscribeService {
                     try {
                         sendToClient(emitterId, emitter, entry.getKey().toString(), NEW_THREAD, objectMapper.writeValueAsString(entry.getValue()));
                     } catch (JsonProcessingException e) {
+                        log.error("SSE data json parsing Exception - " + entry.getValue().toString(),  e);
                         throw new RuntimeException(e);
                     }
                 });

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -53,7 +54,7 @@ public class SseSubscribeService {
 
         sendToClient(emitterId, emitter, emitterId.toString(), CONNECT, String.format(SSE_CONNECTED_MESSAGE_FORMAT, memberId));
 
-        if (!lastEventId.isEmpty()) {
+        if (!Objects.isNull(lastEventId) && !lastEventId.isBlank()) {
             sendCachedEvents(emitterId, emitter, teamPlaceId, lastEventId);
         }
 

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
@@ -68,6 +68,7 @@ public class SseSubscribeService {
                     .data(data));
         } catch (IOException e) {
             teamplaceEmitterRepository.deleteById(emitterId);
+            log.error("fail to send sse", e);
             throw new RuntimeException(e);
         }
     }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
@@ -1,0 +1,88 @@
+package team.teamby.teambyteam.sse.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.vo.Email;
+import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEventId;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Map;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SseSubscribeService {
+
+    public static final String DEFAULT_EVENT_ID = "";
+    private static final String SSE_CONNECTED_MESSAGE_FORMAT = "EventStream Connected. [memberId=%d]";
+    private static final String CONNECT = "connect";
+    private static final String NEW_THREAD = "new_thread";
+    private static final Long DEFAULT_TIMEOUT = 1L * 1000 * 60; // TODO: 시간 적절히 조절하기
+    private static final Comparator<Map.Entry<TeamPlaceEventId, Object>> EVENT_ID_TIME_COMPARATOR = (entity1, entity2) -> {
+        final LocalDateTime timeStamp1 = entity1.getKey().getTimeStamp();
+        final LocalDateTime timeStamp2 = entity2.getKey().getTimeStamp();
+
+        return timeStamp1.compareTo(timeStamp2);
+    };
+
+    private final MemberRepository memberRepository;
+    private final TeamPlaceEmitterRepository teamplaceEmitterRepository;
+    private final ObjectMapper objectMapper;
+
+    public SseEmitter subscribe(final Long teamPlaceId, final MemberEmailDto memberEmailDto, final String lastEventId) {
+
+        final Long memberId = memberRepository.findIdByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()))
+                .id();
+
+        final TeamPlaceEmitterId emitterId = TeamPlaceEmitterId.of(teamPlaceId, memberId);
+        final SseEmitter emitter = teamplaceEmitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        sendToClient(emitterId, emitter, emitterId.toString(), CONNECT, String.format(SSE_CONNECTED_MESSAGE_FORMAT, memberId));
+
+        if (!lastEventId.isEmpty()) {
+            sendCachedEvents(emitterId, emitter, teamPlaceId, lastEventId);
+        }
+
+        return emitter;
+    }
+
+    private void sendToClient(final TeamPlaceEmitterId emitterId, final SseEmitter emitter, final String eventId, final String eventName, final Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId)
+                    .name(eventName)
+                    .data(data));
+        } catch (IOException e) {
+            teamplaceEmitterRepository.deleteById(emitterId);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void sendCachedEvents(final TeamPlaceEmitterId emitterId, final SseEmitter emitter, final Long teamPlaceId, final String lastEventId) {
+        final Map<TeamPlaceEventId, Object> events = teamplaceEmitterRepository.findAllEventCacheWithId(teamPlaceId);
+        events.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey().toString()) < 0)
+                .sorted(EVENT_ID_TIME_COMPARATOR)
+                .forEach(entry -> {
+                    try {
+                        sendToClient(emitterId, emitter, entry.getKey().toString(), NEW_THREAD, objectMapper.writeValueAsString(entry.getValue()));
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
@@ -26,7 +26,6 @@ public class TeamPlaceSsePublisher {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publishEvent(final TeamPlaceSseEvent teamPlaceSseEvent) {
-
         final Long targetTeamPlaceId = teamPlaceSseEvent.getTeamPlaceId();
         final String eventName = teamPlaceSseEvent.getEventName();
         final String eventData = extractEventDataAsJson(teamPlaceSseEvent);

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
@@ -1,0 +1,56 @@
+package team.teamby.teambyteam.sse.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
+import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEventId;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TeamPlaceSsePublisher {
+
+    private final TeamPlaceEmitterRepository teamPlaceEmitterRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishEvent(final TeamPlaceSseEvent teamPlaceSseEvent) {
+
+        final Long targetTeamPlaceId = teamPlaceSseEvent.getTeamPlaceId();
+        final String eventName = teamPlaceSseEvent.getEventName();
+        final Object eventData = teamPlaceSseEvent.getEvent();
+        final TeamPlaceEventId eventId = TeamPlaceEventId.of(targetTeamPlaceId, eventName);
+
+        final Map<TeamPlaceEmitterId, SseEmitter> emitters = teamPlaceEmitterRepository.findByTeamPlaceId(targetTeamPlaceId);
+        emitters.forEach((id, emitter) -> sendEvent(id, emitter, eventId, eventName, eventData));
+        teamPlaceEmitterRepository.addEventCache(eventId, eventData);
+    }
+
+    private void sendEvent(
+            final TeamPlaceEmitterId emitterId,
+            final SseEmitter emitter,
+            final TeamPlaceEventId eventId,
+            final String eventName,
+            final Object eventData
+    ) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId.toString())
+                    .name(eventName)
+                    .data(eventData)
+            );
+        } catch (IOException e) {
+            teamPlaceEmitterRepository.deleteById(emitterId);
+            log.error("fail to send sse", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
@@ -1,20 +1,14 @@
 package team.teamby.teambyteam.sse.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
+import team.teamby.teambyteam.sse.domain.SseEmitters;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEventId;
 import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
-
-import java.io.IOException;
-import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,48 +16,16 @@ import java.util.Map;
 public class TeamPlaceSsePublisher {
 
     private final TeamPlaceEmitterRepository teamPlaceEmitterRepository;
-    private final ObjectMapper objectMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publishEvent(final TeamPlaceSseEvent teamPlaceSseEvent) {
         final Long targetTeamPlaceId = teamPlaceSseEvent.getTeamPlaceId();
         final String eventName = teamPlaceSseEvent.getEventName();
-        final String eventData = extractEventDataAsJson(teamPlaceSseEvent);
         final TeamPlaceEventId eventId = TeamPlaceEventId.of(targetTeamPlaceId, eventName);
 
-        final Map<TeamPlaceEmitterId, SseEmitter> emitters = teamPlaceEmitterRepository.findByTeamPlaceId(targetTeamPlaceId);
-        emitters.forEach((id, emitter) -> sendEvent(id, emitter, eventId, eventName, eventData));
+        final SseEmitters emitters = teamPlaceEmitterRepository.findByTeamPlaceId(targetTeamPlaceId);
+        emitters.sendEvent(eventId, teamPlaceSseEvent);
         teamPlaceEmitterRepository.addEventCache(eventId, teamPlaceSseEvent.getEvent());
-    }
-
-    private String extractEventDataAsJson(final TeamPlaceSseEvent teamPlaceSseEvent) {
-        final String eventData;
-        try {
-            eventData = objectMapper.writeValueAsString(teamPlaceSseEvent.getEvent());
-        } catch (JsonProcessingException e) {
-            log.error("SSE data json parsing Exception - " + teamPlaceSseEvent.getEvent().toString(),  e);
-            throw new RuntimeException(e);
-        }
-        return eventData;
-    }
-
-    private void sendEvent(
-            final TeamPlaceEmitterId emitterId,
-            final SseEmitter emitter,
-            final TeamPlaceEventId eventId,
-            final String eventName,
-            final String eventData
-    ) {
-        try {
-            emitter.send(SseEmitter.event()
-                    .id(eventId.toString())
-                    .name(eventName)
-                    .data(eventData)
-            );
-        } catch (IOException e) {
-            teamPlaceEmitterRepository.deleteById(emitterId);
-            log.error("fail to send sse", e);
-            throw new RuntimeException(e);
-        }
+        log.info("send sse event to teamplace {}", targetTeamPlaceId);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
@@ -34,7 +34,7 @@ public class TeamPlaceSsePublisher {
 
         final Map<TeamPlaceEmitterId, SseEmitter> emitters = teamPlaceEmitterRepository.findByTeamPlaceId(targetTeamPlaceId);
         emitters.forEach((id, emitter) -> sendEvent(id, emitter, eventId, eventName, eventData));
-        teamPlaceEmitterRepository.addEventCache(eventId, eventData);
+        teamPlaceEmitterRepository.addEventCache(eventId, teamPlaceSseEvent.getEvent());
     }
 
     private String extractEventDataAsJson(final TeamPlaceSseEvent teamPlaceSseEvent) {
@@ -42,6 +42,7 @@ public class TeamPlaceSsePublisher {
         try {
             eventData = objectMapper.writeValueAsString(teamPlaceSseEvent.getEvent());
         } catch (JsonProcessingException e) {
+            log.error("SSE data json parsing Exception - " + teamPlaceSseEvent.getEvent().toString(),  e);
             throw new RuntimeException(e);
         }
         return eventData;

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
@@ -1,0 +1,55 @@
+package team.teamby.teambyteam.sse.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+public class SseEmitters {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final TeamPlaceEmitterRepository teamPlaceEmitterRepository;
+    private final Map<TeamPlaceEmitterId, SseEmitter> emitters;
+
+    public SseEmitters(
+            final Map<TeamPlaceEmitterId, SseEmitter> emitters,
+            final TeamPlaceEmitterRepository teamPlaceEmitterRepository
+    ) {
+        this.emitters = emitters;
+        this.teamPlaceEmitterRepository = teamPlaceEmitterRepository;
+    }
+
+    public void sendEvent(final TeamPlaceEventId eventId, final TeamPlaceSseEvent event) {
+        emitters.forEach(
+                (emitterId, emitter) -> {
+                    try {
+                        emitter.send(SseEmitter.event()
+                                .id(eventId.toString())
+                                .name(event.getEventName())
+                                .data(extractEventDataAsJson(event))
+                        );
+                    } catch (IOException e) {
+                        teamPlaceEmitterRepository.deleteById(emitterId);
+                        log.error("fail to send sse", e);
+                        throw new RuntimeException(e);
+                    }
+                }
+        );
+    }
+
+    private String extractEventDataAsJson(final TeamPlaceSseEvent teamPlaceSseEvent) {
+        final String eventData;
+        try {
+            eventData = objectMapper.writeValueAsString(teamPlaceSseEvent.getEvent());
+        } catch (JsonProcessingException e) {
+            log.error("SSE data json parsing Exception - " + teamPlaceSseEvent.getEvent().toString(), e);
+            throw new RuntimeException(e);
+        }
+        return eventData;
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterId.java
@@ -1,0 +1,30 @@
+package team.teamby.teambyteam.sse.domain;
+
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+
+@EqualsAndHashCode
+public class TeamPlaceEmitterId {
+
+    private static final String DELIMITER = "_";
+
+    private final Long teamPlaceId;
+    private final Long memberId;
+    private final LocalDateTime timeStamp;
+
+    private TeamPlaceEmitterId(final Long teamPlaceId, final Long memberId, final LocalDateTime timeStamp) {
+        this.teamPlaceId = teamPlaceId;
+        this.memberId = memberId;
+        this.timeStamp = timeStamp;
+    }
+
+    public static TeamPlaceEmitterId of(final Long teamPlaceId, final Long memberId) {
+        return new TeamPlaceEmitterId(teamPlaceId, memberId, LocalDateTime.now());
+    }
+
+    @Override
+    public String toString() {
+        return teamPlaceId + DELIMITER + memberId + DELIMITER + timeStamp;
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterId.java
@@ -3,6 +3,7 @@ package team.teamby.teambyteam.sse.domain;
 import lombok.EqualsAndHashCode;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @EqualsAndHashCode
 public class TeamPlaceEmitterId {
@@ -21,6 +22,10 @@ public class TeamPlaceEmitterId {
 
     public static TeamPlaceEmitterId of(final Long teamPlaceId, final Long memberId) {
         return new TeamPlaceEmitterId(teamPlaceId, memberId, LocalDateTime.now());
+    }
+
+    public boolean isTeamPlaceId(final Long teamPlaceId) {
+        return Objects.equals(this.memberId, teamPlaceId);
     }
 
     @Override

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -24,11 +24,12 @@ public class TeamPlaceEmitterRepository {
         return sseEmitter;
     }
 
-    public Map<TeamPlaceEmitterId, SseEmitter> findByTeamPlaceId(final Long teamPlaceId) {
-        return emitters.entrySet()
+    public SseEmitters findByTeamPlaceId(final Long teamPlaceId) {
+        final Map<TeamPlaceEmitterId, SseEmitter> emitters = this.emitters.entrySet()
                 .stream()
                 .filter(entity -> entity.getKey().isTeamPlaceId(teamPlaceId))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return new SseEmitters(emitters, this);
     }
 
     public void deleteById(final TeamPlaceEmitterId id) {

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -1,8 +1,10 @@
 package team.teamby.teambyteam.sse.domain;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -31,5 +33,16 @@ public class TeamPlaceEmitterRepository {
                 .stream()
                 .filter(entry -> entry.getKey().isPublishedTo(teamPlaceId))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Scheduled(fixedDelay = 1000 * 60)
+    private void cacheRefreshSchedule() {
+        final LocalDateTime now = LocalDateTime.now();
+        eventCache.keySet().forEach(key -> {
+                    if (key.getTimeStamp().isBefore(now.minusMinutes(1))) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 @Component
 public class TeamPlaceEmitterRepository {
 
+    private static final int CACHE_REMOVE_MINUTE = 1;
+
     private final Map<TeamPlaceEmitterId, SseEmitter> emitters = new ConcurrentHashMap<>();
     private final EventCache eventCache = new EventCache();
 
@@ -46,7 +48,7 @@ public class TeamPlaceEmitterRepository {
 
     @Scheduled(fixedDelayString = "${sse.cache-schedule-period}")
     private void cacheRefreshSchedule() {
-        eventCache.clearCacheFor(1);
+        eventCache.clearCacheFor(CACHE_REMOVE_MINUTE);
     }
 
     private static class EventCache {

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -24,6 +24,13 @@ public class TeamPlaceEmitterRepository {
         return sseEmitter;
     }
 
+    public Map<TeamPlaceEmitterId, SseEmitter> findByTeamPlaceId(final Long teamPlaceId) {
+        return emitters.entrySet()
+                .stream()
+                .filter(entity -> entity.getKey().isTeamPlaceId(teamPlaceId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
     public void deleteById(final TeamPlaceEmitterId id) {
         emitters.remove(id);
     }
@@ -35,7 +42,11 @@ public class TeamPlaceEmitterRepository {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    @Scheduled(fixedDelay = 1000 * 60)
+    public void addEventCache(final TeamPlaceEventId teamPlaceEventId, final Object event) {
+        eventCache.put(teamPlaceEventId, event);
+    }
+
+    @Scheduled(fixedDelayString = "${sse.cache-schedule-period}")
     private void cacheRefreshSchedule() {
         final LocalDateTime now = LocalDateTime.now();
         eventCache.keySet().forEach(key -> {

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -1,0 +1,35 @@
+package team.teamby.teambyteam.sse.domain;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Component
+public class TeamPlaceEmitterRepository {
+
+    private final Map<TeamPlaceEmitterId, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<TeamPlaceEventId, Object> eventCache = new ConcurrentHashMap<>();
+
+    public SseEmitter save(final TeamPlaceEmitterId emitterId, final SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+
+        sseEmitter.onCompletion(() -> emitters.remove(emitterId));
+        sseEmitter.onTimeout(() -> emitters.remove(emitterId));
+
+        return sseEmitter;
+    }
+
+    public void deleteById(final TeamPlaceEmitterId id) {
+        emitters.remove(id);
+    }
+
+    public Map<TeamPlaceEventId, Object> findAllEventCacheWithId(final Long teamPlaceId) {
+        return eventCache.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().isPublishedTo(teamPlaceId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
@@ -1,14 +1,16 @@
 package team.teamby.teambyteam.sse.domain;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@Getter
 @EqualsAndHashCode
 public class TeamPlaceEventId {
 
-    private final String DELIMITER = "_";
+    private static final String DELIMITER = "_";
 
     private final Long teamPlaceId;
     private final String eventName;
@@ -30,12 +32,23 @@ public class TeamPlaceEventId {
         return new TeamPlaceEventId(teamPlaceId, eventName, LocalDateTime.now());
     }
 
+    public static TeamPlaceEventId from(final String stringValue) {
+        final int idIndex = stringValue.indexOf(DELIMITER);
+        final int nameIndex = stringValue.lastIndexOf(DELIMITER);
+
+        final Long teamPlaceId = Long.valueOf(stringValue.substring(0, idIndex));
+        final String eventName = stringValue.substring(idIndex + 1, nameIndex);
+        final LocalDateTime timeStamp = LocalDateTime.parse(stringValue.substring(nameIndex + 1));
+
+        return new TeamPlaceEventId(teamPlaceId, eventName, timeStamp);
+    }
+
     public boolean isPublishedTo(final Long teamPlaceId) {
         return Objects.equals(this.teamPlaceId, teamPlaceId);
     }
 
-    public LocalDateTime getTimeStamp() {
-        return timeStamp;
+    public boolean isPublishedAfter(final TeamPlaceEventId lastEventId) {
+        return timeStamp.isAfter(lastEventId.timeStamp);
     }
 
     @Override

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
@@ -1,0 +1,39 @@
+package team.teamby.teambyteam.sse.domain;
+
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@EqualsAndHashCode
+public class TeamPlaceEventId {
+
+    private final String DELIMITER = "_";
+
+    private final Long teamPlaceId;
+    private final String eventName;
+    private final LocalDateTime timeStamp;
+
+    private TeamPlaceEventId(final Long teamPlaceId, final String eventName, final LocalDateTime timeStamp) {
+        this.teamPlaceId = teamPlaceId;
+        this.eventName = eventName;
+        this.timeStamp = timeStamp;
+    }
+
+    public static TeamPlaceEventId of(final Long teamPlaceId, final String eventName) {
+        return new TeamPlaceEventId(teamPlaceId, eventName, LocalDateTime.now());
+    }
+
+    public boolean isPublishedTo(final Long teamPlaceId) {
+        return Objects.equals(this.teamPlaceId, teamPlaceId);
+    }
+
+    public LocalDateTime getTimeStamp() {
+        return timeStamp;
+    }
+
+    @Override
+    public String toString() {
+        return teamPlaceId + DELIMITER + eventName + DELIMITER + timeStamp;
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
@@ -14,6 +14,12 @@ public class TeamPlaceEventId {
     private final String eventName;
     private final LocalDateTime timeStamp;
 
+    private TeamPlaceEventId() {
+        this.teamPlaceId = null;
+        this.eventName = null;
+        this.timeStamp = null;
+    }
+
     private TeamPlaceEventId(final Long teamPlaceId, final String eventName, final LocalDateTime timeStamp) {
         this.teamPlaceId = teamPlaceId;
         this.eventName = eventName;

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEventId.java
@@ -1,13 +1,16 @@
 package team.teamby.teambyteam.sse.domain;
 
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
 @EqualsAndHashCode
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class TeamPlaceEventId {
 
     private static final String DELIMITER = "_";
@@ -20,12 +23,6 @@ public class TeamPlaceEventId {
         this.teamPlaceId = null;
         this.eventName = null;
         this.timeStamp = null;
-    }
-
-    private TeamPlaceEventId(final Long teamPlaceId, final String eventName, final LocalDateTime timeStamp) {
-        this.teamPlaceId = teamPlaceId;
-        this.eventName = eventName;
-        this.timeStamp = timeStamp;
     }
 
     public static TeamPlaceEventId of(final Long teamPlaceId, final String eventName) {

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceSseEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceSseEvent.java
@@ -1,0 +1,10 @@
+package team.teamby.teambyteam.sse.domain;
+
+public interface TeamPlaceSseEvent {
+
+    Long getTeamPlaceId();
+
+    String getEventName();
+
+    Object getEvent();
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
@@ -18,8 +18,10 @@ import team.teamby.teambyteam.sse.application.SseSubscribeService;
 @RequiredArgsConstructor
 public class SseController {
 
-    private final SseSubscribeService sseSubscribeService;
+    private static final String NGINX_X_ACCEL_BUFFERING_HEADER = "X-Accel-Buffering";
+    private static final String NO = "no";
 
+    private final SseSubscribeService sseSubscribeService;
 
     @GetMapping(value = "/team-place/{teamPlaceId}/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> connect(
@@ -28,6 +30,9 @@ public class SseController {
             @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = SseSubscribeService.DEFAULT_EVENT_ID) final String lastEventId
     ) {
         final SseEmitter emitter = sseSubscribeService.subscribe(teamPlaceId, memberEmailDto, lastEventId);
-        return ResponseEntity.ok(emitter);
+        return ResponseEntity
+                .ok()
+                .header(NGINX_X_ACCEL_BUFFERING_HEADER, NO)
+                .body(emitter);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
@@ -1,0 +1,33 @@
+package team.teamby.teambyteam.sse.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.teamby.teambyteam.member.configuration.AuthPrincipal;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.sse.application.SseSubscribeService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SseController {
+
+    private final SseSubscribeService sseSubscribeService;
+
+
+    @GetMapping(value = "/team-place/{teamPlaceId}/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> connect(
+            @PathVariable final Long teamPlaceId,
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
+            @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = SseSubscribeService.DEFAULT_EVENT_ID) final String lastEventId
+    ) {
+        final SseEmitter emitter = sseSubscribeService.subscribe(teamPlaceId, memberEmailDto, lastEventId);
+        return ResponseEntity.ok(emitter);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
     password:
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: create-drop # for test
     properties:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -35,6 +35,9 @@ jwt:
     secret: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     expiration: 86400000 # 1일
 
+sse:
+  cache-schedule-period: 60 * 1000
+
 aws:
   s3:
     region: abcd

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
@@ -95,6 +95,7 @@ class FeedThreadServiceTest extends ServiceTest {
             // given
             final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             final Member author = testFixtureBuilder.buildMember(PHILIP());
+            testFixtureBuilder.buildMemberTeamPlace(author, teamPlace);
 
             // when
             final Long feedId = feedThreadService.write(request, new MemberEmailDto(author.getEmail().getValue()),

--- a/backend/src/test/java/team/teamby/teambyteam/sse/TestEvent.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/TestEvent.java
@@ -1,0 +1,33 @@
+package team.teamby.teambyteam.sse;
+
+import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
+
+public class TestEvent implements TeamPlaceSseEvent {
+    private final Long teamPlaceId;
+    private final String name;
+    private final TestData data;
+
+    public TestEvent(final Long teamPlaceId, final String name, final String data) {
+        this.teamPlaceId = teamPlaceId;
+        this.name = name;
+        this.data = new TestData(teamPlaceId, data);
+    }
+
+    @Override
+    public Long getTeamPlaceId() {
+        return teamPlaceId;
+    }
+
+    @Override
+    public String getEventName() {
+        return name;
+    }
+
+    @Override
+    public Object getEvent() {
+        return data;
+    }
+
+    private record TestData(long id, String data) {
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
@@ -15,13 +15,19 @@ import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.sse.TestEvent;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEventId;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class SseSubscribeServiceTest extends ServiceTest {
@@ -39,8 +45,6 @@ class SseSubscribeServiceTest extends ServiceTest {
                 .willReturn(sseEmitter);
     }
 
-
-
     @Test
     @DisplayName("SSE 연결에 성공 후 더미이벤트를 발행시킨다.")
     void successWithInitialDummyMessage() throws IOException {
@@ -48,7 +52,6 @@ class SseSubscribeServiceTest extends ServiceTest {
         final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
         final MemberEmailDto email = new MemberEmailDto(member.getEmailValue());
         final Long teamPlaceId = 1L;
-
 
         // when
         final SseEmitter sseEmitter = sseSubscribeService.subscribe(teamPlaceId, email, null);
@@ -60,10 +63,7 @@ class SseSubscribeServiceTest extends ServiceTest {
 
         // verify the content of the SSE
         final Set<ResponseBodyEmitter.DataWithMediaType> properties = argumentCaptor.getValue().build();
-        final String publishedSse = properties.stream()
-                .map(ResponseBodyEmitter.DataWithMediaType::getData)
-                .map(Object::toString)
-                .collect(Collectors.joining());
+        final String publishedSse = SsePropertyToString(properties);
 
         final String[] eventOutputs = publishedSse.split("\n");
 
@@ -74,4 +74,67 @@ class SseSubscribeServiceTest extends ServiceTest {
         });
     }
 
+    @Test
+    @DisplayName("SSE 연결 수 저장된 케시 이벤트들을 발행한다.")
+    void successWithCachedEvent() throws IOException, InterruptedException {
+        // given
+        final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+        final MemberEmailDto email = new MemberEmailDto(member.getEmailValue());
+        final Long teamPlaceId = 1L;
+        final String eventName = "test";
+        final String eventMessage = "message";
+        final TestEvent cachedEvent = new TestEvent(teamPlaceId, eventName, eventMessage);
+
+        final TeamPlaceEventId lastEventId = TeamPlaceEventId.of(teamPlaceId, eventName);
+        Thread.sleep(100);
+        final TeamPlaceEventId cachedEventId = TeamPlaceEventId.of(teamPlaceId, eventName);
+
+        BDDMockito.given(teamPlaceEmitterRepository.findAllEventCacheWithId(teamPlaceId))
+                .willReturn(Map.of(cachedEventId, cachedEvent.getEvent()));
+
+        // when
+
+        final SseEmitter sseEmitter = sseSubscribeService.subscribe(teamPlaceId, email, lastEventId.toString());
+
+        // then
+        // verify if the SSE is sent
+        ArgumentCaptor<SseEmitter.SseEventBuilder> argumentCaptor = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+        verify(sseEmitter, times(2)).send(argumentCaptor.capture());
+
+        // verify the content of the SSE
+        final List<SseEmitter.SseEventBuilder> allEvents = argumentCaptor.getAllValues();
+
+        final Set<ResponseBodyEmitter.DataWithMediaType> dummyEventProperties = allEvents.get(0).build();
+        final String dummySse = SsePropertyToString(dummyEventProperties);
+
+        final Set<ResponseBodyEmitter.DataWithMediaType> cachedEventProperties = allEvents.get(1).build();
+        final String cachedSse = SsePropertyToString(cachedEventProperties);
+
+        final String[] dummyResult = dummySse.split("\n");
+        final String[] cachedResult = cachedSse.split("\n");
+
+
+        Arrays.stream(dummyResult).forEach(System.out::println);
+        System.out.println();
+        Arrays.stream(cachedResult).forEach(System.out::println);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(allEvents).hasSize(2);
+            softly.assertThat(dummyResult[0]).startsWith("id:" + teamPlaceId + "_" + member.getId() + "_");
+            softly.assertThat(dummyResult[1]).isEqualTo("event:connect");
+            softly.assertThat(dummyResult[2]).isEqualTo("data:EventStream Connected. [memberId=%d]", teamPlaceId);
+            softly.assertThat(cachedResult[0]).startsWith("id:" + teamPlaceId + "_" + eventName + "_");
+            softly.assertThat(cachedResult[1]).isEqualTo("event:test");
+            softly.assertThat(cachedResult[2]).isEqualTo("data:{\"id\":1,\"data\":\"message\"}");
+        });
+
+    }
+
+    private String SsePropertyToString(final Set<ResponseBodyEmitter.DataWithMediaType> dummyEventProperties) {
+        final String dummySse = dummyEventProperties.stream()
+                .map(ResponseBodyEmitter.DataWithMediaType::getData)
+                .map(Object::toString)
+                .collect(Collectors.joining());
+        return dummySse;
+    }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
@@ -1,0 +1,77 @@
+package team.teamby.teambyteam.sse.application;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.teamby.teambyteam.common.ServiceTest;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+class SseSubscribeServiceTest extends ServiceTest {
+
+    @Autowired
+    private SseSubscribeService sseSubscribeService;
+
+    @MockBean
+    private TeamPlaceEmitterRepository teamPlaceEmitterRepository;
+
+    @BeforeEach
+    void setup() {
+        final SseEmitter sseEmitter = Mockito.mock(SseEmitter.class);
+        BDDMockito.given(teamPlaceEmitterRepository.save(any(), any()))
+                .willReturn(sseEmitter);
+    }
+
+
+
+    @Test
+    @DisplayName("SSE 연결에 성공 후 더미이벤트를 발행시킨다.")
+    void successWithInitialDummyMessage() throws IOException {
+        // given
+        final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
+        final MemberEmailDto email = new MemberEmailDto(member.getEmailValue());
+        final Long teamPlaceId = 1L;
+
+
+        // when
+        final SseEmitter sseEmitter = sseSubscribeService.subscribe(teamPlaceId, email, null);
+
+        // then
+        // verify if the SSE is sent
+        ArgumentCaptor<SseEmitter.SseEventBuilder> argumentCaptor = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+        verify(sseEmitter).send(argumentCaptor.capture());
+
+        // verify the content of the SSE
+        final Set<ResponseBodyEmitter.DataWithMediaType> properties = argumentCaptor.getValue().build();
+        final String publishedSse = properties.stream()
+                .map(ResponseBodyEmitter.DataWithMediaType::getData)
+                .map(Object::toString)
+                .collect(Collectors.joining());
+
+        final String[] eventOutputs = publishedSse.split("\n");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(eventOutputs[0]).startsWith("id:" + teamPlaceId + "_" + member.getId() + "_");
+            softly.assertThat(eventOutputs[1]).isEqualTo("event:connect");
+            softly.assertThat(eventOutputs[2]).isEqualTo("data:EventStream Connected. [memberId=%d]", teamPlaceId);
+        });
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
@@ -68,7 +68,7 @@ class SseSubscribeServiceTest extends ServiceTest {
         final String[] eventOutputs = publishedSse.split("\n");
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(eventOutputs[0]).startsWith("id:" + teamPlaceId + "_" + member.getId() + "_");
+            softly.assertThat(eventOutputs[0]).startsWith("id:" + teamPlaceId + "_connect_");
             softly.assertThat(eventOutputs[1]).isEqualTo("event:connect");
             softly.assertThat(eventOutputs[2]).isEqualTo("data:EventStream Connected. [memberId=%d]", teamPlaceId);
         });
@@ -120,7 +120,7 @@ class SseSubscribeServiceTest extends ServiceTest {
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(allEvents).hasSize(2);
-            softly.assertThat(dummyResult[0]).startsWith("id:" + teamPlaceId + "_" + member.getId() + "_");
+            softly.assertThat(dummyResult[0]).startsWith("id:" + teamPlaceId + "_connect_");
             softly.assertThat(dummyResult[1]).isEqualTo("event:connect");
             softly.assertThat(dummyResult[2]).isEqualTo("data:EventStream Connected. [memberId=%d]", teamPlaceId);
             softly.assertThat(cachedResult[0]).startsWith("id:" + teamPlaceId + "_" + eventName + "_");

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
@@ -1,0 +1,104 @@
+package team.teamby.teambyteam.sse.application;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
+import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class TeamPlaceSsePublisherTest {
+
+    @Autowired
+    private TeamPlaceSsePublisher teamPlaceSsePublisher;
+
+    @Autowired
+    private TeamPlaceEmitterRepository teamPlaceEmitterRepository;
+
+    @Test
+    @DisplayName("발행된 이벤트로 SSE를 전송한다")
+    void sendSseWithEmitter() throws IOException {
+        // given
+        final Long teamPlaceId = 1L;
+        final String eventName = "test_event";
+        final String data = "{message: event}";
+        final TestEvent testEvent = new TestEvent(teamPlaceId, eventName, data);
+
+        final TeamPlaceEmitterId emitterId = TeamPlaceEmitterId.of(teamPlaceId, 1L);
+
+        final SseEmitter sseEmitter = Mockito.mock(SseEmitter.class);
+        final SseEmitter savedEmitter = teamPlaceEmitterRepository.save(emitterId, sseEmitter);
+
+        // when
+        teamPlaceSsePublisher.publishEvent(testEvent);
+
+        // then
+
+        // verify if the SSE is sent
+        ArgumentCaptor<SseEventBuilder> argumentCaptor = ArgumentCaptor.forClass(SseEventBuilder.class);
+        verify(savedEmitter).send(argumentCaptor.capture());
+
+        // verify the content of the SSE
+        final Set<ResponseBodyEmitter.DataWithMediaType> properties = argumentCaptor.getValue().build();
+        final String publishedSse = properties.stream()
+                .map(ResponseBodyEmitter.DataWithMediaType::getData)
+                .map(Object::toString)
+                .collect(Collectors.joining());
+
+        final String[] eventOutputs = publishedSse.split("\n");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(eventOutputs[0]).startsWith("id:" + teamPlaceId + "_" + eventName + "_");
+            softly.assertThat(eventOutputs[1]).isEqualTo("event:" + eventName);
+            softly.assertThat(eventOutputs[2]).isEqualTo("data:{\"id\":1,\"data\":\"{message: event}\"}");
+        });
+
+        // remove cache
+        teamPlaceEmitterRepository.deleteById(emitterId);
+    }
+
+    private static class TestEvent implements TeamPlaceSseEvent {
+
+        private final Long id;
+        private final String name;
+        private final TestData data;
+
+        public TestEvent(final Long id, final String name, final String data) {
+            this.id = id;
+            this.name = name;
+            this.data = new TestData(id, data);
+        }
+
+        @Override
+        public Long getTeamPlaceId() {
+            return id;
+        }
+
+        @Override
+        public String getEventName() {
+            return name;
+        }
+
+        @Override
+        public Object getEvent() {
+            return data;
+        }
+
+        private record TestData(long id, String data) {
+        }
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
@@ -10,9 +10,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+import team.teamby.teambyteam.sse.TestEvent;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
-import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
 
 import java.io.IOException;
 import java.util.Set;
@@ -69,36 +69,5 @@ class TeamPlaceSsePublisherTest {
 
         // remove cache
         teamPlaceEmitterRepository.deleteById(emitterId);
-    }
-
-    private static class TestEvent implements TeamPlaceSseEvent {
-
-        private final Long id;
-        private final String name;
-        private final TestData data;
-
-        public TestEvent(final Long id, final String name, final String data) {
-            this.id = id;
-            this.name = name;
-            this.data = new TestData(id, data);
-        }
-
-        @Override
-        public Long getTeamPlaceId() {
-            return id;
-        }
-
-        @Override
-        public String getEventName() {
-            return name;
-        }
-
-        @Override
-        public Object getEvent() {
-            return data;
-        }
-
-        private record TestData(long id, String data) {
-        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepositoryTest.java
@@ -1,0 +1,85 @@
+package team.teamby.teambyteam.sse.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class TeamPlaceEmitterRepositoryTest {
+
+    @Autowired
+    private TeamPlaceEmitterRepository teamPlaceEmitterRepository;
+
+    @Value("${sse.cache-schedule-period}")
+    private Long schedulePeriod;
+
+    @DisplayName("emitter 저장을 성공한다.")
+    @Test
+    void save() {
+        //given
+        final TeamPlaceEmitterId teamPlaceEmitterId = TeamPlaceEmitterId.of(1L, 1L);
+        final SseEmitter sseEmitter = new SseEmitter(1000L * 60);
+
+        //when
+        final SseEmitter save = teamPlaceEmitterRepository.save(teamPlaceEmitterId, sseEmitter);
+
+        //then
+        assertThat(save).isEqualTo(sseEmitter);
+    }
+
+    @DisplayName("팀플레이스 아이디로 저징된 캐시들을 찾는다.")
+    @Test
+    void findCache() {
+        //given
+        final TeamPlaceEventId teamPlaceEventId1 = TeamPlaceEventId.of(1L, "test");
+        final TeamPlaceEventId teamPlaceEventId2 = TeamPlaceEventId.of(2L, "test");
+        final String event1 = "test1";
+        final String event2 = "test2";
+
+        teamPlaceEmitterRepository.addEventCache(teamPlaceEventId1, event1);
+        teamPlaceEmitterRepository.addEventCache(teamPlaceEventId2, event2);
+
+        //when
+        final Map<TeamPlaceEventId, Object> events = teamPlaceEmitterRepository.findAllEventCacheWithId(1L);
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(events).hasSize(1);
+            softly.assertThat(events.get(teamPlaceEventId1)).isEqualTo(event1);
+        });
+    }
+
+    @DisplayName("이벤트 캐시를 일정 시간마다 제거한다.")
+    @Test
+    void refreshCache() throws InterruptedException {
+        //given
+        final LocalDateTime pastLocalDateTime = LocalDateTime.now().minusMinutes(1);
+
+        final TeamPlaceEventId teamPlaceEventId = Mockito.spy(TeamPlaceEventId.class);
+        given(teamPlaceEventId.getTimeStamp())
+                .willReturn(pastLocalDateTime);
+        given(teamPlaceEventId.isPublishedTo(1L))
+                .willReturn(true);
+
+        final String event = "event";
+        teamPlaceEmitterRepository.addEventCache(teamPlaceEventId, event);
+
+        //when
+        Thread.sleep(schedulePeriod);
+
+        //then
+        final Map<TeamPlaceEventId, Object> allEventCacheWithId = teamPlaceEmitterRepository.findAllEventCacheWithId(1L);
+        assertThat(allEventCacheWithId).hasSize(0);
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,6 +18,7 @@ spring:
     password:
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: create-drop # for test
     properties:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,7 +18,6 @@ spring:
     password:
 
   jpa:
-    open-in-view: false
     hibernate:
       ddl-auto: create-drop # for test
     properties:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -35,6 +35,9 @@ jwt:
     secret: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     expiration: 86400000 # 1일
 
+sse:
+  cache-schedule-period: 1000
+
 aws:
   s3:
     region: abcd


### PR DESCRIPTION
## 이슈번호
> close #753

## PR 내용

- SSE 연결하여 피드 실시간 정보 전달
- SSE관련 기능들은 모두 SSE패키지에 유지
- `SseSubscribeService` : 사용자가 SSE 연결 요청시 연결 생성
- `TeamPlaceSsePublisher` : 팀플레이스 관련 이벤트 발생시 연결된 해당 팀플레이스 사용자들에게 SSE 발행

- 해당 SSE로 발행할 모든 이벤트는 TeamPlaceSseEvnet를 구현하여 사용
- 의존성 방향 통일 : `SSE` <- `domain` 으로 이벤트를 발행시킬 도메인이 sse에 대한 의존성만 가질 수 있도록 구현
- 추후 새로운 이벤트 발행시 sse패키지는 수정 없이 반영 가능

## 참고자료

## 의논할 거리
