### PR TITLE
[FE] 에러발생시 연결 끊는로직 제거

### DIFF
--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -38,10 +38,6 @@ export const useSSE = (teamPlaceId: number, ref: RefObject<HTMLDivElement>) => {
       queryClient.invalidateQueries(['threadData', teamPlaceId]);
     });
 
-    eventSource.onerror = () => {
-      eventSource.close();
-    };
-
     return () => {
       eventSource.close();
     };


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> #772

## PR 내용
아마도 연결이 끊긴것도 에러로 받아서 닫아버리면 브라우저가 다시 연결을 시도하지 못하는것 같습니다
## 참고자료

## 의논할 거리
