### PR TITLE
[BE] SSE 관련 기능들 리팩터링 및 멀티스레드 제거

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/application/SseSubscribeService.java
@@ -16,11 +16,6 @@ import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterId;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEmitterRepository;
 import team.teamby.teambyteam.sse.domain.TeamPlaceEventId;
 
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.Objects;
-
 @Slf4j
 @Service
 @Transactional
@@ -28,13 +23,6 @@ import java.util.Objects;
 public class SseSubscribeService {
 
     public static final String DEFAULT_EVENT_ID = "";
-    private static final Comparator<Map.Entry<TeamPlaceEventId, Object>> EVENT_ID_TIME_COMPARATOR = (entity1, entity2) -> {
-        final LocalDateTime timeStamp1 = entity1.getKey().getTimeStamp();
-        final LocalDateTime timeStamp2 = entity2.getKey().getTimeStamp();
-
-        return timeStamp1.compareTo(timeStamp2);
-    };
-
     private final MemberRepository memberRepository;
     private final TeamPlaceEmitterRepository teamplaceEmitterRepository;
 

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
@@ -25,7 +25,12 @@ public class SseEmitters {
         );
     }
 
-    private void sendToEmitter(TeamPlaceEventId eventId, Object event, TeamPlaceEmitterId emitterId, SseEmitter emitter) {
+    private void sendToEmitter(
+            final TeamPlaceEventId eventId,
+            final Object event,
+            final TeamPlaceEmitterId emitterId,
+            final SseEmitter emitter
+    ) {
         log.info("SSE 메시지 보내기 시도 : {}", emitterId.toString());
         try {
             emitter.send(SseEmitter.event()

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/SseEmitters.java
@@ -7,15 +7,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 
 @Slf4j
 public class SseEmitters {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final int NUMBER_OF_THREAD = 100;
-    private static final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(NUMBER_OF_THREAD);
 
     private final Map<TeamPlaceEmitterId, SseEmitter> emitters;
 
@@ -25,7 +21,7 @@ public class SseEmitters {
 
     public void sendEvent(final TeamPlaceEventId eventId, final TeamPlaceSseEvent event) {
         emitters.forEach(
-                (emitterId, emitter) -> threadPoolExecutor.execute(() -> sendToEmitter(eventId, event.getEvent(emitterId), emitterId, emitter))
+                (emitterId, emitter) -> sendToEmitter(eventId, event.getEvent(emitterId), emitterId, emitter)
         );
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -55,12 +55,12 @@ public class TeamPlaceEmitterRepository {
     }
 
     public void closeById(final TeamPlaceEmitterId emitterId) {
-        final SseEmitter emitter = emitters.remove(emitterId);
+        final SseEmitter emitter = emitters.get(emitterId);
         if (emitter != null) {
             emitter.complete();
-            log.info("SseEmitter 제거 : {}, {}", emitterId.toString(), METHOD_CALL);
+            log.info("SseEmitter 종료 : {}, {}", emitterId.toString(), METHOD_CALL);
         } else {
-            log.warn("SseEmitter 제거 실패 - EmitterId 찾을 수 없음 : {}", emitterId.toString());
+            log.warn("SseEmitter 종료 실패 - EmitterId 찾을 수 없음 : {}", emitterId.toString());
         }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/TeamPlaceEmitterRepository.java
@@ -12,8 +12,6 @@ import java.util.stream.Collectors;
 @Component
 public class TeamPlaceEmitterRepository {
 
-    private static final int CACHE_REMOVE_MINUTE = 1;
-
     private final Map<TeamPlaceEmitterId, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public SseEmitters save(final TeamPlaceEmitterId emitterId, final SseEmitter sseEmitter) {

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
@@ -83,6 +83,6 @@ class TeamPlaceSsePublisherTest {
         });
 
         // remove cache
-        teamPlaceEmitterRepository.deleteById(emitterId);
+        teamPlaceEmitterRepository.closeById(emitterId);
     }
 }


### PR DESCRIPTION
## PR 내용
- SSE 발행시 스레드 분리 제거
  - 제거 이유
  - 프런트에서 중복으로 연결 요청하는 버그 수정 후 연결 관리가 어느정도 됨
  - 멀티스레드로 인한 성능테스트가 아직 안되어서 일단 TeamPlace 이벤트 하나당 스레드 하나 사용하도록 복귀 -> 후에 성능문제시 정략적인 테스트 후 스레드 분리 다시 고려

- Sse관련 클래스들 리팩터링
  - 중복로직 메서드 분리
  - 로깅 가독성 향상시켜서 디버깅 쉽게 변경
  - 미사용 메서드 제거


## 참고자료

## 의논할 거리
