### PR TITLE
[FE] 채팅 변경되었을 시 스크롤 하단 볼 수 있도록 수정

### DIFF
--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -57,6 +57,14 @@ const ThreadList = (props: ThreadListProps) => {
   }, [threadPages?.pages.length]);
 
   useEffect(() => {
+    if (!threadEndRef.current) {
+      return;
+    }
+
+    threadEndRef.current.scrollIntoView();
+  }, [teamPlaceId]);
+
+  useEffect(() => {
     if (threadPages?.pages[0].threads.length !== threadPagesRef.current) {
       threadPagesRef.current = threadPages?.pages[0].threads.length ?? 0;
     } else {

--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -32,7 +32,6 @@ const ThreadList = (props: ThreadListProps) => {
 
   const threadEndRef = useRef<HTMLDivElement>(null);
   const threadPagesRef = useRef<number>(0);
-  const firstPagesRef = useRef<number>(0);
   const observeRef = useRef<HTMLDivElement>(null);
   const [scrollHeight, setScrollHeight] = useState(0);
 

--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -32,6 +32,7 @@ const ThreadList = (props: ThreadListProps) => {
 
   const threadEndRef = useRef<HTMLDivElement>(null);
   const threadPagesRef = useRef<number>(0);
+  const firstPagesRef = useRef<number>(0);
   const observeRef = useRef<HTMLDivElement>(null);
   const [scrollHeight, setScrollHeight] = useState(0);
 
@@ -56,8 +57,8 @@ const ThreadList = (props: ThreadListProps) => {
   }, [threadPages?.pages.length]);
 
   useEffect(() => {
-    if (threadPages?.pages.length !== threadPagesRef.current) {
-      threadPagesRef.current = threadPages?.pages.length ?? 0;
+    if (threadPages?.pages[0].threads.length !== threadPagesRef.current) {
+      threadPagesRef.current = threadPages?.pages[0].threads.length ?? 0;
     } else {
       if (!threadEndRef.current) {
         return;

--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -25,7 +25,7 @@ export const useSSE = () => {
       },
     );
 
-    eventSource.addEventListener('open', () => {
+    eventSource.addEventListener('connect', () => {
       queryClient.invalidateQueries([['threadData', teamPlaceId]]);
     });
 

--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -39,12 +39,6 @@ export const useSSE = () => {
           }
         },
       );
-
-      const newList = queryClient.getQueryData<ThreadsResponse>([
-        'threadData',
-        teamPlaceId,
-      ]);
-      console.log(newList);
     });
 
     return () => {

--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -4,8 +4,7 @@ import { baseUrl } from '~/apis/http';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useToken } from '~/hooks/useToken';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
-import type { ThreadsResponse } from '~/apis/feed';
-import type { Thread } from '~/types/feed';
+import { type ThreadsResponse } from '~/apis/feed';
 
 export const useSSE = () => {
   const queryClient = useQueryClient();
@@ -25,6 +24,10 @@ export const useSSE = () => {
         },
       },
     );
+
+    eventSource.addEventListener('open', () => {
+      queryClient.invalidateQueries([['threadData', teamPlaceId]]);
+    });
 
     eventSource.addEventListener('new_thread', (e) => {
       const newThread = JSON.parse(e.data);


### PR DESCRIPTION
# [FE] 채팅 변경되었을 시 스크롤 하단 볼 수 있도록 수정
## 이슈번호
> close #883 

## PR 내용
본 PR에는 채팅이 렌더링 되지 않는 현상에 대한 코드가 없습니다. 
해당 PR의 변경은 채팅 이벤트 발생 시 스크롤이 맨 하단이 볼 수 있도록 하는 작업과 SSE가 연결되었을 때 채팅쿼리를 무효화하는 작업만 존재합니다. 따라서 버그를 수정한 것+ 그동안 변경된 부분에 대해서는 아래에 자세히 작성하도록 하겠습니다.

---

```
//초기 문제가 되었던 부분 useSSE.ts
queryClient.setQueryData<ThreadsResponse>(
        ['threadData', teamPlaceId],
        (old) => {
          if (old) {
            return { threads: [...old.threads, newThread] };
          }
```
채팅이 렌더링 되지 않았던 이유입니다. 
해당 문제는 threadData가 무한스크롤형태의 데이터인데 그냥 조회쿼리의 응답값으로 쿼리 데이터를 저장해서 발생했습니다.
이를 무한데이터 형식으로 타입을 지정해주고 지정한 타입에 맞춰 데이터를 저장하도록 변경하여 해결했습니다.
#886 

```
// 문제 해결을 위해 수정된 부분 useSSE.ts
queryClient.setQueryData<InfiniteData<ThreadsResponse>>(
        ['threadData', teamPlaceId],
        (old) => {
          if (old) {
            old.pages[0].threads = [newThread, ...old.pages[0].threads];

            return old;
          }
        }
```

---
이후 콘솔로 확인해본결과 채팅데이터는 적절히 수정되고 있는데 e.data가 json형식이라 렌더링이 되지 않았습니다. 따라서 기존코드를 아래와 같이 변경하였습니다. #887 

```
// 기존 코드 useSSE.ts
eventSource.addEventListener('new_thread', (e: MessageEvent<Thread>) => {
      const newThread = e.data;
... 이하 생략

// 변경된 코드 useSSE.ts
eventSource.addEventListener('new_thread', (e) => {
      const newThread = JSON.parse(e.data);
.. 이하 생략
```

----

또한 팀피드 쿼리에 대한 staleTime을 기존 1분에서 5분으로 변경하였습니다.
#885 
