### PR TITLE
[FE] git page로 storybook 배포

### DIFF
--- a/.github/workflows/frontend-deploy-storybook.yml
+++ b/.github/workflows/frontend-deploy-storybook.yml
@@ -1,0 +1,46 @@
+name: frontend deploy dev
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches: ["develop"]
+    paths:
+      - "frontend/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Setup Repository
+        uses: actions/checkout@v3
+
+      - name: Setup node with cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: |
+          npm run build-storybook
+          mv ./storybook-static ./build
+
+      - name: Upload frontend build file to github page
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/.github/workflows/frontend-deploy-storybook.yml
+++ b/.github/workflows/frontend-deploy-storybook.yml
@@ -1,4 +1,4 @@
-name: frontend deploy dev
+name: frontend deploy storybook
 
 on:
   pull_request:
@@ -8,14 +8,9 @@ on:
     paths:
       - "frontend/**"
 
-permissions:
-  contents: read
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/frontend-deploy-storybook.yml
+++ b/.github/workflows/frontend-deploy-storybook.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> close #769 

## PR 내용
gh-page를 안쓰고 있는김에 배포합니다.
특정파일을 제외하거나 특정 submodule를 제외한 채로 netilfy배포가 불가능합니다. 백엔드 security 모듈이 private상태라 접근이 불가능해 현재 스토리북 배포가 진행되고있지 않습니다.
되는지 안되는지 모름 해봐야함

## 참고자료

## 의논할 거리
