### PR TITLE
[FE] 이미지 모달의 이미지 전환을 키보드 조작으로 할 수 있도록 개선

### DIFF
--- a/frontend/src/components/feed/Carousel/Carousel.styled.ts
+++ b/frontend/src/components/feed/Carousel/Carousel.styled.ts
@@ -50,9 +50,11 @@ export const closeButton = css`
   height: 40px;
 `;
 
-export const arrowButton = css`
+export const arrowButton = (disabled: boolean) => css`
   width: 90px;
   padding: 0;
+
+  cursor: ${disabled ? 'not-allowed' : 'pointer'};
 
   & svg {
     width: 60px;
@@ -60,6 +62,7 @@ export const arrowButton = css`
   }
 
   & svg > path {
+    opacity: ${disabled ? 0.3 : 1};
     stroke: ${({ theme }) => theme.color.WHITE};
   }
 `;

--- a/frontend/src/components/feed/Carousel/Carousel.styled.ts
+++ b/frontend/src/components/feed/Carousel/Carousel.styled.ts
@@ -1,10 +1,10 @@
 import { styled, css } from 'styled-components';
 
-export const Container = styled.div<{ width: string; height: string }>`
+export const Container = styled.div<{ $width: string; $height: string }>`
   position: relative;
 
-  width: ${({ width }) => width};
-  height: ${({ height }) => height};
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
 `;
 
 export const SlidesView = styled.div`
@@ -15,12 +15,12 @@ export const SlidesView = styled.div`
   padding: 20px 0;
 `;
 
-export const Slides = styled.div<{ currentPage: number }>`
+export const Slides = styled.div<{ $currentPage: number }>`
   display: flex;
   height: 100%;
 
   transition: 0.4s;
-  transform: ${({ currentPage }) => `translateX(-${currentPage - 1}00%)`};
+  transform: ${({ $currentPage }) => `translateX(-${$currentPage - 1}00%)`};
 `;
 
 const buttonWrapper = css`

--- a/frontend/src/components/feed/Carousel/Carousel.tsx
+++ b/frontend/src/components/feed/Carousel/Carousel.tsx
@@ -28,9 +28,9 @@ const Carousel = (props: CarouselProps) => {
   const hasSingleImage = images.length === 1;
 
   return (
-    <S.Container width={width} height={height}>
+    <S.Container $width={width} $height={height}>
       <S.SlidesView>
-        <S.Slides currentPage={currentPage}>
+        <S.Slides $currentPage={currentPage}>
           {images.map((image) => (
             <CarouselImage key={image.id} image={image} />
           ))}

--- a/frontend/src/components/feed/Carousel/Carousel.tsx
+++ b/frontend/src/components/feed/Carousel/Carousel.tsx
@@ -25,6 +25,7 @@ interface CarouselProps {
 
 const Carousel = (props: CarouselProps) => {
   const { width, height, images, currentPage, onChangePage } = props;
+  const hasSingleImage = images.length === 1;
 
   return (
     <S.Container width={width} height={height}>
@@ -39,11 +40,11 @@ const Carousel = (props: CarouselProps) => {
         <Button
           variant="plain"
           type="button"
-          css={S.arrowButton(images.length === 1)}
+          css={S.arrowButton(hasSingleImage)}
           onClick={() =>
             onChangePage(getPreviousPageIndex(images.length, currentPage))
           }
-          disabled={images.length === 1}
+          disabled={hasSingleImage}
           aria-label="이전 이미지 보기"
         >
           <ArrowLeftIcon />
@@ -53,11 +54,11 @@ const Carousel = (props: CarouselProps) => {
         <Button
           variant="plain"
           type="button"
-          css={S.arrowButton(images.length === 1)}
+          css={S.arrowButton(hasSingleImage)}
           onClick={() =>
             onChangePage(getNextPageIndex(images.length, currentPage))
           }
-          disabled={images.length === 1}
+          disabled={hasSingleImage}
           aria-label="다음 이미지 보기"
         >
           <ArrowRightIcon />

--- a/frontend/src/components/feed/Carousel/Carousel.tsx
+++ b/frontend/src/components/feed/Carousel/Carousel.tsx
@@ -39,10 +39,11 @@ const Carousel = (props: CarouselProps) => {
         <Button
           variant="plain"
           type="button"
-          css={S.arrowButton}
+          css={S.arrowButton(images.length === 1)}
           onClick={() =>
             onChangePage(getPreviousPageIndex(images.length, currentPage))
           }
+          disabled={images.length === 1}
           aria-label="이전 이미지 보기"
         >
           <ArrowLeftIcon />
@@ -52,10 +53,11 @@ const Carousel = (props: CarouselProps) => {
         <Button
           variant="plain"
           type="button"
-          css={S.arrowButton}
+          css={S.arrowButton(images.length === 1)}
           onClick={() =>
             onChangePage(getNextPageIndex(images.length, currentPage))
           }
+          disabled={images.length === 1}
           aria-label="다음 이미지 보기"
         >
           <ArrowRightIcon />

--- a/frontend/src/components/feed/ThreadImageModal/ThreadImageModal.tsx
+++ b/frontend/src/components/feed/ThreadImageModal/ThreadImageModal.tsx
@@ -4,8 +4,8 @@ import Modal from '~/components/common/Modal/Modal';
 import Button from '~/components/common/Button/Button';
 import Text from '~/components/common/Text/Text';
 import * as S from './ThreadImageModal.styled';
-import { useState } from 'react';
 import { useModal } from '~/hooks/useModal';
+import { useCarouselPageNo } from '~/hooks/thread/useCarouselPageNo';
 import { CloseIcon } from '~/assets/svg';
 import type { ThreadImage } from '~/types/feed';
 
@@ -17,7 +17,10 @@ interface ThreadImageModalProps {
 const ThreadImageModal = (props: ThreadImageModalProps) => {
   const { images, initialPage } = props;
   const { closeModal } = useModal();
-  const [currentPage, setCurrentPage] = useState(initialPage);
+  const { currentPage, setCurrentPage } = useCarouselPageNo({
+    initialPage,
+    pageCount: images.length,
+  });
 
   return (
     <Modal>

--- a/frontend/src/constants/feed.ts
+++ b/frontend/src/constants/feed.ts
@@ -23,10 +23,3 @@ export const VALID_IMAGE_TYPES = [
 ];
 
 export const MAX_IMAGE_CAPACITY = 5_242_880;
-
-export const KEY_CODE = {
-  DIGIT1: 49,
-  DIGIT9: 57,
-  ARROW_LEFT: 37,
-  ARROW_RIGHT: 39,
-};

--- a/frontend/src/constants/feed.ts
+++ b/frontend/src/constants/feed.ts
@@ -23,3 +23,10 @@ export const VALID_IMAGE_TYPES = [
 ];
 
 export const MAX_IMAGE_CAPACITY = 5_242_880;
+
+export const KEY_CODE = {
+  DIGIT1: 49,
+  DIGIT9: 57,
+  ARROW_LEFT: 37,
+  ARROW_RIGHT: 39,
+};

--- a/frontend/src/hooks/thread/useCarouselPageNo.ts
+++ b/frontend/src/hooks/thread/useCarouselPageNo.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import { KEY_CODE } from '~/constants/feed';
+
+interface UseCarouselPageNoProps {
+  initialPage: number;
+  pageCount: number;
+}
+
+const useCarouselPageNo = (props: UseCarouselPageNoProps) => {
+  const { initialPage, pageCount } = props;
+  const [currentPage, setCurrentPage] = useState(initialPage);
+
+  useEffect(() => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      const { key, keyCode } = e;
+
+      console.log('key press', key);
+
+      if (key >= '1' && key <= '9' && Number(key) <= pageCount) {
+        setCurrentPage(() => Number(key));
+        return;
+      }
+
+      if (
+        keyCode >= KEY_CODE.DIGIT1 &&
+        keyCode <= KEY_CODE.DIGIT9 &&
+        keyCode - 48 <= pageCount
+      ) {
+        setCurrentPage(() => KEY_CODE.DIGIT1 - 48);
+        return;
+      }
+
+      if (key === 'ArrowLeft' || keyCode === KEY_CODE.ARROW_LEFT) {
+        setCurrentPage((prev) => ((prev + pageCount - 2) % pageCount) + 1);
+      }
+
+      if (key === 'ArrowRight' || keyCode === KEY_CODE.ARROW_RIGHT) {
+        setCurrentPage((prev) => (prev % pageCount) + 1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [pageCount]);
+
+  return { currentPage, setCurrentPage };
+};
+
+export { useCarouselPageNo };

--- a/frontend/src/hooks/thread/useCarouselPageNo.ts
+++ b/frontend/src/hooks/thread/useCarouselPageNo.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { KEY_CODE } from '~/constants/feed';
 
 interface UseCarouselPageNoProps {
   initialPage: number;
@@ -12,27 +11,18 @@ const useCarouselPageNo = (props: UseCarouselPageNoProps) => {
 
   useEffect(() => {
     const handleKeyDown = (e: globalThis.KeyboardEvent) => {
-      const { key, keyCode } = e;
+      const { key } = e;
 
       if (key >= '1' && key <= '9' && Number(key) <= pageCount) {
         setCurrentPage(() => Number(key));
         return;
       }
 
-      if (
-        keyCode >= KEY_CODE.DIGIT1 &&
-        keyCode <= KEY_CODE.DIGIT9 &&
-        keyCode - 48 <= pageCount
-      ) {
-        setCurrentPage(() => KEY_CODE.DIGIT1 - 48);
-        return;
-      }
-
-      if (key === 'ArrowLeft' || keyCode === KEY_CODE.ARROW_LEFT) {
+      if (key === 'ArrowLeft') {
         setCurrentPage((prev) => ((prev + pageCount - 2) % pageCount) + 1);
       }
 
-      if (key === 'ArrowRight' || keyCode === KEY_CODE.ARROW_RIGHT) {
+      if (key === 'ArrowRight') {
         setCurrentPage((prev) => (prev % pageCount) + 1);
       }
     };

--- a/frontend/src/hooks/thread/useCarouselPageNo.ts
+++ b/frontend/src/hooks/thread/useCarouselPageNo.ts
@@ -14,8 +14,6 @@ const useCarouselPageNo = (props: UseCarouselPageNoProps) => {
     const handleKeyDown = (e: globalThis.KeyboardEvent) => {
       const { key, keyCode } = e;
 
-      console.log('key press', key);
-
       if (key >= '1' && key <= '9' && Number(key) <= pageCount) {
         setCurrentPage(() => Number(key));
         return;


### PR DESCRIPTION
# [FE] 이미지 모달의 이미지 전환을 키보드 조작으로 할 수 있도록 개선
## 이슈번호
> close #834 

## PR 내용
본 PR에서는 팀 채팅 메뉴에서 쓰이는 이미지 모달의 이미지를 키보드 조작으로도 가능하게 만들어 사용자가 보다 편리하게 기능을 사용할 수 있도록 개선하였다.

### 주요 기능
- `←`, `→` 키를 누르면 이미지를 양옆으로 전환할 수 있다.
- `1` ~ `9` 키를 누르면 누른 숫자 키에 해당하는 번호의 이미지를 보여 준다. 단, 전체 이미지 개수보다 누른 키의 번호가 클 경우에는 아무 일도 일어나지 않는다.

### 보조 기능
- 모달의 이미지가 하나뿐인 경우, 양옆의 이미지 전환 버튼을 비활성화시키고 시각적으로도 전환이 불가능함을 표현하였다.

## 참고자료
- 이미지가 하나뿐이었을 때 버튼이 비활성화되어 시각적으로도 흐리게 표시되며, 마우스 포인터도 `not-allowed` 로 표시된다.

![캡처_2023_10_27_22_50_57_869](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/517b3426-8a30-43d8-a310-875e0424a7a2)


## 의논할 거리
구현 중 `keyDown` 이벤트의 `keyCode` 를 사용했는데, 이 프로퍼티는 사실 deprecated된 프로퍼티로, 사용이 권장되지 않는 상태야. 그럼에도 사용했는데, 이유는 [이 이슈](https://github.com/wzrabbit/boj-totamjung/issues/11)에서 트러블슈팅을 했을 때, 일부 Mac OS 유저에 한해, `key` 프로퍼티에 찍히는 값이 이상한 경우가 간혹 있었더라고.

그래서, 기본적으로 사용이 권장되는 `key` 프로퍼티를 통해 눌린 키가 방향키/숫자키인지 검사하되, 아닐 경우에 `keyCode` 를 사용하여 보조적으로 추가 검증을 하는 방향으로 구현해 보았어.

내가 명확하게 권장되지 않는 걸 쓴 것은 맞으니, 이에 대해서 의논해 보면 좋을 것 같아!