### PR TITLE
[BE] 피드작성 이벤트에 작성된 피드 내용 포함

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -33,7 +33,6 @@ import team.teamby.teambyteam.filesystem.FileCloudUploader;
 import team.teamby.teambyteam.filesystem.util.FileUtil;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
-import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
@@ -47,8 +46,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import static team.teamby.teambyteam.feed.application.event.FeedEvent.Status.WRITE;
 
 @Slf4j
 @Service
@@ -86,24 +83,30 @@ public class FeedThreadService {
             final Long teamPlaceId
     ) {
         final String content = feedThreadWritingRequest.content();
-        List<MultipartFile> images = feedThreadWritingRequest.images();
+        final List<MultipartFile> images = feedThreadWritingRequest.images();
         validateEmptyRequest(content, images);
         validateImages(images);
 
         final Content contentVo = new Content(content);
-        final Member member = memberRepository.findByEmail(new Email(memberEmailDto.email()))
-                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()));
-        final FeedThread feedThread = new FeedThread(teamPlaceId, contentVo, member.getId());
+        final Long memberId = memberRepository.findIdByEmail(new Email(memberEmailDto.email()))
+                .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()))
+                .id();
+
+        final FeedThread feedThread = new FeedThread(teamPlaceId, contentVo, memberId);
         final FeedThread savedFeedThread = feedRepository.save(feedThread);
 
         saveImages(images, savedFeedThread);
-        Long threadId = savedFeedThread.getId();
+        final Long threadId = savedFeedThread.getId();
         log.info("스레드 생성 - 생성자 이메일 : {}, 스레드 아이디 : {}", memberEmailDto.email(), threadId);
 
         // TODO : 캐시 고치고 추가
 //        feedCache.addCache(teamPlaceId, FeedCache.from(savedFeedThread));
 
-        applicationEventPublisher.publishEvent(FeedEvent.of(teamPlaceId, savedFeedThread.getId(), WRITE));
+        final MemberTeamPlace threadAuthorInfo = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, memberId)
+                .orElseThrow(() -> new IllegalArgumentException(String.format("멤버-팀플레이스 조회 실패 memberId : %d, teamPlaceId %d", memberId, teamPlaceId)));
+        applicationEventPublisher.publishEvent(new FeedEvent(teamPlaceId,
+                FeedResponse.from(savedFeedThread, threadAuthorInfo, mapToFeedImageResponse(savedFeedThread), memberEmailDto.email())
+        ));
 
         return threadId;
     }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
@@ -1,6 +1,5 @@
 package team.teamby.teambyteam.feed.application.dto;
 
-import team.teamby.teambyteam.feed.domain.cache.RecentFeedCache;
 import team.teamby.teambyteam.feed.domain.cache.RecentFeedCache.FeedImageCache;
 
 public record FeedImageResponse(

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedResponse.java
@@ -40,7 +40,12 @@ public record FeedResponse(
         );
     }
 
-    public static FeedResponse from(final Feed feed, final MemberTeamPlace threadAuthorInfo, final List<FeedImageResponse> images, final String loginMemberEmail) {
+    public static FeedResponse from(
+            final Feed feed,
+            final MemberTeamPlace threadAuthorInfo,
+            final List<FeedImageResponse> images,
+            final String loginMemberEmail
+    ) {
         final String createdAt = feed.getCreatedAt().format(DATE_TIME_FORMATTER);
 
         return new FeedResponse(

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedEvent.java
@@ -1,24 +1,24 @@
 package team.teamby.teambyteam.feed.application.event;
 
+import team.teamby.teambyteam.feed.application.dto.FeedResponse;
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
 import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
 
 public class FeedEvent implements TeamPlaceSseEvent {
 
     private static final String EVENT_NAME = "new_thread";
 
-    private final FeedSse feedSse;
+    private final FeedResponse feedResponse;
+    private final Long teamPlaceId;
 
-    private FeedEvent(final FeedSse feedSse) {
-        this.feedSse = feedSse;
-    }
-
-    public static FeedEvent of(final Long teamPlaceId, final Long feedId, final Status status) {
-        return new FeedEvent(new FeedSse(teamPlaceId, feedId, status));
+    public FeedEvent(final Long teamPlaceId, final FeedResponse feedResponse) {
+        this.teamPlaceId = teamPlaceId;
+        this.feedResponse = feedResponse;
     }
 
     @Override
     public Long getTeamPlaceId() {
-        return feedSse.teamPlaceId;
+        return teamPlaceId;
     }
 
     @Override
@@ -27,14 +27,30 @@ public class FeedEvent implements TeamPlaceSseEvent {
     }
 
     @Override
-    public Object getEvent() {
-        return feedSse;
-    }
-
-    public record FeedSse(Long teamPlaceId, Long ThreadId, Status status) {
-    }
-
-    public enum Status {
-        WRITE
+    public Object getEvent(final TeamPlaceEmitterId emitterId) {
+        if (emitterId.isMemberId(feedResponse.authorId())) {
+            return new FeedResponse(
+                    feedResponse.id(),
+                    feedResponse.type(),
+                    feedResponse.authorId(),
+                    feedResponse.authorName(),
+                    feedResponse.profileImageUrl(),
+                    feedResponse.createdAt(),
+                    feedResponse.content(),
+                    feedResponse.images(),
+                    true
+            );
+        }
+        return new FeedResponse(
+                feedResponse.id(),
+                feedResponse.type(),
+                feedResponse.authorId(),
+                feedResponse.authorName(),
+                feedResponse.profileImageUrl(),
+                feedResponse.createdAt(),
+                feedResponse.content(),
+                feedResponse.images(),
+                false
+        );
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
@@ -24,12 +24,8 @@ public class SseEmitters {
     }
 
     public void sendEvent(final TeamPlaceEventId eventId, final TeamPlaceSseEvent event) {
-        sendEvent(eventId, event.getEvent());
-    }
-
-    public void sendEvent(final TeamPlaceEventId eventId, final Object event) {
         emitters.forEach(
-                (emitterId, emitter) -> threadPoolExecutor.execute(() -> sendToEmitter(eventId, event, emitterId, emitter))
+                (emitterId, emitter) -> threadPoolExecutor.execute(() -> sendToEmitter(eventId, event.getEvent(emitterId), emitterId, emitter))
         );
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceConnectedEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceConnectedEvent.java
@@ -25,7 +25,7 @@ public class TeamPlaceConnectedEvent implements TeamPlaceSseEvent {
     }
 
     @Override
-    public Object getEvent() {
+    public Object getEvent(final TeamPlaceEmitterId emitterId) {
         return event;
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterId.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterId.java
@@ -28,6 +28,10 @@ public class TeamPlaceEmitterId {
         return Objects.equals(this.teamPlaceId, teamPlaceId);
     }
 
+    public boolean isMemberId(final Long memberId) {
+        return Objects.equals(this.memberId, memberId);
+    }
+
     @Override
     public String toString() {
         return teamPlaceId + DELIMITER + memberId + DELIMITER + timeStamp;

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceSseEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceSseEvent.java
@@ -6,5 +6,5 @@ public interface TeamPlaceSseEvent {
 
     String getEventName();
 
-    Object getEvent();
+    Object getEvent(TeamPlaceEmitterId emitterId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/presentation/SseController.java
@@ -21,8 +21,10 @@ public class SseController {
     private static final String NGINX_X_ACCEL_BUFFERING_HEADER = "X-Accel-Buffering";
     private static final String NO = "no";
     private static final String KEEP_ALIVE = "Keep-Alive";
-    private static final String TIMEOUT = "timout=";
+    private static final String TIMEOUT = "timeout=";
     private static final int TIMEOUT_VALUE = 5*60;
+    private static final String CONNECTION = "Connection";
+    private static final String CONNECTION_KEEP_ALIVE = "keep-alive";
 
     private final SseSubscribeService sseSubscribeService;
 
@@ -37,6 +39,7 @@ public class SseController {
                 .ok()
                 .header(NGINX_X_ACCEL_BUFFERING_HEADER, NO)
                 .header(KEEP_ALIVE, TIMEOUT + TIMEOUT_VALUE)
+                .header(CONNECTION, CONNECTION_KEEP_ALIVE)
                 .body(emitter);
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/sse/TestEvent.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/TestEvent.java
@@ -1,5 +1,6 @@
 package team.teamby.teambyteam.sse;
 
+import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
 import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
 
 public class TestEvent implements TeamPlaceSseEvent {
@@ -24,7 +25,7 @@ public class TestEvent implements TeamPlaceSseEvent {
     }
 
     @Override
-    public Object getEvent() {
+    public Object getEvent(final TeamPlaceEmitterId emitterId) {
         return data;
     }
 


### PR DESCRIPTION
## 이슈번호
> close #781

## PR 내용

### 피드작성시 발행되는 SSE에서 피드내용이 포함될 수 있도록 구현

- 기존에 있던 `FeedResponse`재활용
- 이벤트 수신자가 피드 작성자인지 확인하기 위해서 `TeamPlaceSseEvent`에서 이미터 아이디를 받아 수신자 아이디에 따라 메시지 다르게 전송하도록 구현 변경
  - 인터페이스의 메서드 선언 변경
  - `FeedEvent`에서 authorId와 memberId를 비교하여 isMe필드가 변경된 객체를 재생성하여 반환하도록 구현 변경
    - 처음에는 작성자가 다른경우의 이벤트발행이 많아 isMe를 기본으로 false로 두고 멤버앙디가 일치하는 경우만 재생성하여 리소스를 줄이도록 설계하였지만, 지금 있는 코드를 최대한 재사용하며 주석없이 `FeedEvent` 내의 `isMe`필드가 false임을 표현하기 어려워서 매번 재생성 하도록 구현. (햇갈릴까봐~)

피드작성 서비스 가독성 생각해서 소소한 리팩터링 했는데, 전반적으로 건들기는 작업이 커질것같아서 일단 보류했습니다.

## 참고자료

## 의논할 거리
