### PR TITLE
[FE] 일부 일정이 캘린더에 보이지 않는 문제 해결

### DIFF
--- a/frontend/src/hooks/queries/useFetchSchedules.ts
+++ b/frontend/src/hooks/queries/useFetchSchedules.ts
@@ -1,24 +1,67 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import { fetchSchedules } from '~/apis/schedule';
 import { STALE_TIME } from '~/constants/query';
+import type { Schedule } from '~/types/schedule';
 
 export const useFetchSchedules = (
   teamPlaceId: number,
   year: number,
   month: number,
 ) => {
-  const { data } = useQuery(
-    ['schedules', teamPlaceId, year, month],
-    () => fetchSchedules(teamPlaceId, year, month + 1),
-    {
-      enabled: teamPlaceId > 0,
-      staleTime: STALE_TIME.SCHEDULES,
-    },
-  );
+  const previousQueryYear = month === 0 ? year - 1 : year;
+  const previousQueryMonth = month === 0 ? 12 : month;
+  const nextQueryYear = month === 11 ? year + 1 : year;
+  const nextQueryMonth = month === 11 ? 1 : month + 2;
 
-  if (data === undefined) return [];
+  const [previousQuery, currentQuery, nextQuery] = useQueries({
+    queries: [
+      {
+        queryKey: [
+          'schedules',
+          teamPlaceId,
+          previousQueryYear,
+          previousQueryMonth,
+        ],
+        queryFn: () =>
+          fetchSchedules(teamPlaceId, previousQueryYear, previousQueryMonth),
+        enabled: teamPlaceId > 0,
+        staleTime: STALE_TIME.SCHEDULES,
+      },
+      {
+        queryKey: ['schedules', teamPlaceId, year, month],
+        queryFn: () => fetchSchedules(teamPlaceId, year, month + 1),
+        enabled: teamPlaceId > 0,
+        staleTime: STALE_TIME.SCHEDULES,
+      },
+      {
+        queryKey: ['schedules', teamPlaceId, nextQueryYear, nextQueryMonth],
+        queryFn: () =>
+          fetchSchedules(teamPlaceId, nextQueryYear, nextQueryMonth),
+        enabled: teamPlaceId > 0,
+        staleTime: STALE_TIME.SCHEDULES,
+      },
+    ],
+  });
 
-  const { schedules } = data;
+  if (!previousQuery.data || !currentQuery.data || !nextQuery.data) {
+    return [];
+  }
 
-  return schedules;
+  const rawSchedules = [
+    ...previousQuery.data.schedules,
+    ...currentQuery.data.schedules,
+    ...nextQuery.data.schedules,
+  ];
+
+  const uniqueSchedules: Schedule[] = [];
+  const appearedScheduleIds = new Set();
+
+  rawSchedules.forEach((schedule) => {
+    if (!appearedScheduleIds.has(schedule.id)) {
+      uniqueSchedules.push(schedule);
+      appearedScheduleIds.add(schedule.id);
+    }
+  });
+
+  return uniqueSchedules;
 };

--- a/frontend/src/mocks/fixtures/schedules.ts
+++ b/frontend/src/mocks/fixtures/schedules.ts
@@ -73,6 +73,42 @@ export const schedules: Schedule[] = [
     startDateTime: '2023-09-30 05:00',
     endDateTime: '2023-10-02 05:00',
   },
+  {
+    id: 12,
+    title: '이전 달 일정',
+    startDateTime: '2023-11-27 10:00',
+    endDateTime: '2023-11-30 18:00',
+  },
+  {
+    id: 13,
+    title: '이번 달과 이전 달에 겹친 일정',
+    startDateTime: '2023-11-29 10:00',
+    endDateTime: '2023-12-01 18:00',
+  },
+  {
+    id: 14,
+    title: '이번 달 일정',
+    startDateTime: '2023-12-12 10:00',
+    endDateTime: '2023-12-14 18:00',
+  },
+  {
+    id: 15,
+    title: '이번 달과 다음 달에 걸친 일정',
+    startDateTime: '2023-12-29 10:00',
+    endDateTime: '2024-01-01 18:00',
+  },
+  {
+    id: 16,
+    title: '다음 달 일정',
+    startDateTime: '2024-01-01 10:00',
+    endDateTime: '2024-01-03 18:00',
+  },
+  {
+    id: 17,
+    title: '다음 달 일정 2',
+    startDateTime: '2024-01-02 10:00',
+    endDateTime: '2024-01-15 18:00',
+  },
 ];
 
 export const mySchedules: ScheduleWithTeamPlaceId[] = [

--- a/frontend/src/mocks/handlers/calendar.ts
+++ b/frontend/src/mocks/handlers/calendar.ts
@@ -24,16 +24,35 @@ export const calendarHandlers = [
     `/api/team-place/:teamPlaceId/calendar/schedules`,
     (req, res, ctx) => {
       const teamPlaceId = Number(req.params.teamPlaceId);
+      const year = Number(req.url.searchParams.get('year'));
+      const month = Number(req.url.searchParams.get('month'));
+
       const index = teamPlaces.findIndex(
         (teamPlace) => teamPlace.id === teamPlaceId,
       );
 
       if (index === -1) return res(ctx.status(403));
 
+      const searchedSchedules = schedules.filter(
+        ({ startDateTime, endDateTime }) => {
+          const isScheduleInRange = [startDateTime, endDateTime].some(
+            (dateTime) => {
+              const [currentYear, currentMonth] = dateTime
+                .split('-')
+                .map(Number);
+
+              return currentYear === year && currentMonth === month;
+            },
+          );
+
+          return isScheduleInRange;
+        },
+      );
+
       return res(
         ctx.status(200),
         ctx.json({
-          schedules,
+          schedules: searchedSchedules,
         }),
       );
     },


### PR DESCRIPTION
# [FE] 일부 일정이 캘린더에 보이지 않는 문제 해결
## 이슈번호
> close #881

## PR 내용
본 PR에서는 캘린더에서 실제로는 일정이 있음에도 일부 일정이 캘린더 바로 보여지지 않는 문제를 해결하였다.
정확히는, **하루도 현재 달의 일정과 겹치지 않으면서 현재 달의 달력에는 보여야 하는 일정들이 보이지 않는 문제**를 해결하였다.

### 무슨 일정...이라고?

2023년 12월을 예로 들자. 2023년 12월의 경우 달력에 보이는 범위는 2023년 11월 26일부터 2024년 1월 6일까지이다. 2023년 12월의 데이터를 요청했을 때, 응답으로 받게 되는 일정들은 단 하루라도 2023년 12월과 겹치는 경우(= 2023년 12월과 관련이 있는 경우)로 추측된다.

2023년 11월 29일 ~ 2023년 12월 5일에 해당하는 일정은 응답에 포함되고 스케줄 바로도 성공적으로 렌더링되지만, 2023년 11월 25일 ~ 2023년 11월 30일에 해당하는 일정은 응답에 포함되지 않으며 스케줄 바로도 렌더링되지 않는다. 하지만, 두 일정 모두 2023년 12월 달력에 보이는 범위이므로 렌더링되어야만 한다.

**완전히 해당 달의 일정이 아니더라도 달력에 렌더링되어야 하는 경우가 있기 때문이다. 이 일정들이 렌더링되지 않는 문제를 해결한 것이다.**

![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/6a6e7f0a-eeff-457c-abe7-0eff8cf0bc98)


### 수행한 요구사항

- msw 로직을 현재 동작 방식에 맞게 변경하였다. 이렇게 해야 로컬에서도 실제 상황과 동일하게 버그가 발생하는 상황을 재현할 수 있기 때문이다.
  - **Before**: 어느 연/월의 일정을 요청했는지와 관계없이 모든 일정을 반환한다.
  - **After**: 어느 연/월의 일정을 요청했는지에 따라, 일정이 해당 연/월과 하루라도 겹치는 일정만을 필터링하여 반환한다.
- `useQueries` 를 사용해 누락되는 일정까지 모두 요청해 가져올 수 있도록 변경하였다. 이 문제를 해결하기 위해 프론트엔드에서 사용할 수 있는 방법은 바로 전 월과 다음 월까지 요청하는 것이다. 즉 $n$월에 해당하는 캘린더의 정보를 렌더링하기 위해 $n - 1$월, $n$월, $n + 1$월의 정보를 요청한 후, 중복되는 아이디의 스케줄들은 제거하는 것이다. 즉 요청을 3회 진행하게 된다.

## 참고자료
- [useQueries](https://tanstack.com/query/v4/docs/react/reference/useQueries)

## 의논할 거리
해결하기 위해 사용한 방법을 보면, 요청을 3번이나 해야 하고, 중복되는 값들을 처리하는 등 다소 더러운 방법으로 문제를 해결한 것이 보일 거야...
이 PR의 경우에는 결국 API 서버로 여러 번 요청해서 가져온 데이터를 가공한 방식이라, **백엔드에서 응답으로 데이터를 반환하는 로직을 변경하는 것으로 해결할 수도** 있어보여. 이 경우라면 이 PR은 그대로 closed되어도 문제 없을듯?
어떻게 할 지 고민해 보자고