### PR TITLE
[ALL] PR시 자동 리뷰어 설정에 v2 관리 인력만 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Automatically set front-end reviewers when front-end files are changed
-/frontend/ @wzrabbit @hafnium1923 @suyoungj
+/frontend/ @wzrabbit @hafnium1923
 
 # Automatically set back-end reviewers when back-end files are changed
-/backend/ @pilyang @sh111-coder @SproutMJ @the9kim
+/backend/ @pilyang


### PR DESCRIPTION
자동 설정에만 현 관리인원 자동 설정되어 슬랙알림 갈 수 있도록 설정
만약 추가적으로 리뷰어 설정이 필요하다면 수동으로 추가 가능
