### PR TITLE
[BE] 일정변동이 잦은 경우 ics배포 

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarEventListener.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarEventListener.java
@@ -1,7 +1,6 @@
 package team.teamby.teambyteam.icalendar.application;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -9,51 +8,33 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import team.teamby.teambyteam.icalendar.application.event.CreateIcalendarEvent;
-import team.teamby.teambyteam.icalendar.domain.IcalendarPublishCounter;
 import team.teamby.teambyteam.schedule.application.event.ScheduleEvent;
 import team.teamby.teambyteam.teamplace.application.event.TeamPlaceCreatedEvent;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class IcalendarEventListener {
 
-    private final IcalendarPublishCounter publishCounter;
-    private final IcalendarPublishService icalendarPublishService;
+    private final PeriodicIcalendarPublishService periodicIcalendarPublishService;
 
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void createIcalendar(final TeamPlaceCreatedEvent teamPlaceCreatedEvent) {
-        final Long teamPlaceId = teamPlaceCreatedEvent.teamPlaceId();
-
-        icalendarPublishService.createAndPublishIcalendar(teamPlaceId);
-        log.info("ics파일 생성 - teamPlaceId : {}", teamPlaceId);
+        periodicIcalendarPublishService.createAndPublishIcalendar(teamPlaceCreatedEvent.teamPlaceId());
     }
 
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void createIcalendar(final CreateIcalendarEvent createIcalendarEvent) {
-        final Long teamPlaceId = createIcalendarEvent.teamPlaceId();
-
-        icalendarPublishService.createAndPublishIcalendar(teamPlaceId);
-        log.info("ics파일 생성 - teamPlaceId : {}", teamPlaceId);
+        periodicIcalendarPublishService.createAndPublishIcalendar(createIcalendarEvent.teamPlaceId());
     }
 
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void updateIcalendar(final ScheduleEvent scheduleEvent) {
-        final Long teamPlaceId = scheduleEvent.getTeamPlaceId();
-
-        if (publishCounter.isReachedToMaxCount(teamPlaceId)) {
-            log.warn("ics배포 과요청으로 배포 연기 : {}", teamPlaceId);
-            return;
-        }
-
-        icalendarPublishService.updateIcalendar(teamPlaceId);
-        log.info("ics파일 업데이트 - teamPlaceId : {}", teamPlaceId);
-        publishCounter.addCountFor(teamPlaceId);
+        periodicIcalendarPublishService.updateIcalendar(scheduleEvent.getTeamPlaceId());
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishScheduler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishScheduler.java
@@ -1,0 +1,28 @@
+package team.teamby.teambyteam.icalendar.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import team.teamby.teambyteam.icalendar.domain.IcalendarPublishCounter;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class IcalendarPublishScheduler {
+
+    private final IcalendarPublishService icalendarPublishService;
+    private final IcalendarPublishCounter publishCounter;
+
+    /**
+     * 매시 45분에 밀린 icalendar 배포 수행
+     */
+    @Scheduled(cron = "0 45 * * * *")
+    private void publishDelayedIcalendarUpdates() {
+        final List<Long> teamPlaceIds = publishCounter.getPublishDelayedTeamPlaceIds();
+        teamPlaceIds.forEach(teamPlaceId -> {
+            icalendarPublishService.updateIcalendar(teamPlaceId);
+            publishCounter.clearFor(teamPlaceId);
+        });
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/application/IcalendarPublishService.java
@@ -1,6 +1,5 @@
 package team.teamby.teambyteam.icalendar.application;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +15,8 @@ import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -39,32 +40,29 @@ public class IcalendarPublishService {
             return;
         }
         final IcalendarFileName icalendarFileName = IcalendarFileName.generateRandomFileName(teamPlaceId);
+
+        final String uploadedUrl = uploadIcalendarFile(teamPlaceId, icalendarFileName);
+
+        final PublishedIcalendar publishedIcalendar = new PublishedIcalendar(teamPlaceId, icalendarFileName, new PublishUrl(uploadedUrl));
+        publishedIcalendarRepository.save(publishedIcalendar);
+    }
+
+    private String uploadIcalendarFile(final Long teamPlaceId, final IcalendarFileName icalendarFileName) {
         final TeamPlace teamPlace = teamPlaceRepository.findById(teamPlaceId)
                 .orElseThrow(() -> {
                     log.error("캘린더 생성요청이 들어온 팀플레이스가 존제하지 않음 - teamPlaceId : {}", teamPlaceId);
                     return new IllegalArgumentException(TEAM_PLACE_NOT_CREATED_EXCEPTION_MESSAGE + teamPlaceId);
                 });
 
-        final String uploadedUrl = uploadIcalendarFile(teamPlace, icalendarFileName);
-
-        final PublishedIcalendar publishedIcalendar = new PublishedIcalendar(teamPlaceId, icalendarFileName, new PublishUrl(uploadedUrl));
-        publishedIcalendarRepository.save(publishedIcalendar);
-    }
-
-    private String uploadIcalendarFile(final TeamPlace teamPlace, final IcalendarFileName icalendarFileName) {
-        final List<Schedule> schedules = scheduleRepository.findAllByTeamPlaceId(teamPlace.getId());
+        final List<Schedule> schedules = scheduleRepository.findAllByTeamPlaceId(teamPlaceId);
         final String icalString = icalendarParser.parse(teamPlace, schedules);
         return fileStorageManager.upload(icalString.getBytes(), icalDirectory + "/" + icalendarFileName.getValue(), icalendarFileName.getValue());
     }
 
-    public void updateIcalendar(Long teamPlaceId) {
+    public void updateIcalendar(final Long teamPlaceId) {
         publishedIcalendarRepository.findByTeamPlaceId(teamPlaceId)
                 .ifPresentOrElse(
-                        publishedIcal -> {
-                            final TeamPlace teamPlace = teamPlaceRepository.findById(teamPlaceId)
-                                    .orElseThrow(() -> new IllegalArgumentException(TEAM_PLACE_NOT_CREATED_EXCEPTION_MESSAGE + teamPlaceId));
-                            uploadIcalendarFile(teamPlace, publishedIcal.getIcalendarFileName());
-                        },
+                        publishedIcal -> uploadIcalendarFile(teamPlaceId, publishedIcal.getIcalendarFileName()),
                         () -> createAndPublishIcalendar(teamPlaceId)
                 );
     }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/application/PeriodicIcalendarPublishService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/application/PeriodicIcalendarPublishService.java
@@ -37,6 +37,8 @@ public class PeriodicIcalendarPublishService {
      */
     @Scheduled(cron = "0 45 * * * *")
     private void publishDelayedIcalendarUpdates() {
+        publishCounter.clearNotDelayedCounts();
+
         final List<Long> teamPlaceIds = publishCounter.getPublishDelayedTeamPlaceIds();
         teamPlaceIds.forEach(teamPlaceId -> {
             icalendarPublishService.updateIcalendar(teamPlaceId);

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/application/PeriodicIcalendarPublishService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/application/PeriodicIcalendarPublishService.java
@@ -1,18 +1,36 @@
 package team.teamby.teambyteam.icalendar.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import team.teamby.teambyteam.icalendar.domain.IcalendarPublishCounter;
 
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-public class IcalendarPublishScheduler {
+public class PeriodicIcalendarPublishService {
 
     private final IcalendarPublishService icalendarPublishService;
     private final IcalendarPublishCounter publishCounter;
+
+    public void createAndPublishIcalendar(final Long teamPlaceId) {
+        icalendarPublishService.createAndPublishIcalendar(teamPlaceId);
+        log.info("ics파일 생성 - teamPlaceId : {}", teamPlaceId);
+    }
+
+    public void updateIcalendar(final Long teamPlaceId) {
+        if (publishCounter.isReachedToMaxCount(teamPlaceId)) {
+            log.warn("ics배포 과요청으로 배포 연기 : {}", teamPlaceId);
+            return;
+        }
+
+        icalendarPublishService.updateIcalendar(teamPlaceId);
+        log.info("ics파일 업데이트 - teamPlaceId : {}", teamPlaceId);
+        publishCounter.addCountFor(teamPlaceId);
+    }
 
     /**
      * 매시 45분에 밀린 icalendar 배포 수행

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
@@ -1,0 +1,39 @@
+package team.teamby.teambyteam.icalendar.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class IcalendarPublishCounter {
+
+    private static final int MAX_PUBLISH_COUNT_PER_HOUR = 10;
+    private static final int ZERO = 0;
+
+    private final Map<Long, Integer> teamPlacePublishedCount = new ConcurrentHashMap<>();
+
+    public void addCountFor(final Long teamPlaceId) {
+        teamPlacePublishedCount.put(teamPlaceId, teamPlacePublishedCount.getOrDefault(teamPlaceId, ZERO) + 1);
+    }
+
+    public boolean isReachedToMaxCount(final Long teamPlaceId) {
+        if (teamPlacePublishedCount.containsKey(teamPlaceId)) {
+            return teamPlacePublishedCount.get(teamPlaceId) >= MAX_PUBLISH_COUNT_PER_HOUR;
+        }
+        return false;
+    }
+
+    public List<Long> getPublishDelayedTeamPlaceIds() {
+        return teamPlacePublishedCount.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() >= MAX_PUBLISH_COUNT_PER_HOUR)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    public void clearAll() {
+        teamPlacePublishedCount.clear();
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
@@ -33,6 +33,10 @@ public class IcalendarPublishCounter {
                 .toList();
     }
 
+    public void clearFor(final Long teamPlaceId) {
+        teamPlacePublishedCount.remove(teamPlaceId);
+    }
+
     public void clearAll() {
         teamPlacePublishedCount.clear();
     }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
@@ -20,7 +20,7 @@ public class IcalendarPublishCounter {
 
     public boolean isReachedToMaxCount(final Long teamPlaceId) {
         if (teamPlacePublishedCount.containsKey(teamPlaceId)) {
-            return teamPlacePublishedCount.get(teamPlaceId) >= MAX_PUBLISH_COUNT_PER_HOUR;
+            return teamPlacePublishedCount.get(teamPlaceId) > MAX_PUBLISH_COUNT_PER_HOUR;
         }
         return false;
     }
@@ -28,7 +28,7 @@ public class IcalendarPublishCounter {
     public List<Long> getPublishDelayedTeamPlaceIds() {
         return teamPlacePublishedCount.entrySet()
                 .stream()
-                .filter(entry -> entry.getValue() >= MAX_PUBLISH_COUNT_PER_HOUR)
+                .filter(entry -> entry.getValue() > MAX_PUBLISH_COUNT_PER_HOUR)
                 .map(Map.Entry::getKey)
                 .toList();
     }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounter.java
@@ -37,6 +37,15 @@ public class IcalendarPublishCounter {
         teamPlacePublishedCount.remove(teamPlaceId);
     }
 
+    public void clearNotDelayedCounts() {
+        final List<Long> notDelayedTeamPlaceIds = teamPlacePublishedCount.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() <= MAX_PUBLISH_COUNT_PER_HOUR)
+                .map(Map.Entry::getKey)
+                .toList();
+        notDelayedTeamPlaceIds.forEach(teamPlacePublishedCount::remove);
+    }
+
     public void clearAll() {
         teamPlacePublishedCount.clear();
     }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/PublishedIcalendarRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/PublishedIcalendarRepository.java
@@ -10,6 +10,4 @@ public interface PublishedIcalendarRepository extends JpaRepository<PublishedIca
     boolean existsByTeamPlaceId(Long teamPlaceId);
 
     Optional<PublishedIcalendar> findByTeamPlaceId(Long teamPlaceId);
-
-    List<PublishedIcalendar> findAllByTeamPlaceIds(List<Long> teamPlaceIds);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/PublishedIcalendarRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/PublishedIcalendarRepository.java
@@ -2,6 +2,7 @@ package team.teamby.teambyteam.icalendar.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PublishedIcalendarRepository extends JpaRepository<PublishedIcalendar, Long> {
@@ -9,4 +10,6 @@ public interface PublishedIcalendarRepository extends JpaRepository<PublishedIca
     boolean existsByTeamPlaceId(Long teamPlaceId);
 
     Optional<PublishedIcalendar> findByTeamPlaceId(Long teamPlaceId);
+
+    List<PublishedIcalendar> findAllByTeamPlaceIds(List<Long> teamPlaceIds);
 }

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/application/IcalendarEventListenerTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/application/IcalendarEventListenerTest.java
@@ -29,7 +29,7 @@ class IcalendarEventListenerTest extends ServiceTest {
     private IcalendarEventListener icalendarEventListener;
 
     @MockBean
-    private IcalendarPublishService icalendarPublishService;
+    private PeriodicIcalendarPublishService icalendarPublishService;
 
     @TestConfiguration
     static class TestConfig {

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
@@ -63,7 +63,7 @@ class IcalendarPublishCounterTest {
         final Long teamPlace3Id = 3L;
 
         icalendarPublishCounter.addCountFor(teamPlace3Id);
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             icalendarPublishCounter.addCountFor(teamPlace1Id);
             icalendarPublishCounter.addCountFor(teamPlace2Id);
         }
@@ -77,11 +77,32 @@ class IcalendarPublishCounterTest {
     }
 
     @Test
+    @DisplayName("지정된 팀의 배포 카운트 초기화 테스트")
+    void clearSpecificTeamPlaceCounterTest() {
+        // given
+        final Long teamPlaceId = 1L;
+        for (int i = 0; i < 10; i++) {
+            icalendarPublishCounter.addCountFor(teamPlaceId);
+        }
+
+        // when
+        final boolean beforeClear = icalendarPublishCounter.isReachedToMaxCount(teamPlaceId);
+        icalendarPublishCounter.clearFor(teamPlaceId);
+        final boolean afterClear = icalendarPublishCounter.isReachedToMaxCount(teamPlaceId);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(beforeClear).isTrue();
+            softly.assertThat(afterClear).isFalse();
+        });
+    }
+
+    @Test
     @DisplayName("배포 카운트 초기화 test")
     void clearTest() {
         // given
         final Long teamPlace1Id = 1L;
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             icalendarPublishCounter.addCountFor(teamPlace1Id);
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
@@ -21,7 +21,7 @@ class IcalendarPublishCounterTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {0, 1, 5, 9})
+    @ValueSource(ints = {0, 1, 5, 10})
     @DisplayName("10회 미만 배포한 경우 MAX에 도달했는지 확인시 false 반환 테스트")
     void unreachedMaxTest(final int publishCount) {
         // given
@@ -38,7 +38,7 @@ class IcalendarPublishCounterTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {10, 11})
+    @ValueSource(ints = {11, 12})
     @DisplayName("10회 이상 배포한 경우 MAX에 도달했는지 확인시 true 반환 테스트")
     void reachMaxTest(final int publishCount) {
         // given
@@ -63,7 +63,7 @@ class IcalendarPublishCounterTest {
         final Long teamPlace3Id = 3L;
 
         icalendarPublishCounter.addCountFor(teamPlace3Id);
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 11; i++) {
             icalendarPublishCounter.addCountFor(teamPlace1Id);
             icalendarPublishCounter.addCountFor(teamPlace2Id);
         }
@@ -81,7 +81,7 @@ class IcalendarPublishCounterTest {
     void clearSpecificTeamPlaceCounterTest() {
         // given
         final Long teamPlaceId = 1L;
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 11; i++) {
             icalendarPublishCounter.addCountFor(teamPlaceId);
         }
 
@@ -134,7 +134,7 @@ class IcalendarPublishCounterTest {
     void clearTest() {
         // given
         final Long teamPlace1Id = 1L;
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 11; i++) {
             icalendarPublishCounter.addCountFor(teamPlace1Id);
         }
 

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
@@ -98,6 +98,38 @@ class IcalendarPublishCounterTest {
     }
 
     @Test
+    @DisplayName("딜레이 되지 않은 배포 카운트 초기화 테스트")
+    void clearNotDelayedCountTest() {
+        // given
+        final Long teamPlace1Id = 1L;
+        final Long teamPlace2Id = 2L;
+        final Long teamPlace3Id = 3L;
+
+        for (int i = 0; i < 11; i++) {
+            icalendarPublishCounter.addCountFor(teamPlace1Id);
+            icalendarPublishCounter.addCountFor(teamPlace2Id);
+        }
+        icalendarPublishCounter.addCountFor(teamPlace2Id);
+        for (int i = 0; i < 5; i++) {
+            icalendarPublishCounter.addCountFor(teamPlace3Id);
+        }
+
+        // when
+        icalendarPublishCounter.clearNotDelayedCounts();
+        final List<Long> firstResult = icalendarPublishCounter.getPublishDelayedTeamPlaceIds();
+        for (int i = 0; i < 6; i++) {
+            icalendarPublishCounter.addCountFor(teamPlace3Id);
+        }
+        final List<Long> secondResult = icalendarPublishCounter.getPublishDelayedTeamPlaceIds();
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(firstResult).containsExactlyInAnyOrder(teamPlace1Id, teamPlace2Id);
+            softly.assertThat(secondResult).containsExactlyInAnyOrder(teamPlace1Id, teamPlace2Id);
+        });
+    }
+
+    @Test
     @DisplayName("배포 카운트 초기화 test")
     void clearTest() {
         // given

--- a/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/icalendar/domain/IcalendarPublishCounterTest.java
@@ -1,0 +1,99 @@
+package team.teamby.teambyteam.icalendar.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IcalendarPublishCounterTest {
+
+    private IcalendarPublishCounter icalendarPublishCounter;
+
+    @BeforeEach
+    void setup() {
+        icalendarPublishCounter = new IcalendarPublishCounter();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 5, 9})
+    @DisplayName("10회 미만 배포한 경우 MAX에 도달했는지 확인시 false 반환 테스트")
+    void unreachedMaxTest(final int publishCount) {
+        // given
+        final long teamPlaceId = 1L;
+        for (int i = 0; i < publishCount; i++) {
+            icalendarPublishCounter.addCountFor(teamPlaceId);
+        }
+
+        // when
+        final boolean actual = icalendarPublishCounter.isReachedToMaxCount(teamPlaceId);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 11})
+    @DisplayName("10회 이상 배포한 경우 MAX에 도달했는지 확인시 true 반환 테스트")
+    void reachMaxTest(final int publishCount) {
+        // given
+        final long teamPlaceId = 1L;
+        for (int i = 0; i < publishCount; i++) {
+            icalendarPublishCounter.addCountFor(teamPlaceId);
+        }
+
+        // when
+        final boolean actual = icalendarPublishCounter.isReachedToMaxCount(teamPlaceId);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    @DisplayName("10회 이상 배포요청이 들어온 팀 아이디리스트 반환 테스트")
+    void getPublishDelayedTeamPlaceIdsTest() {
+        // given
+        final Long teamPlace1Id = 1L;
+        final Long teamPlace2Id = 2L;
+        final Long teamPlace3Id = 3L;
+
+        icalendarPublishCounter.addCountFor(teamPlace3Id);
+        for (int i=0; i<10; i++) {
+            icalendarPublishCounter.addCountFor(teamPlace1Id);
+            icalendarPublishCounter.addCountFor(teamPlace2Id);
+        }
+        icalendarPublishCounter.addCountFor(teamPlace2Id);
+
+        // when
+        final List<Long> publishDelayedTeamPlaceIds = icalendarPublishCounter.getPublishDelayedTeamPlaceIds();
+
+        // then
+        assertThat(publishDelayedTeamPlaceIds).containsExactlyInAnyOrder(teamPlace1Id, teamPlace2Id);
+    }
+
+    @Test
+    @DisplayName("배포 카운트 초기화 test")
+    void clearTest() {
+        // given
+        final Long teamPlace1Id = 1L;
+        for (int i=0; i<10; i++) {
+            icalendarPublishCounter.addCountFor(teamPlace1Id);
+        }
+
+        // when
+        final boolean beforeClear = icalendarPublishCounter.isReachedToMaxCount(teamPlace1Id);
+        icalendarPublishCounter.clearAll();
+        final boolean afterClear = icalendarPublishCounter.isReachedToMaxCount(teamPlace1Id);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(beforeClear).isTrue();
+            softly.assertThat(afterClear).isFalse();
+        });
+    }
+}


### PR DESCRIPTION
## 이슈번호
> close #796

## PR 내용

- icalendar 배포 주기 조절 기능 구현
- 배포 방식
  - 1시간에 최대 10회까지는 일정 변동시 자동 업데이트 배포
  - 1시간에 10회 이상 요청시에는 배포 안하고 대기
  - 매시 45분에 지난 1시간동안 10회 이상 변경요청이 들어온 팀 일괄 배포

`IcalendarPublishCounter` : 팀플레이스당 최근 1시간동안 배포 요청 수 카운트
~~`IcalendarEventListener` : 일정변동 & 업데이트 이벤트 발생시 `배포카운터`가 10회 미만시 배포진행, 카운터 추가 + 10회 이상시 ics배포 취소~~
~~`IcalendarPublishScheduler`: 매시 45분에 밀린 배포요청 처리 후 카운터 초기화`~~

`PeriodicIcalendarPublishService`
- 1시간 주기동안은 카운터에서 지정한 횟수 미만의 업데이트 요청만 업데이트 배포 처리
- 매시 45분 딜레이된 배포 일괄 수행

`IcalendarEventListner`
- 기존 : IcalendarPublishService를 통해 ics 배포 수행
- 변경 : PeriodicIcalendarPublishService를 통해 ics 배포 수행

45분에 업데이트인 이후
- 대다수의 캘린더 클라이언트 프로그램이 ics파일 일정을 매시 정각에 업데이트를 하기 때문에 정각이 되기 일정 시간 전에 업데이트 후 카운터 초기화를 해둬야 정각에 외부 캘린더에서 일정을 가져올때 최신 정보를 가져올 확률이 높다고 판단하였음

## 참고자료

## 의논할 거리

### 업데이트 주기 설정

1. 1시간동안 변동되는 모든 팀플레이스 캐싱 후 매시간 1회만 업데이트 진행
2. 1시간동안 10회까지는 실시간 업데이트, 이후에는 초과 요청에 한하여 일괄 업데이트 진행

1번의 상황이 구현난이도와 깔끔한 코드를 작성하는 측면에서 좋아보이고, 어차피 외부 캘린더 클라이언트가 실시간으로 업데이트를 함으로 1시간마다만 업데이트를 해주어도 충분하다고 생각을 했음.
하지만 1번 상황이 문제가 되는 경우는 팀 생성초기 기본적인 일정들을 생성하고, 외부캘리더 연동을 한 경우에 최대 1시간동안 업데이트가 안될 수 있다고 판단. 팀이 유지되는 초반 이후에는 1의 상황으로도 충분하다고 생각하지만 팀을 생성하고 서비스의 첫 인상을 결정할 순간에 1번의 상황이 부정적으로 영향을 미칠 수 있다고 생각을 했음. 그래서 2의 경우로 구현을 결정함.


### 전체적인 구조

지금 구조는 일단 되게 한다는 생각으로 구현을 함.

~~이벤트 리스너 -> ics 업데이트 의사 결정(서비스 사용)
icalendar service -> ics 업데이트만 진행
schedular -> 밀린 업데이트들 업데이트 실행 결정 (서비스 사용)~~


~~이 방식외에도 ics를 배포하는 클래스에서 업데이트 의사결정까지 해야하는지, 이벤트 리스너와 IcalendarPublishService사이의 중간 클래스에서 해당 역할을 수행해야 하는지등에 대한 고민을 함.
일단은 코드의 복잡성이 가장 단순해보이는 (복잡하지 않은) 방법이라 생각되어 위처럼 구현을 했지만, 역할과 책임에 대한 고민이 진행중임...~~

이에재한 의견 주시면 감사하겠습니다.

주기적으로 배포한다는 역할이 한곳에 있으면 좋을 것 같아서 counter를 사용하는 중간클래스를 하나 만들어서 사용하는식으로 구현 변경