### PR TITLE
[FE] 이미지가 깨지는 경우에 대해 적절히 예외처리 할 수 있도록 개선

### DIFF
--- a/frontend/src/components/feed/Carousel/Carousel.styled.ts
+++ b/frontend/src/components/feed/Carousel/Carousel.styled.ts
@@ -23,22 +23,6 @@ export const Slides = styled.div<{ currentPage: number }>`
   transform: ${({ currentPage }) => `translateX(-${currentPage - 1}00%)`};
 `;
 
-export const Slide = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex: 1 0 100%;
-
-  width: 100%;
-  height: 100%;
-  padding: 0 100px;
-
-  & > img {
-    max-width: 100%;
-    max-height: 100%;
-  }
-`;
-
 const buttonWrapper = css`
   display: flex;
   align-items: center;
@@ -78,8 +62,4 @@ export const arrowButton = css`
   & svg > path {
     stroke: ${({ theme }) => theme.color.WHITE};
   }
-`;
-
-export const expiredText = css`
-  color: ${({ theme }) => theme.color.WHITE};
 `;

--- a/frontend/src/components/feed/Carousel/Carousel.tsx
+++ b/frontend/src/components/feed/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 import * as S from './Carousel.styled';
+import CarouselImage from '../CarouselImage/CarouselImage';
 import Button from '~/components/common/Button/Button';
-import Text from '~/components/common/Text/Text';
 import { ArrowLeftIcon, ArrowRightIcon } from '~/assets/svg';
 import type { ThreadImage } from '~/types/feed';
 
@@ -30,16 +30,8 @@ const Carousel = (props: CarouselProps) => {
     <S.Container width={width} height={height}>
       <S.SlidesView>
         <S.Slides currentPage={currentPage}>
-          {images.map(({ id, isExpired, url, name }) => (
-            <S.Slide key={id}>
-              {isExpired ? (
-                <Text as="span" size="xxl" css={S.expiredText}>
-                  이 이미지는 기간이 만료되었습니다.
-                </Text>
-              ) : (
-                <img src={url} alt={name} />
-              )}
-            </S.Slide>
+          {images.map((image) => (
+            <CarouselImage key={image.id} image={image} />
           ))}
         </S.Slides>
       </S.SlidesView>

--- a/frontend/src/components/feed/CarouselImage/CarouselImage.stories.tsx
+++ b/frontend/src/components/feed/CarouselImage/CarouselImage.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Carousel from '~/components/feed/Carousel/Carousel';
+
+/**
+ * `CarouselImage`는 `Carousel` 컴포넌트에 표시되는 하나의 이미지를 이루는 컴포넌트입니다. 이미지에 문제가 있어 표시할 수 없을 경우에는 관련된 오류 메시지를 대신 보여주게 됩니다.
+ */
+const meta = {
+  title: 'feed/Carousel',
+  component: Carousel,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div
+        style={{ backgroundColor: 'black', width: '700px', height: '500px' }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Carousel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const image = [
+  {
+    id: 9283,
+    isExpired: false,
+    name: 'neon.png',
+    url: 'https://images.unsplash.com/photo-1508700115892-45ecd05ae2ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
+  },
+  {
+    id: 4165,
+    isExpired: false,
+    name: 'donut.png',
+    url: 'https://images.unsplash.com/photo-1551106652-a5bcf4b29ab6?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1965&q=80',
+  },
+  {
+    id: 8729,
+    isExpired: false,
+    name: 'zXwMd93Xwz2V03M5xAw_fVmxzEwNiDv_93-xVm__902XvC-2XzOqPdR93F3Xz_24RzV01IjSwmOkVeZmIoPlLliFmMVc2__s9Xz.png',
+    url: 'https://images.unsplash.com/photo-1591382386627-349b692688ff?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
+  },
+  {
+    id: 1092,
+    isExpired: false,
+    name: 'icon.png',
+    url: 'https://img.icons8.com/?size=256&id=VUoFEYkLOaMn&format=png&color=1A6DFF,C822FF',
+  },
+  {
+    id: 3493,
+    isExpired: true,
+    name: '만료된 사진',
+    url: '',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    image: {
+      id: 9283,
+      isExpired: false,
+      name: 'neon.png',
+      url: 'https://images.unsplash.com/photo-1508700115892-45ecd05ae2ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
+    },
+  },
+};

--- a/frontend/src/components/feed/CarouselImage/CarouselImage.stories.tsx
+++ b/frontend/src/components/feed/CarouselImage/CarouselImage.stories.tsx
@@ -1,66 +1,65 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Carousel from '~/components/feed/Carousel/Carousel';
+import CarouselImage from '~/components/feed/CarouselImage/CarouselImage';
 
 /**
  * `CarouselImage`는 `Carousel` 컴포넌트에 표시되는 하나의 이미지를 이루는 컴포넌트입니다. 이미지에 문제가 있어 표시할 수 없을 경우에는 관련된 오류 메시지를 대신 보여주게 됩니다.
  */
 const meta = {
-  title: 'feed/Carousel',
-  component: Carousel,
+  title: 'feed/CarouselImage',
+  component: CarouselImage,
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div
-        style={{ backgroundColor: 'black', width: '700px', height: '500px' }}
-      >
+      <div style={{ backgroundColor: 'black', width: '100%', height: '500px' }}>
         <Story />
       </div>
     ),
   ],
-} satisfies Meta<typeof Carousel>;
+  argTypes: {
+    image: {
+      description:
+        '컴포넌트에 표시할 이미지의 정보를 의미합니다. 유효하지 않은 이미지의 url이 주어져도 상관 없습니다.',
+    },
+  },
+} satisfies Meta<typeof CarouselImage>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
-
-const image = [
-  {
-    id: 9283,
-    isExpired: false,
-    name: 'neon.png',
-    url: 'https://images.unsplash.com/photo-1508700115892-45ecd05ae2ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
-  },
-  {
-    id: 4165,
-    isExpired: false,
-    name: 'donut.png',
-    url: 'https://images.unsplash.com/photo-1551106652-a5bcf4b29ab6?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1965&q=80',
-  },
-  {
-    id: 8729,
-    isExpired: false,
-    name: 'zXwMd93Xwz2V03M5xAw_fVmxzEwNiDv_93-xVm__902XvC-2XzOqPdR93F3Xz_24RzV01IjSwmOkVeZmIoPlLliFmMVc2__s9Xz.png',
-    url: 'https://images.unsplash.com/photo-1591382386627-349b692688ff?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
-  },
-  {
-    id: 1092,
-    isExpired: false,
-    name: 'icon.png',
-    url: 'https://img.icons8.com/?size=256&id=VUoFEYkLOaMn&format=png&color=1A6DFF,C822FF',
-  },
-  {
-    id: 3493,
-    isExpired: true,
-    name: '만료된 사진',
-    url: '',
-  },
-];
 
 export const Default: Story = {
   args: {
     image: {
       id: 9283,
       isExpired: false,
+      name: 'neon.png',
+      url: 'https://images.unsplash.com/photo-1508700115892-45ecd05ae2ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
+    },
+  },
+};
+
+/**
+ * API 서버 측에서 이 이미지가 만료되었음을 명시하지 않았으나, 실제로 이미지를 로드한 결과 이미지의 url이 올바르지 않아 깨진 경우입니다.
+ */
+export const CorruptedImage: Story = {
+  args: {
+    image: {
+      id: 9834,
+      isExpired: false,
+      name: 'neon.png',
+      url: 'https://chicken-meokko-shipda.com/yangnium/ganjang/chicken.jpg',
+    },
+  },
+};
+
+/**
+ * API 서버 측에서 이 이미지가 만료되었음을 명시한 경우입니다.
+ */
+export const ExpiredImage: Story = {
+  args: {
+    image: {
+      id: 4657,
+      isExpired: true,
       name: 'neon.png',
       url: 'https://images.unsplash.com/photo-1508700115892-45ecd05ae2ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
     },

--- a/frontend/src/components/feed/CarouselImage/CarouselImage.styled.ts
+++ b/frontend/src/components/feed/CarouselImage/CarouselImage.styled.ts
@@ -1,0 +1,21 @@
+import { styled, css } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1 0 100%;
+
+  width: 100%;
+  height: 100%;
+  padding: 0 100px;
+
+  & > img {
+    max-width: 100%;
+    max-height: 100%;
+  }
+`;
+
+export const errorText = css`
+  color: ${({ theme }) => theme.color.WHITE};
+`;

--- a/frontend/src/components/feed/CarouselImage/CarouselImage.tsx
+++ b/frontend/src/components/feed/CarouselImage/CarouselImage.tsx
@@ -1,0 +1,39 @@
+import Text from '~/components/common/Text/Text';
+import type { ThreadImage } from '~/types/feed';
+import { useState } from 'react';
+import * as S from './CarouselImage.styled';
+
+interface CarouselImageProps {
+  image: ThreadImage;
+}
+
+const CarouselImage = (props: CarouselImageProps) => {
+  const { image } = props;
+  const { isExpired, name, url } = image;
+  const [errorMessage, setErrorMessage] = useState<string | null>(
+    isExpired ? '이 이미지는 기간이 만료되었습니다.' : null,
+  );
+
+  return (
+    <S.Container>
+      {errorMessage ? (
+        <Text as="span" size="xxl" css={S.errorText}>
+          {errorMessage}
+        </Text>
+      ) : (
+        <img
+          src={url}
+          alt={name}
+          onError={() =>
+            setErrorMessage(
+              () =>
+                '이미지를 표시하는 데 실패했습니다. 올바르지 않은 형식의 이미지거나, 이미지가 손상되었을 수 있습니다.',
+            )
+          }
+        />
+      )}
+    </S.Container>
+  );
+};
+
+export default CarouselImage;

--- a/frontend/src/components/feed/CarouselImage/CarouselImage.tsx
+++ b/frontend/src/components/feed/CarouselImage/CarouselImage.tsx
@@ -27,7 +27,7 @@ const CarouselImage = (props: CarouselImageProps) => {
           onError={() =>
             setErrorMessage(
               () =>
-                '이미지를 표시하는 데 실패했습니다. 올바르지 않은 형식의 이미지거나, 이미지가 손상되었을 수 있습니다.',
+                '이미지를 표시하는 데 실패했습니다.\n올바르지 않은 형식의 이미지거나, 이미지가 손상되었을 수 있습니다.',
             )
           }
         />

--- a/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.tsx
+++ b/frontend/src/components/feed/DeletableThumbnail/DeletableThumbnail.tsx
@@ -1,7 +1,9 @@
 import * as S from './DeletableThumbnail.styled';
 import Button from '~/components/common/Button/Button';
 import { CloseBoldIcon } from '~/assets/svg';
+import type { SyntheticEvent } from 'react';
 import type { PreviewImage } from '~/types/feed';
+import { thumbnailFallbackImage } from '~/assets/png';
 
 interface DeletableThumbnailProps {
   image: PreviewImage;
@@ -12,9 +14,14 @@ const DeletableThumbnail = (props: DeletableThumbnailProps) => {
   const { image, onDelete } = props;
   const { uuid, url } = image;
 
+  const handleImageError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+    e.currentTarget.src = thumbnailFallbackImage;
+    e.currentTarget.alt = '손상된 이미지';
+  };
+
   return (
     <S.Container>
-      <S.Image src={url} alt="미리보기 이미지" />
+      <S.Image src={url} alt="미리보기 이미지" onError={handleImageError} />
       <Button
         variant="plain"
         type="button"

--- a/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.styled.ts
+++ b/frontend/src/components/feed/ImageUploadDrawer/ImageUploadDrawer.styled.ts
@@ -13,7 +13,7 @@ export const Container = styled.div<{ isOpen: boolean }>`
   background: linear-gradient(30deg, #bfc3ff, #eaebff);
 
   transition: 0.35s;
-  transform: translateY(${({ isOpen }) => (isOpen ? '-168px' : '0')});
+  transform: translateY(${({ isOpen }) => (isOpen ? '-163px' : '0')});
 `;
 
 export const ContentWrapper = styled.div`

--- a/frontend/src/components/feed/PageIndicator/PageIndicator.styled.ts
+++ b/frontend/src/components/feed/PageIndicator/PageIndicator.styled.ts
@@ -23,24 +23,24 @@ export const DotIndicator = styled.div`
 `;
 
 export const Dot = styled.button<{ selected: boolean }>`
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 
   border-radius: 50%;
   background-color: ${({ theme, selected }) =>
-    selected ? theme.color.WHITE : theme.color.GRAY600};
+    selected ? theme.color.WHITE : theme.color.GRAY550};
 
   transition: 0.2s;
 `;
 
 export const currentPageText = css`
   color: ${({ theme }) => theme.color.WHITE};
-  font-size: 40px;
-  line-height: 40px;
+  font-size: 34px;
+  line-height: 34px;
 `;
 
 export const pageCountText = css`
-  color: ${({ theme }) => theme.color.GRAY600};
-  font-size: 28px;
-  line-height: 34px;
+  color: ${({ theme }) => theme.color.GRAY550};
+  font-size: 24px;
+  line-height: 30px;
 `;

--- a/frontend/src/components/feed/ThreadImageModal/ThreadImageModal.styled.ts
+++ b/frontend/src/components/feed/ThreadImageModal/ThreadImageModal.styled.ts
@@ -11,7 +11,7 @@ export const Container = styled.div`
   height: 100%;
 
   background: ${({ theme }) => theme.gradient.SMOOTH_BLACK};
-  backdrop-filter: blur(20px);
+  backdrop-filter: blur(10px);
 `;
 
 export const HeaderWrapper = styled.div`
@@ -38,7 +38,7 @@ export const PageIndicatorWrapper = styled.div`
 export const title = css`
   overflow: hidden;
 
-  font-size: 32px;
+  font-size: 26px;
   color: ${({ theme }) => theme.color.WHITE};
   line-height: 40px;
   white-space: nowrap;
@@ -46,14 +46,14 @@ export const title = css`
 `;
 
 export const closeButton = css`
-  width: 60px;
-  height: 60px;
+  width: 48px;
+  height: 48px;
   padding: 5px;
 
   color: ${({ theme }) => theme.color.WHITE};
 
   & svg {
-    width: 50px;
-    height: 50px;
+    width: 38px;
+    height: 38px;
   }
 `;

--- a/frontend/src/components/feed/ViewableThumbnail/ViewableThumbnail.tsx
+++ b/frontend/src/components/feed/ViewableThumbnail/ViewableThumbnail.tsx
@@ -1,6 +1,7 @@
 import * as S from './ViewableThumbnail.styled';
 import Button from '~/components/common/Button/Button';
 import type { ThreadImage } from '~/types/feed';
+import type { SyntheticEvent } from 'react';
 import { thumbnailFallbackImage } from '~/assets/png';
 
 interface ViewableThumbnailProps {
@@ -13,6 +14,11 @@ const ViewableThumbnail = (props: ViewableThumbnailProps) => {
   const { image, size = 'md', onClick } = props;
   const { isExpired, name, url } = image;
 
+  const handleImageError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+    e.currentTarget.src = thumbnailFallbackImage;
+    e.currentTarget.alt = '손상된 이미지';
+  };
+
   return (
     <S.Container size={size}>
       <Button
@@ -22,7 +28,11 @@ const ViewableThumbnail = (props: ViewableThumbnailProps) => {
         onClick={onClick}
         aria-label={`${name} 이미지 자세히 보기`}
       >
-        <S.Image src={isExpired ? thumbnailFallbackImage : url} alt={name} />
+        <S.Image
+          src={isExpired ? thumbnailFallbackImage : url}
+          alt={name}
+          onError={handleImageError}
+        />
       </Button>
     </S.Container>
   );

--- a/frontend/src/mocks/fixtures/threads.ts
+++ b/frontend/src/mocks/fixtures/threads.ts
@@ -18,7 +18,7 @@ const images = [
     id: 1092,
     isExpired: false,
     name: 'icon.png',
-    url: 'https://img.icons8.com/?size=256&id=VUoFEYkLOaMn&format=png&color=1A6DFF,C822FF',
+    url: 'https://wrong-link.com/must-show-fallback.png',
   },
   {
     id: 3493,

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -19,6 +19,7 @@ const color = {
   GRAY350: '#c9c9c9',
   GRAY400: '#b0b8c1',
   GRAY500: '#8b95a1',
+  GRAY550: '#848484',
   GRAY600: '#6b7684',
   GRAY700: '#4e5968',
   GRAY800: '#333d4b',

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,14 +1,14 @@
 import { keyframes } from 'styled-components';
 
 const color = {
-  LOGO: '#3145FF',
-  PRIMARY: '#516FFF',
-  PRIMARY200: '#B7BAFF',
-  PRIMARY900: '#5054FF',
+  LOGO: '#3145ff',
+  PRIMARY: '#516Fff',
+  PRIMARY200: '#b7baff',
+  PRIMARY900: '#5054ff',
   WHITE: '#fff',
   BLACK: '#000',
-  RED: '#FF5B5B',
-  PURPLE: '#6E61ff',
+  RED: '#ff5b5b',
+  PURPLE: '#6e61ff',
 
   NAVY: '#303650',
 
@@ -39,21 +39,21 @@ const color = {
 } as const;
 
 const teamColor = {
-  0: '#4886FF',
-  1: '#FF66F9',
-  2: '#FF6666',
-  3: '#8E1DFF',
+  0: '#4886ff',
+  1: '#ff66F9',
+  2: '#ff6666',
+  3: '#8e1dff',
   4: '#707070',
-  5: '#003E86',
-  6: '#B900B2',
-  7: '#9D1C1C',
-  8: '#46008C',
-  9: '#4C4C4C',
+  5: '#003e86',
+  6: '#b900b2',
+  7: '#9d1c1c',
+  8: '#46008c',
+  9: '#4c4c4c',
   100: '#fff',
 } as const;
 
 const gradient = {
-  SMOOTH_BLACK: 'linear-gradient(45deg, #121212, #303030)',
+  SMOOTH_BLACK: 'linear-gradient(45deg, #797979aa, #a0a0a0aa)',
   WHITE: (pixels: `${number}px`) =>
     `linear-gradient(to top, #eaeaea 0%, #eaeaea ${pixels}, transparent 100%)`,
   BLURPLE: (pixels: `${number}px`) =>


### PR DESCRIPTION
# [FE] 이미지가 깨지는 경우에 대해 적절히 예외처리 할 수 있도록 개선
## 이슈번호
> close #750

- styled-components prop 관련 리팩토링은 미포함

## PR 내용

본 PR에서는 이미지가 깨지는 상황에 보다 유연하게 동작할 수 있도록, 이미지가 깨질 경우에 대한 예외처리가 가능하도록 개선하였다. 이미지가 깨지는 원인은 다양하지만 백엔드에서 잘못된 형식의 이미지를 내려주는 경우, 인터넷 연결이 불안정해 이미지의 로딩이 실패하는 등 여러 요인이 있을 것이다.
- 여기서 이미지가 **깨진다** 는 것은, 이미지가 만료되지는 않았으나 손상된 이미지의 `src` 를 지니게 되어 이미지가 보이지 않고 `alt` 텍스트가 보이는 문제를 의미한다.
<img src="https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/7736d5c7-641e-46e3-9f56-cc61fb5b58e8" width="350px" />  

#### 아래의 사항을 개선하였다.

1. 썸네일 컴포넌트에 보여져야 하는 이미지가 깨졌을 경우, 만료되었을 때와 마찬가지로 대체 이미지를 보여주도록 개선하였다.
2. 이미지 모달에 보여져야 하는 이미지가 깨졌을 경우, 이미지가 깨졌음을 알리는 대체 텍스트를 대신 띄워 사용자에게 이를 알릴 수 있도록 개선하였다.

#### 또한, 이슈와 직접적인 관련은 없지만 아래의 사항도 개선하였다.

1. 이미지 서랍장 모달이 정확하게 맞지 않아 위치를 교정하였다.
2. @suyoungj 의 제안으로 이미지 모달의 디자인을 좀 더 프로젝트에 연관성이 있도록 수정해 보았다.
  - UX에 무리가 가지 않는 선에서 제목/닫기 버튼/인디케이터의 크기 축소
  - 배경색을 밝게 하고, 다소 투명하게 변경
3. `theme` 파일의 HEX 코드를 모두 영소문자로 통일하였다.

## 참고자료
- 1번 기능
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/914a4317-5b6a-442a-a7ea-c08e0c2524e2)

- 2번 기능
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/13392139-4d59-4a87-bda0-b60836e68fb9)


## 의논할 거리
여담으로 이미지 모달의 경우 `blur` 가 처음부터 있는 상황이었더라...?