### PR TITLE
[FE] iCalendar url에 placeholder 적용하여 빈 input을 보지 않도록 수정

### DIFF
--- a/frontend/src/hooks/queries/useFetchICalendarUrl.ts
+++ b/frontend/src/hooks/queries/useFetchICalendarUrl.ts
@@ -11,6 +11,7 @@ export const useFetchICalendarUrl = (teamPlaceId: number) => {
         errorMessage:
           '일정 내보내기에 실패했습니다. \n지속되는 경우 관리자에게 문의해주세요.',
       },
+      placeholderData: { url: 'https://assets.teamby.team/dev/ical/1' },
     },
   );
 

--- a/frontend/src/hooks/queries/useFetchICalendarUrl.ts
+++ b/frontend/src/hooks/queries/useFetchICalendarUrl.ts
@@ -11,7 +11,7 @@ export const useFetchICalendarUrl = (teamPlaceId: number) => {
         errorMessage:
           '일정 내보내기에 실패했습니다. \n지속되는 경우 관리자에게 문의해주세요.',
       },
-      placeholderData: { url: 'https://assets.teamby.team/dev/ical/1' },
+      placeholderData: { url: 'https://assets.teamby.team/prod/ical/1' },
     },
   );
 

--- a/frontend/src/mocks/handlers/calendar.ts
+++ b/frontend/src/mocks/handlers/calendar.ts
@@ -156,8 +156,9 @@ export const calendarHandlers = [
     return res(
       ctx.status(200),
       ctx.json({
-        url: 'https://assets.teamby.team/icalendar/path/ical.ics',
+        url: 'https://assets.teamby.team/dev/ical/1-5',
       }),
+      ctx.delay(1000),
     );
   }),
 ];

--- a/frontend/src/mocks/handlers/calendar.ts
+++ b/frontend/src/mocks/handlers/calendar.ts
@@ -156,7 +156,7 @@ export const calendarHandlers = [
     return res(
       ctx.status(200),
       ctx.json({
-        url: 'https://assets.teamby.team/dev/ical/1-5',
+        url: 'https://assets.teamby.team/prod/ical/1-5',
       }),
       ctx.delay(1000),
     );


### PR DESCRIPTION
## PR 내용
- iCalendar url에 placeholder 적용하여 빈 input을 보지 않도록 수정
- url이 고정되어 있으므로 빈 input 대신 url 일부를 사용자에게 미리 보여줌