### PR TITLE
[BE] SSE connection timeout 설정 위치 변경

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/EnableAsyncConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/EnableAsyncConfiguration.java
@@ -1,9 +1,9 @@
-package team.teamby.teambyteam.icalendar.cofig;
+package team.teamby.teambyteam.global.configuration;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @Configuration
 @EnableAsync
-public class IcalendarConfiguration {
+public class EnableAsyncConfiguration {
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
@@ -1,6 +1,7 @@
 package team.teamby.teambyteam.sse.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -15,6 +16,7 @@ public class TeamPlaceSsePublisher {
 
     private final TeamPlaceEmitterRepository teamPlaceEmitterRepository;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publishEvent(final TeamPlaceSseEvent teamPlaceSseEvent) {
         final Long targetTeamPlaceId = teamPlaceSseEvent.getTeamPlaceId();

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
@@ -40,7 +40,7 @@ public class SseEmitters {
                         log.info("send event to {}, event : {}", emitterId.toString(), eventId.getEventName());
                     } catch (IOException e) {
                         teamPlaceEmitterRepository.deleteById(emitterId);
-                        log.error("fail to send sse", e);
+                        log.error("fail to send sse message : {}, error : {}", e.getMessage(), e.getClass());
                         throw new RuntimeException(e);
                     }
                 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
@@ -5,8 +5,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;
@@ -27,7 +27,7 @@ public class SseController {
     public ResponseEntity<SseEmitter> connect(
             @PathVariable final Long teamPlaceId,
             @AuthPrincipal final MemberEmailDto memberEmailDto,
-            @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = SseSubscribeService.DEFAULT_EVENT_ID) final String lastEventId
+            @RequestParam(value = "lastEventID", required = false, defaultValue = SseSubscribeService.DEFAULT_EVENT_ID) final String lastEventId
     ) {
         final SseEmitter emitter = sseSubscribeService.subscribe(teamPlaceId, memberEmailDto, lastEventId);
         return ResponseEntity

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,7 +37,8 @@ jwt:
     expiration: 86400000 # 1일
 
 sse:
-  cache-schedule-period: 60 * 1000
+  connection-time: 60000  # 60 * 1000
+  cache-schedule-period: 60000 # 60 * 1000
 
 aws:
   s3:

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
@@ -7,6 +7,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
@@ -16,6 +20,7 @@ import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.verify;
@@ -28,6 +33,15 @@ class TeamPlaceSsePublisherTest {
 
     @Autowired
     private TeamPlaceEmitterRepository teamPlaceEmitterRepository;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        public Executor executor() {
+            return new SyncTaskExecutor();
+        }
+    }
 
     @Test
     @DisplayName("발행된 이벤트로 SSE를 전송한다")

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -37,6 +37,7 @@ jwt:
     expiration: 86400000 # 1일
 
 sse:
+  connection-time: 60000  # 60 * 1000
   cache-schedule-period: 1000
 
 aws:


### PR DESCRIPTION
## PR 내용

- application.yml 설정파일을 통해서 connection timeout을 설정할 수 있도록 변경
- lastEventId를 가져오는 방식을 RequestHeader -> RequstParam으로 변경
  - 실제 요청 확인시 `lastEventId`라는 이름의 쿼리파람으로 날라옴


## 참고자료

## 의논할 거리
