### PR TITLE
[FE] 내 일정 캘린더에 Prefetching 적용

### DIFF
--- a/frontend/src/components/my_calendar/MyCalendar/MyCalendar.tsx
+++ b/frontend/src/components/my_calendar/MyCalendar/MyCalendar.tsx
@@ -12,6 +12,7 @@ import { generateScheduleCirclesMatrix } from '~/utils/generateScheduleCirclesMa
 import TeamBadge from '~/components/team/TeamBadge/TeamBadge';
 import { getInfoByTeamPlaceId } from '~/utils/getInfoByTeamPlaceId';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { usePrefetchMySchedules } from '~/hooks/queries/usePrefetchMySchedules';
 
 interface MyCalendarProps {
   onDailyClick: (date: Date) => void;
@@ -19,6 +20,7 @@ interface MyCalendarProps {
 
 const MyCalendar = (props: MyCalendarProps) => {
   const { onDailyClick } = props;
+
   const {
     year,
     month,
@@ -26,10 +28,18 @@ const MyCalendar = (props: MyCalendarProps) => {
     today,
     handlers: { handlePrevButtonClick, handleNextButtonClick },
   } = useCalendar();
-
   const schedules = useFetchMySchedules(year, month);
-  const scheduleCircles = generateScheduleCirclesMatrix(year, month, schedules);
   const { teamPlaces } = useTeamPlace();
+  usePrefetchMySchedules(
+    month === 11 ? year + 1 : year,
+    month === 11 ? 0 : month + 1,
+  );
+  usePrefetchMySchedules(
+    month === 0 ? year - 1 : year,
+    month === 0 ? 11 : month - 1,
+  );
+
+  const scheduleCircles = generateScheduleCirclesMatrix(year, month, schedules);
 
   return (
     <S.Container>

--- a/frontend/src/hooks/queries/usePrefetchMySchedules.ts
+++ b/frontend/src/hooks/queries/usePrefetchMySchedules.ts
@@ -1,0 +1,16 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { fetchMySchedules } from '~/apis/schedule';
+import { STALE_TIME } from '~/constants/query';
+
+export const usePrefetchMySchedules = async (year: number, month: number) => {
+  const queryKey = ['mySchedules', year, month];
+  const queryClient = useQueryClient();
+
+  await queryClient.prefetchQuery(
+    queryKey,
+    () => fetchMySchedules(year, month + 1),
+    {
+      staleTime: STALE_TIME.MY_SCHEDULES,
+    },
+  );
+};


### PR DESCRIPTION
# [FE] 내 일정 캘린더에 Prefetching 적용
## 이슈번호
> close #850 

## PR 내용
- 내 일정 캘린더에 Prefetching 적용
- 방식은 팀 캘린더와 동일합니다
