### PR TITLE
[FE] sse 발생시 팀 채팅 조회로직 제거 밑 이벤트 이용해 채팅 렌더링

### DIFF
--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -2,7 +2,7 @@ import { http } from '~/apis/http';
 import { THREAD_SIZE } from '~/constants/feed';
 import type { Thread, NoticeThread } from '~/types/feed';
 
-interface ThreadsResponse {
+export interface ThreadsResponse {
   threads: Thread[];
 }
 

--- a/frontend/src/constants/query.ts
+++ b/frontend/src/constants/query.ts
@@ -11,5 +11,7 @@ export const STALE_TIME = {
 
   TEAM_LINKS: 1000 * 60,
 
+  TEAM_FEED: 1000 * 30,
+
   ICALENDAR_URL: Infinity,
 };

--- a/frontend/src/hooks/queries/useFetchThreads.ts
+++ b/frontend/src/hooks/queries/useFetchThreads.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { fetchThreads } from '~/apis/feed';
 import { THREAD_SIZE } from '~/constants/feed';
+import { STALE_TIME } from '~/constants/query';
 
 export const useFetchThreads = (teamPlaceId: number) => {
   const {
@@ -16,6 +17,7 @@ export const useFetchThreads = (teamPlaceId: number) => {
         if (lastPage.threads.length !== THREAD_SIZE) return undefined;
         return lastPage.threads[THREAD_SIZE - 1].id;
       },
+      staleTime: STALE_TIME.TEAM_FEED,
     },
   );
 

--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -4,8 +4,8 @@ import { baseUrl } from '~/apis/http';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useToken } from '~/hooks/useToken';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
-import { type ThreadsResponse } from '~/apis/feed';
-import { type Thread } from '~/types/feed';
+import type { ThreadsResponse } from '~/apis/feed';
+import type { Thread } from '~/types/feed';
 
 export const useSSE = () => {
   const queryClient = useQueryClient();
@@ -26,8 +26,8 @@ export const useSSE = () => {
       },
     );
 
-    eventSource.addEventListener('new_thread', (e) => {
-      const newThread = e.data as Thread;
+    eventSource.addEventListener('new_thread', (e: MessageEvent<Thread>) => {
+      const newThread = e.data;
 
       queryClient.setQueryData<ThreadsResponse>(['threadData'], (old) => {
         if (old) {

--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -4,6 +4,8 @@ import { baseUrl } from '~/apis/http';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useToken } from '~/hooks/useToken';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
+import { type ThreadsResponse } from '~/apis/feed';
+import { type Thread } from '~/types/feed';
 
 export const useSSE = () => {
   const queryClient = useQueryClient();
@@ -11,7 +13,6 @@ export const useSSE = () => {
   const { teamPlaceId } = useTeamPlace();
 
   const connect = useCallback(() => {
-    console.log(teamPlaceId);
     if (!teamPlaceId) {
       return;
     }
@@ -26,9 +27,13 @@ export const useSSE = () => {
     );
 
     eventSource.addEventListener('new_thread', (e) => {
-      console.log('1 ' + e.data);
+      const newThread = e.data as Thread;
 
-      queryClient.invalidateQueries(['threadData', teamPlaceId]);
+      queryClient.setQueryData<ThreadsResponse>(['threadData'], (old) => {
+        if (old) {
+          return { threads: [...old.threads, newThread] };
+        }
+      });
     });
 
     return () => {


### PR DESCRIPTION
# [FE] sse 발생시 팀 채팅 조회로직 제거 밑 이벤트 이용해 채팅 렌더링
## 이슈번호
> close #836 

## PR 내용
queryClient.setQueryData를 이용해봄
되는지 안되는지는 확인해봐야함

https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientsetquerydata