### PR TITLE
[BE] SSE 연결시 케시전송 제거 및 Keep-Alive 설정 추가

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
@@ -54,23 +54,7 @@ public class SseSubscribeService {
         final TeamPlaceEventId dummyEventId = TeamPlaceEventId.of(teamPlaceId, dummyEvent.getEventName());
         emitter.sendEvent(dummyEventId, dummyEvent);
 
-        if (!Objects.isNull(lastEventId) && !lastEventId.isBlank()) {
-            sendCachedEvents(emitter, teamPlaceId, TeamPlaceEventId.from(lastEventId));
-        }
-
         log.info("SSE 연결 생성 {}", emitterId);
         return emitter.getSingleEmitter();
-    }
-
-    private void sendCachedEvents(
-            final SseEmitters emitter,
-            final Long teamPlaceId,
-            final TeamPlaceEventId lastEventId
-    ) {
-        final Map<TeamPlaceEventId, Object> events = teamplaceEmitterRepository.findAllEventCacheWithId(teamPlaceId);
-        events.entrySet().stream()
-                .filter(entry -> entry.getKey().isPublishedAfter(lastEventId))
-                .sorted(EVENT_ID_TIME_COMPARATOR)
-                .forEach(entry -> emitter.sendEvent(entry.getKey(), entry.getValue()));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisher.java
@@ -25,6 +25,5 @@ public class TeamPlaceSsePublisher {
 
         final SseEmitters emitters = teamPlaceEmitterRepository.findByTeamPlaceId(targetTeamPlaceId);
         emitters.sendEvent(eventId, teamPlaceSseEvent);
-        teamPlaceEmitterRepository.addEventCache(eventId, teamPlaceSseEvent.getEvent());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
@@ -14,7 +14,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 public class SseEmitters {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
+    private static final int NUMBER_OF_THREAD = 100;
+    private static final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(NUMBER_OF_THREAD);
 
     private final Map<TeamPlaceEmitterId, SseEmitter> emitters;
 

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -1,11 +1,9 @@
 package team.teamby.teambyteam.sse.domain;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -17,7 +15,6 @@ public class TeamPlaceEmitterRepository {
     private static final int CACHE_REMOVE_MINUTE = 1;
 
     private final Map<TeamPlaceEmitterId, SseEmitter> emitters = new ConcurrentHashMap<>();
-    private final EventCache eventCache = new EventCache();
 
     public SseEmitters save(final TeamPlaceEmitterId emitterId, final SseEmitter sseEmitter) {
         emitters.put(emitterId, sseEmitter);
@@ -51,44 +48,5 @@ public class TeamPlaceEmitterRepository {
 
     public void deleteById(final TeamPlaceEmitterId id) {
         emitters.remove(id);
-    }
-
-    public Map<TeamPlaceEventId, Object> findAllEventCacheWithId(final Long teamPlaceId) {
-        return eventCache.findAllByTeamPlaceId(teamPlaceId);
-    }
-
-    public void addEventCache(final TeamPlaceEventId teamPlaceEventId, final Object event) {
-        eventCache.put(teamPlaceEventId, event);
-    }
-
-    @Scheduled(fixedDelayString = "${sse.cache-schedule-period}")
-    private void cacheRefreshSchedule() {
-        eventCache.clearCacheFor(CACHE_REMOVE_MINUTE);
-    }
-
-    private static class EventCache {
-
-        private final Map<TeamPlaceEventId, Object> cache = new ConcurrentHashMap<>();
-
-        public Map<TeamPlaceEventId, Object> findAllByTeamPlaceId(final Long teamPlaceId) {
-            return cache.entrySet()
-                    .stream()
-                    .filter(entry -> entry.getKey().isPublishedTo(teamPlaceId))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        }
-
-        public void put(final TeamPlaceEventId teamPlaceEventId, final Object event) {
-            cache.put(teamPlaceEventId, event);
-        }
-
-        public void clearCacheFor(final int minutes) {
-            final LocalDateTime now = LocalDateTime.now();
-            cache.keySet().forEach(key -> {
-                        if (key.getTimeStamp().isBefore(now.minusMinutes(minutes))) {
-                            cache.remove(key);
-                        }
-                    }
-            );
-        }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
@@ -21,8 +21,8 @@ public class SseController {
     private static final String NGINX_X_ACCEL_BUFFERING_HEADER = "X-Accel-Buffering";
     private static final String NO = "no";
     private static final String KEEP_ALIVE = "Keep-Alive";
-    private static final String TIMOUT = "timout=";
-    private static final int TIMOUT_VALUE = 5*60;
+    private static final String TIMEOUT = "timout=";
+    private static final int TIMEOUT_VALUE = 5*60;
 
     private final SseSubscribeService sseSubscribeService;
 
@@ -36,7 +36,7 @@ public class SseController {
         return ResponseEntity
                 .ok()
                 .header(NGINX_X_ACCEL_BUFFERING_HEADER, NO)
-                .header(KEEP_ALIVE, TIMOUT + TIMOUT_VALUE)
+                .header(KEEP_ALIVE, TIMEOUT + TIMEOUT_VALUE)
                 .body(emitter);
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
@@ -20,6 +20,9 @@ public class SseController {
 
     private static final String NGINX_X_ACCEL_BUFFERING_HEADER = "X-Accel-Buffering";
     private static final String NO = "no";
+    private static final String KEEP_ALIVE = "Keep-Alive";
+    private static final String TIMOUT = "timout=";
+    private static final int TIMOUT_VALUE = 5*60;
 
     private final SseSubscribeService sseSubscribeService;
 
@@ -33,6 +36,7 @@ public class SseController {
         return ResponseEntity
                 .ok()
                 .header(NGINX_X_ACCEL_BUFFERING_HEADER, NO)
+                .header(KEEP_ALIVE, TIMOUT + TIMOUT_VALUE)
                 .body(emitter);
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/acceptance/IcalendarAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/acceptance/IcalendarAcceptanceTest.java
@@ -1,11 +1,7 @@
 package team.teamby.teambyteam.icalendar.acceptance;
 
-import static org.mockito.ArgumentMatchers.any;
-import static team.teamby.teambyteam.common.fixtures.acceptance.IcalendarAcceptanceFixtures.GET_ICALENDAR_PUBLISHED_URL;
-
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.concurrent.CountDownLatch;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.assertj.core.api.SoftAssertions;
@@ -27,6 +23,11 @@ import team.teamby.teambyteam.filesystem.FileCloudUploader;
 import team.teamby.teambyteam.icalendar.domain.PublishedIcalendar;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static team.teamby.teambyteam.common.fixtures.acceptance.IcalendarAcceptanceFixtures.GET_ICALENDAR_PUBLISHED_URL;
 
 public class IcalendarAcceptanceTest extends AcceptanceTest {
 
@@ -56,6 +57,7 @@ public class IcalendarAcceptanceTest extends AcceptanceTest {
 
             public void await() throws InterruptedException {
                 countDownLatch.await();
+                Thread.sleep(10);
             }
         }
     }

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/SseSubscribeServiceTest.java
@@ -15,21 +15,16 @@ import team.teamby.teambyteam.common.ServiceTest;
 import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.Member;
-import team.teamby.teambyteam.sse.TestEvent;
 import team.teamby.teambyteam.sse.domain.SseEmitters;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
-import team.teamby.teambyteam.sse.domain.TeamPlaceEventId;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class SseSubscribeServiceTest extends ServiceTest {
@@ -77,62 +72,6 @@ class SseSubscribeServiceTest extends ServiceTest {
             softly.assertThat(eventOutputs[1]).isEqualTo("event:connect");
             softly.assertThat(eventOutputs[2]).isEqualTo("data:{\"teamPlaceId\":%d,\"memberId\":%d}", teamPlaceId, member.getId());
         });
-    }
-
-    @Test
-    @DisplayName("SSE 연결 수 저장된 케시 이벤트들을 발행한다.")
-    void successWithCachedEvent() throws IOException, InterruptedException {
-        // given
-        final Member member = testFixtureBuilder.buildMember(MemberFixtures.PHILIP());
-        final MemberEmailDto email = new MemberEmailDto(member.getEmailValue());
-        final Long teamPlaceId = 1L;
-        final String eventName = "test";
-        final String eventMessage = "message";
-        final TestEvent cachedEvent = new TestEvent(teamPlaceId, eventName, eventMessage);
-
-        final TeamPlaceEventId lastEventId = TeamPlaceEventId.of(teamPlaceId, eventName);
-        Thread.sleep(100);
-        final TeamPlaceEventId cachedEventId = TeamPlaceEventId.of(teamPlaceId, eventName);
-
-        BDDMockito.given(teamPlaceEmitterRepository.findAllEventCacheWithId(teamPlaceId))
-                .willReturn(Map.of(cachedEventId, cachedEvent.getEvent()));
-
-        // when
-
-        final SseEmitter sseEmitter = sseSubscribeService.subscribe(teamPlaceId, email, lastEventId.toString());
-
-        Thread.sleep(1000);
-        // then
-        // verify if the SSE is sent
-        ArgumentCaptor<SseEmitter.SseEventBuilder> argumentCaptor = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
-        verify(sseEmitter, times(2)).send(argumentCaptor.capture());
-
-        // verify the content of the SSE
-        final List<SseEmitter.SseEventBuilder> allEvents = argumentCaptor.getAllValues();
-
-        final Set<ResponseBodyEmitter.DataWithMediaType> dummyEventProperties = allEvents.get(0).build();
-        final String dummySse = SsePropertyToString(dummyEventProperties);
-
-        final Set<ResponseBodyEmitter.DataWithMediaType> cachedEventProperties = allEvents.get(1).build();
-        final String cachedSse = SsePropertyToString(cachedEventProperties);
-
-        final String[] dummyResult = dummySse.split("\n");
-        final String[] cachedResult = cachedSse.split("\n");
-
-        Arrays.stream(dummyResult).forEach(System.out::println);
-        System.out.println();
-        Arrays.stream(cachedResult).forEach(System.out::println);
-
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(allEvents).hasSize(2);
-            softly.assertThat(dummyResult[0]).startsWith("id:" + teamPlaceId + "_connect_");
-            softly.assertThat(dummyResult[1]).isEqualTo("event:connect");
-            softly.assertThat(dummyResult[2]).isEqualTo("data:{\"teamPlaceId\":%d,\"memberId\":%d}", teamPlaceId, member.getId());
-            softly.assertThat(cachedResult[0]).startsWith("id:" + teamPlaceId + "_" + eventName + "_");
-            softly.assertThat(cachedResult[1]).isEqualTo("event:test");
-            softly.assertThat(cachedResult[2]).isEqualTo("data:{\"id\":1,\"data\":\"message\"}");
-        });
-
     }
 
     private String SsePropertyToString(final Set<ResponseBodyEmitter.DataWithMediaType> dummyEventProperties) {

--- a/backend/src/test/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepositoryTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepositoryTest.java
@@ -1,28 +1,18 @@
 package team.teamby.teambyteam.sse.domain;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.time.LocalDateTime;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class TeamPlaceEmitterRepositoryTest {
 
     @Autowired
     private TeamPlaceEmitterRepository teamPlaceEmitterRepository;
-
-    @Value("${sse.cache-schedule-period}")
-    private Long schedulePeriod;
 
     @DisplayName("emitter 저장을 성공한다.")
     @Test
@@ -38,48 +28,4 @@ class TeamPlaceEmitterRepositoryTest {
         assertThat(save).isEqualTo(sseEmitter);
     }
 
-    @DisplayName("팀플레이스 아이디로 저징된 캐시들을 찾는다.")
-    @Test
-    void findCache() {
-        //given
-        final TeamPlaceEventId teamPlaceEventId1 = TeamPlaceEventId.of(1L, "test");
-        final TeamPlaceEventId teamPlaceEventId2 = TeamPlaceEventId.of(2L, "test");
-        final String event1 = "test1";
-        final String event2 = "test2";
-
-        teamPlaceEmitterRepository.addEventCache(teamPlaceEventId1, event1);
-        teamPlaceEmitterRepository.addEventCache(teamPlaceEventId2, event2);
-
-        //when
-        final Map<TeamPlaceEventId, Object> events = teamPlaceEmitterRepository.findAllEventCacheWithId(1L);
-
-        //then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(events).hasSize(1);
-            softly.assertThat(events.get(teamPlaceEventId1)).isEqualTo(event1);
-        });
-    }
-
-    @DisplayName("이벤트 캐시를 일정 시간마다 제거한다.")
-    @Test
-    void refreshCache() throws InterruptedException {
-        //given
-        final LocalDateTime pastLocalDateTime = LocalDateTime.now().minusMinutes(1);
-
-        final TeamPlaceEventId teamPlaceEventId = Mockito.spy(TeamPlaceEventId.class);
-        given(teamPlaceEventId.getTimeStamp())
-                .willReturn(pastLocalDateTime);
-        given(teamPlaceEventId.isPublishedTo(1L))
-                .willReturn(true);
-
-        final String event = "event";
-        teamPlaceEmitterRepository.addEventCache(teamPlaceEventId, event);
-
-        //when
-        Thread.sleep(schedulePeriod);
-
-        //then
-        final Map<TeamPlaceEventId, Object> allEventCacheWithId = teamPlaceEmitterRepository.findAllEventCacheWithId(1L);
-        assertThat(allEventCacheWithId).hasSize(0);
-    }
 }


### PR DESCRIPTION
## 이슈번호
> close #773

## PR 내용

- SSE 연결시 캐시된 이벤트 전달 및 이벤트 발행시 캐시 저장 기능 제거
  - 재연결시 프런트에서 요청을 보내는것으로 전환해서 일단 캐시 제거
  - 추후 필요시 다시 기능구현 후 추가 예정
  - 이때는 프런트에서 연결이 되었음을 다시 전달해주고, 연결이 완료된 후 캐시를 한번에 보내는식으로 발행할 필요 있음

- SSE subscribe 요청에 대한 응답에 `Keep-Alive: timout={time}`헤더 추가
  - 문제가 생긴 원인
    - sse 연결 유지 도중 1분(약 45초)간 발행된 이벤트가 없을시 스프링에서 `SseEmitter`생성시 설정한 timeout이 지나기 전에 클라이언트에서 연결종료 후 재연결시도
    - 이때 기존 연결이 서버인스턴스에 `close_wait`상태로 유지중으로 리소스를 계속 잡아먹음
  - 일단 개발서버에 해당 헤더를 추가해서 올려보고, 5분간 이벤트가 없어도 연결이 유지되면 이대로 유지, 안된다면 슬랙에 공유한 방법중 한가지를 선택하여 그대로 변경 예정
  - 슬렉에 공유한 내용 간단 정리
    - spring SseEmitter timout시간을 1분으로 설정한다.
    - 생성된 connection들에 30초마다 (브라우저가 45초가 되는 시점에 재연결을 해서) dummy이벤트를 발행한다

## 참고자료

## 의논할 거리
