### PR TITLE
[FE] 프로필 닉네임 수정 낙관적 업데이트 적용

### DIFF
--- a/frontend/src/hooks/queries/useModifyUserInfo.ts
+++ b/frontend/src/hooks/queries/useModifyUserInfo.ts
@@ -2,13 +2,38 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { modifyUserInfo } from '~/apis/user';
 import type { UserInfo } from '~/types/team';
 
+const QUERY_KEY = ['userInfo'];
+
 export const useModifyUserInfo = () => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation(
     (body: Pick<UserInfo, 'name'>) => modifyUserInfo(body),
     {
+      onMutate: async (body) => {
+        await queryClient.cancelQueries(QUERY_KEY);
+
+        const previousUserInfo = queryClient.getQueryData<UserInfo>(QUERY_KEY);
+
+        if (previousUserInfo) {
+          queryClient.setQueryData<UserInfo>(QUERY_KEY, (old) => {
+            if (old) {
+              return { ...old, ...body };
+            }
+          });
+        }
+
+        return { previousUserInfo };
+      },
+      onError: (err, newName, context) => {
+        if (context?.previousUserInfo) {
+          queryClient.setQueryData<UserInfo>(
+            QUERY_KEY,
+            context.previousUserInfo,
+          );
+        }
+      },
       onSuccess: () => {
-        queryClient.invalidateQueries(['userInfo']);
+        queryClient.invalidateQueries(QUERY_KEY);
       },
     },
   );

--- a/frontend/src/hooks/queries/useModifyUserInfo.ts
+++ b/frontend/src/hooks/queries/useModifyUserInfo.ts
@@ -32,7 +32,7 @@ export const useModifyUserInfo = () => {
           );
         }
       },
-      onSuccess: () => {
+      onSettled: () => {
         queryClient.invalidateQueries(QUERY_KEY);
       },
     },

--- a/frontend/src/hooks/user/useUserInfoModal.ts
+++ b/frontend/src/hooks/user/useUserInfoModal.ts
@@ -76,6 +76,8 @@ export const useUserInfoModal = () => {
       return;
     }
 
+    setIsUserInfoEditing(() => false);
+
     mutateModifyUserInfo(
       { name },
       {
@@ -84,6 +86,7 @@ export const useUserInfoModal = () => {
           showToast('success', '닉네임이 변경되었습니다.');
         },
         onError: () => {
+          setIsUserInfoEditing(() => true);
           showToast('error', '닉네임 변경에 실패했습니다.');
         },
       },


### PR DESCRIPTION
# [FE] 프로필 닉네임 수정 낙관적 업데이트 적용
## 이슈번호
> close #848 

## PR 내용
- 프로필 닉네임 수정 낙관적 업데이트 적용

## 참고자료
https://tanstack.com/query/v4/docs/react/examples/react/optimistic-updates-typescript

- MSW delay 1초 줘서 결과 비교

- 낙관적 업데이트 X
![화면 기록 2023-11-01 오후 4 18 33](https://github.com/woowacourse-teams/2023-team-by-team/assets/19235163/ff6207f7-db0d-4b62-8378-0467f3949065)

- 낙관적 업데이트 O
![화면 기록 2023-11-01 오후 4 19 56](https://github.com/woowacourse-teams/2023-team-by-team/assets/19235163/9945e840-4dda-4f52-99d3-d2c8662074b9)

