### PR TITLE
[BE] 피드조회시 쿼리 최적화

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -187,7 +187,11 @@ public class FeedThreadService {
                 .toList();
     }
 
-    private List<FeedResponse> getFeedResponsesFromDatasource(Long teamPlaceId, MemberEmailDto memberEmailDto, Integer size) {
+    private List<FeedResponse> getFeedResponsesFromDatasource(
+            final Long teamPlaceId,
+            final MemberEmailDto memberEmailDto,
+            final Integer size
+    ) {
         final Pageable pageSize = getPageableInitSize(size);
         final List<Feed> list = feedRepository.findByTeamPlaceId(teamPlaceId, pageSize);
         return mapFeedResponses(list, memberEmailDto.email(), teamPlaceId);
@@ -222,7 +226,7 @@ public class FeedThreadService {
         return memberTeamPlaceRepository.findAllByTeamPlaceId(teamPlaceId).stream()
                 .collect(Collectors.toMap(
                         MemberTeamPlace::findMemberId,
-                        e -> e
+                        memberTeamPlace -> memberTeamPlace
                 ));
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedThreadService.java
@@ -237,7 +237,7 @@ public class FeedThreadService {
     }
 
     private List<FeedImageResponse> mapToFeedImageResponse(final FeedThread feedThread) {
-        final List<FeedThreadImage> images = feedThreadImageRepository.findAllByFeedThread(feedThread);
+        final List<FeedThreadImage> images = feedThread.getImages();
         return images.stream().map(feedThreadImage ->
                         new FeedImageResponse(
                                 feedThreadImage.getId(),

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/FeedRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/FeedRepository.java
@@ -1,6 +1,7 @@
 package team.teamby.teambyteam.feed.domain;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/FeedThread.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/FeedThread.java
@@ -4,13 +4,15 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import team.teamby.teambyteam.feed.domain.image.FeedThreadImage;
 import team.teamby.teambyteam.feed.domain.vo.Content;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,7 +22,8 @@ public class FeedThread extends Feed {
     @Column(nullable = false)
     private Long authorId;
 
-    @OneToMany(mappedBy = "feedThread", fetch = FetchType.EAGER)
+    @BatchSize(size = 20)
+    @OneToMany(mappedBy = "feedThread", fetch = FetchType.LAZY)
     private final List<FeedThreadImage> images = new ArrayList<>();
 
     public FeedThread(final Long teamPlaceId, final Content content, final Long authorId) {

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlaceRepository.java
@@ -1,5 +1,7 @@
 package team.teamby.teambyteam.member.domain;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,5 +13,6 @@ public interface MemberTeamPlaceRepository extends JpaRepository<MemberTeamPlace
 
     List<MemberTeamPlace> findAllByMemberId(Long memberId);
 
+    @EntityGraph(attributePaths = {"member"}, type = EntityGraphType.FETCH)
     List<MemberTeamPlace> findAllByTeamPlaceId(Long teamPlaceId);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/domain/Notice.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/domain/Notice.java
@@ -8,14 +8,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.global.domain.BaseEntity;
 import team.teamby.teambyteam.notice.domain.image.NoticeImage;
 import team.teamby.teambyteam.notice.domain.vo.Content;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,7 +36,7 @@ public class Notice extends BaseEntity {
     @Column(nullable = false, updatable = false)
     private Long authorId;
 
-    @OneToMany(mappedBy = "notice", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "notice", fetch = FetchType.LAZY)
     private List<NoticeImage> images = new ArrayList<>();
 
     public Notice(final Content content, final Long teamPlaceId, final Long authorId) {


### PR DESCRIPTION
## PR 내용

- 피드조회시 쿼리 N+1문제 최적화

### 1. 피드 이미지 조회시 n+1 해결

eager -> lazy로 전환 (eager로 있으면 후에 jpql로 조회시에도 이미지를 가져오려 해서 n+1생길 여지 있음 + 사이드이펙트들이 있을 수 있음)

`@BatchSize`를 통해서 n+1제거
- size = 20
- 비지니스규칙이 매번 20개의 피드만 조회함으로 20개로 지정

BatchSize 20으로 조회시 쿼리
<img width="600" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/30036534/734c6d96-4e6e-4506-8408-1fa0944f071e">


### 2. 사용자 정보 조회시 MemberTeamPlace - Member N+1문제 해결

`@EntityGraph`를 통하여 fetch join을 하여 MemberTeamPlace 조회시 Member를 같이 조회할 수 있도록 변경


## 참고자료

## 의논할 거리

의논할거리까지는 아니고 이미지 문제를 해결할때 Pagable에서의 해결방법이 BatchSize, Fetch(FetchType.SUBSELECT)가 있었는데 BatchSize를 선택한 이유는 아래와 같음

BatchSize시의 쿼리는 위에 첨부를 함 만약에 이게 subselect방식을 이용하게 된다면

<img width="433" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/30036534/d28cf39d-cfe2-4300-8f36-806b016d28ea">

위와같이 나오게 됨.
복잡성이 너무 증가하게 되어서 BatchSize가 더 좋다고 판단 + 우리 비지니스상 BatchSize가 20정도로 100 이상처럼 많은 값으로 갈 필요도 없다고 생각을 해서 위와같은 구현을 결정
