### PR TITLE
[FE] 팀 정보 아이콘 접근 시 prefetching 적용

### DIFF
--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -159,6 +159,7 @@ const Header = () => {
           <Button
             type="button"
             variant="plain"
+            onFocus={prefetchTeamPlaceInfo}
             onMouseEnter={prefetchTeamPlaceInfo}
             onClick={handleTeamButtonClick}
             css={S.teamPlaceInfoButton}


### PR DESCRIPTION
# [FE] 팀 정보 아이콘 접근 시 prefetching 적용
## 이슈번호
> close #826 

## PR 내용
- 팀 정보 아이콘 onFocus, onMouseEnter시 prefetching 적용
- onFocus / onMouseEnter가 일어나면 사용자가 클릭할 것이라 가정하고 데이터를 미리 불러와서 로딩 상태를 보지 않도록 구현했습니다
- 아이디어는 저번에 요토랑 잡담하다 갑자기 생각났습니다
