### PR TITLE
[BE] 피드 최신조회에 인메모리 캐싱 추가

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -45,10 +45,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static team.teamby.teambyteam.feed.application.event.FeedEvent.Status.WRITE;
 

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -169,7 +169,11 @@ public class FeedThreadService {
 
         final List<FeedCache> caches = feedCache.getCache(teamPlaceId, size);
         return caches.stream()
-                .map(cache -> FeedResponse.from(cache, teamPlaceMembers.get(cache.authorId()), memberId))
+                .map(cache -> FeedResponse.from(
+                        cache,
+                        teamPlaceMembers.getOrDefault(cache.authorId(), MemberTeamPlace.UNKNOWN_MEMBER_TEAM_PLACE),
+                        memberId)
+                )
                 .toList();
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
@@ -1,9 +1,20 @@
 package team.teamby.teambyteam.feed.application.dto;
 
+import team.teamby.teambyteam.feed.domain.cache.RecentFeedCache;
+import team.teamby.teambyteam.feed.domain.cache.RecentFeedCache.FeedImageCache;
+
 public record FeedImageResponse(
         Long id,
         Boolean isExpired,
         String name,
         String url
 ) {
+    public static FeedImageResponse from(final FeedImageCache feedImageCache) {
+        return new FeedImageResponse(
+                feedImageCache.id(),
+                feedImageCache.isExpired(),
+                feedImageCache.name(),
+                feedImageCache.url()
+        );
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -1,11 +1,14 @@
 package team.teamby.teambyteam.feed.application.dto;
 
 import team.teamby.teambyteam.feed.domain.Feed;
+import team.teamby.teambyteam.feed.domain.cache.RecentFeedCache;
+import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public record FeedResponse(
         Long id,
@@ -50,6 +53,27 @@ public record FeedResponse(
                 feed.getContent().getValue(),
                 images,
                 threadAuthorInfo.isEmailEqual(loginMemberEmail)
+        );
+    }
+
+    public static FeedResponse from(
+            final RecentFeedCache.FeedCache cache,
+            final MemberTeamPlace authorInfo,
+            final IdOnly memberId
+    ) {
+        return new FeedResponse(
+                cache.id(),
+                cache.type(),
+                cache.authorId(),
+                authorInfo.getDisplayMemberNameValue(),
+                cache.profileImageUrl(),
+                cache.createdAt(),
+                cache.content(),
+                cache.images()
+                        .stream()
+                        .map(FeedImageResponse::from)
+                        .toList(),
+                Objects.equals(cache.authorId(), memberId.id())
         );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -66,8 +66,8 @@ public record FeedResponse(
                 cache.type(),
                 cache.authorId(),
                 authorInfo.getDisplayMemberNameValue(),
-                cache.profileImageUrl(),
-                cache.createdAt(),
+                authorInfo.findMemberProfileImageUrl(),
+                cache.createdAt().format(DATE_TIME_FORMATTER),
                 cache.content(),
                 cache.images()
                         .stream()

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/InMemoryRecentFeedCache.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/InMemoryRecentFeedCache.java
@@ -4,7 +4,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -18,8 +17,6 @@ public class InMemoryRecentFeedCache implements RecentFeedCache {
 
     public static final long CACHE_REMOVE_POLICY_DAY = 3L;
     private final int MAX_CACHE_FEED_SIZE = 20;
-    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
 
     private final Map<Long, Deque<FeedCache>> feedCaches = new ConcurrentHashMap<>();
 
@@ -54,7 +51,7 @@ public class InMemoryRecentFeedCache implements RecentFeedCache {
         final LocalDateTime cacheRemoveDateTime = LocalDateTime.now().minusDays(CACHE_REMOVE_POLICY_DAY);
         feedCaches.forEach((key, value) -> {
             final FeedCache latest = value.getFirst();
-            final LocalDateTime latestDateTime = LocalDateTime.parse(latest.createdAt(), DATE_TIME_FORMATTER);
+            final LocalDateTime latestDateTime = latest.createdAt();
             if (latestDateTime.isBefore(cacheRemoveDateTime)) {
                 feedCaches.remove(key);
             }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/InMemoryRecentFeedCache.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/InMemoryRecentFeedCache.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class InMemoryRecentFeedCache implements RecentFeedCache {
 
     public static final long CACHE_REMOVE_POLICY_DAY = 3L;
-    private final int MAX_CACHE_FEED_SIZE = 20;
+    public static final int MAX_CACHE_FEED_SIZE = 20;
 
     private final Map<Long, Deque<FeedCache>> feedCaches = new ConcurrentHashMap<>();
 

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/RecentFeedCache.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/RecentFeedCache.java
@@ -1,0 +1,31 @@
+package team.teamby.teambyteam.feed.domain.cache;
+
+import java.util.List;
+
+public interface RecentFeedCache {
+
+    boolean isCached(final Long teamPlaceId, final int size);
+
+    List<FeedCache> getCache(final Long teamPlaceId, final int size);
+
+    void addCache(final Long teamPlaceId, final FeedCache cache);
+
+    record FeedCache(
+            Long id,
+            String type,
+            Long authorId,
+            String profileImageUrl,
+            String createdAt,
+            String content,
+            List<FeedImageCache> images
+    ) {
+    }
+
+    record FeedImageCache(
+            Long id,
+            Boolean isExpired,
+            String name,
+            String url
+    ) {
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/RecentFeedCache.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/cache/RecentFeedCache.java
@@ -1,5 +1,9 @@
 package team.teamby.teambyteam.feed.domain.cache;
 
+import team.teamby.teambyteam.feed.domain.FeedThread;
+import team.teamby.teambyteam.feed.domain.image.FeedThreadImage;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RecentFeedCache {
@@ -14,11 +18,22 @@ public interface RecentFeedCache {
             Long id,
             String type,
             Long authorId,
-            String profileImageUrl,
-            String createdAt,
+            LocalDateTime createdAt,
             String content,
             List<FeedImageCache> images
     ) {
+        public static FeedCache from(final FeedThread feedThread) {
+            return new FeedCache(
+                    feedThread.getId(),
+                    feedThread.getType().name(),
+                    feedThread.getAuthorId(),
+                    feedThread.getCreatedAt(),
+                    feedThread.getContent().getValue(),
+                    feedThread.getImages().stream()
+                            .map(FeedImageCache::from)
+                            .toList()
+            );
+        }
     }
 
     record FeedImageCache(
@@ -27,5 +42,13 @@ public interface RecentFeedCache {
             String name,
             String url
     ) {
+        public static FeedImageCache from(final FeedThreadImage feedThreadImage) {
+            return new FeedImageCache(
+                    feedThreadImage.getId(),
+                    false,
+                    feedThreadImage.getImageName().getValue(),
+                    feedThreadImage.getImageUrl().getValue()
+            );
+        }
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadServiceTest.java
@@ -25,6 +25,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,7 @@ import team.teamby.teambyteam.feed.application.dto.FeedsResponse;
 import team.teamby.teambyteam.feed.domain.Feed;
 import team.teamby.teambyteam.feed.domain.FeedThread;
 import team.teamby.teambyteam.feed.domain.FeedType;
+import team.teamby.teambyteam.feed.domain.cache.RecentFeedCache;
 import team.teamby.teambyteam.feed.domain.notification.schedulenotification.ScheduleNotification;
 import team.teamby.teambyteam.feed.domain.vo.Content;
 import team.teamby.teambyteam.feed.exception.FeedException;
@@ -67,8 +69,18 @@ class FeedThreadServiceTest extends ServiceTest {
     @MockBean
     private FileCloudUploader fileCloudUploader;
 
+    @MockBean
+    private RecentFeedCache recentFeedCache;
+
     @SpyBean
     private Clock clock;
+
+    @BeforeEach
+    void invalidateCaching() {
+        given(recentFeedCache.isCached(any(Long.class), any(int.class)))
+                .willReturn(false);
+
+    }
 
     @Nested
     @DisplayName("피드에 스레드 작성시")

--- a/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadWithCacheServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/application/FeedThreadWithCacheServiceTest.java
@@ -1,0 +1,80 @@
+package team.teamby.teambyteam.feed.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.web.multipart.MultipartFile;
+import team.teamby.teambyteam.common.ServiceTest;
+import team.teamby.teambyteam.feed.domain.FeedRepository;
+import team.teamby.teambyteam.filesystem.FileCloudUploader;
+import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.CONTENT_AND_IMAGE_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.FeedThreadFixtures.CONTENT_ONLY_REQUEST;
+import static team.teamby.teambyteam.common.fixtures.MemberFixtures.PHILIP;
+import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
+import static team.teamby.teambyteam.feed.domain.cache.InMemoryRecentFeedCache.MAX_CACHE_FEED_SIZE;
+
+class FeedThreadWithCacheServiceTest extends ServiceTest {
+
+    @SpyBean
+    private FeedRepository feedRepository;
+
+    @MockBean
+    private FileCloudUploader fileCloudUploader;
+
+    @Autowired
+    private FeedThreadService feedThreadService;
+
+    @BeforeEach
+    void setup() {
+        given(fileCloudUploader.upload(any(MultipartFile.class), any(String.class), any(String.class)))
+                .willReturn("https://s3://seongha-seeik");
+    }
+
+    @Test
+    @DisplayName("캐시에서 정보를 가져온다.")
+    void readFromCache() {
+        final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+        final Member author = testFixtureBuilder.buildMember(PHILIP());
+        testFixtureBuilder.buildMemberTeamPlace(author, teamPlace);
+
+        // when
+        final MemberEmailDto memberEmailDto = new MemberEmailDto(author.getEmail().getValue());
+        feedThreadService.write(CONTENT_ONLY_REQUEST, memberEmailDto, teamPlace.getId());
+        feedThreadService.write(CONTENT_AND_IMAGE_REQUEST, memberEmailDto, teamPlace.getId());
+
+        feedThreadService.firstRead(teamPlace.getId(), memberEmailDto, 2);
+
+        // then
+        verify(feedRepository, never()).findByTeamPlaceId(any(), any());
+    }
+
+    @Test
+    @DisplayName("db에서 정보를 가져온다.")
+    void readFromDb() {
+        final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+        final Member author = testFixtureBuilder.buildMember(PHILIP());
+        testFixtureBuilder.buildMemberTeamPlace(author, teamPlace);
+
+        // when
+        final MemberEmailDto memberEmailDto = new MemberEmailDto(author.getEmail().getValue());
+        feedThreadService.write(CONTENT_ONLY_REQUEST, memberEmailDto, teamPlace.getId());
+        feedThreadService.write(CONTENT_AND_IMAGE_REQUEST, memberEmailDto, teamPlace.getId());
+
+        feedThreadService.firstRead(teamPlace.getId(), memberEmailDto, MAX_CACHE_FEED_SIZE + 1);
+
+        // then
+        verify(feedRepository, times(1)).findByTeamPlaceId(any(), any());
+    }
+}

--- a/backend/src/test/java/team/teamby/teambyteam/feed/domain/cache/InMemoryRecentFeedCacheTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/feed/domain/cache/InMemoryRecentFeedCacheTest.java
@@ -1,0 +1,121 @@
+package team.teamby.teambyteam.feed.domain.cache;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import team.teamby.teambyteam.common.fixtures.FeedThreadFixtures;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryRecentFeedCacheTest {
+
+    private RecentFeedCache recentFeedCache;
+
+    @BeforeEach
+    void setup() {
+        recentFeedCache = new InMemoryRecentFeedCache();
+    }
+
+    @Nested
+    @DisplayName("캐시 여부 확인 테스트")
+    class IsCachedTest {
+
+        @Test
+        @DisplayName("케시가 저장되지 않은 팀플레이스 아이디는 isCached가 flase를 반환한다.")
+        void falseWithUnCachedTeamPlace() {
+            // given
+            final long teamPlaceId = 1L;
+            final long authorId = 2L;
+            recentFeedCache.addCache(teamPlaceId, RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_AND_IMAGE(teamPlaceId, authorId)));
+
+            // when
+            final boolean cached = recentFeedCache.isCached(2L, 0);
+
+            // then
+            assertThat(cached).isFalse();
+        }
+
+        @Test
+        @DisplayName("저장된 케시 수보다 많은 수로 요청하면 false를 반환한다.")
+        void falseWithLessCachedTeamPlace() {
+            // given
+            final long teamPlaceId = 1L;
+            final long authorId = 2L;
+            recentFeedCache.addCache(teamPlaceId, RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_AND_IMAGE(teamPlaceId, authorId)));
+
+            // when
+            final boolean cached = recentFeedCache.isCached(teamPlaceId, 2);
+
+            // then
+            assertThat(cached).isFalse();
+        }
+
+        @Test
+        @DisplayName("저장된 케시가 있으면 true를 반환한다")
+        void trueWithCachedData() {
+            final long teamPlaceId = 1L;
+            final long authorId = 2L;
+            recentFeedCache.addCache(teamPlaceId, RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_AND_IMAGE(teamPlaceId, authorId)));
+
+            // when
+            final boolean cached = recentFeedCache.isCached(teamPlaceId, 1);
+
+            // then
+            assertThat(cached).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("캐시 추가 및 가져오기 테스트")
+    void test() {
+        // given
+        final long teamPlaceId = 1L;
+        final long authorId = 2L;
+        final RecentFeedCache.FeedCache cache1 = RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_AND_IMAGE(teamPlaceId, authorId));
+        final RecentFeedCache.FeedCache cache2 = RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_ONLY_AND_IMAGE_EMPTY(teamPlaceId, authorId));
+
+        // when
+        recentFeedCache.addCache(teamPlaceId, cache1);
+        recentFeedCache.addCache(teamPlaceId, cache2);
+        final List<RecentFeedCache.FeedCache> cachedData = recentFeedCache.getCache(teamPlaceId, 2);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(cachedData.get(0)).usingRecursiveComparison()
+                    .isEqualTo(cache2);
+            softly.assertThat(cachedData.get(1)).usingRecursiveComparison()
+                    .isEqualTo(cache1);
+        });
+    }
+
+    @Test
+    @DisplayName("캐시의 수는 20개로 고정이된다")
+    void maximumCacheCountIs20() {
+        // given
+        final long teamPlaceId = 1L;
+        final long authorId = 2L;
+        final RecentFeedCache.FeedCache cache1 = RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_AND_IMAGE(teamPlaceId, authorId));
+        final RecentFeedCache.FeedCache cache2 = RecentFeedCache.FeedCache.from(FeedThreadFixtures.CONTENT_ONLY_AND_IMAGE_EMPTY(teamPlaceId, authorId));
+
+        // when
+        for (int i = 0; i < 20; i++) {
+            recentFeedCache.addCache(teamPlaceId, cache1);
+        }
+        recentFeedCache.addCache(teamPlaceId, cache2);
+
+        final boolean cached = recentFeedCache.isCached(teamPlaceId, 21);
+        final List<RecentFeedCache.FeedCache> cachedData = recentFeedCache.getCache(teamPlaceId, 20);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(cachedData.get(0)).usingRecursiveComparison()
+                    .isEqualTo(cache2);
+            softly.assertThat(cachedData).hasSize(20);
+            softly.assertThat(cached).isFalse();
+        });
+    }
+}


### PR DESCRIPTION
## 이슈번호
> #774

## PR 내용

- 피드 최신정보 조회시 인메모리 캐시에서 글 읽어올 수 있도록 변경
- 캐시정보 없을시 db에서 정보조회
- 캐시정보는 피드 작성시 같이 추가
- 3일이상 활동이 없는팀에 한해 캐시 제거

## 참고자료

## 의논할 거리
