### PR TITLE
[BE] 특정 기간을 지정해서 일정 조회 기능 구현

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/GlobalExceptionHandler.java
@@ -123,6 +123,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {
             ScheduleException.SpanWrongOrderException.class,
+            ScheduleException.dateFormatException.class,
             TeamPlaceInviteCodeException.LengthException.class,
             TeamPlaceException.NameLengthException.class,
             TeamPlaceException.NameBlankException.class,

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/LocalDateParser.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/LocalDateParser.java
@@ -1,0 +1,20 @@
+package team.teamby.teambyteam.schedule.application;
+
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class LocalDateParser {
+
+    private static final DateTimeFormatter DATE_PARAM_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public static LocalDate parse(final String yearMonthDay) {
+        try {
+            return LocalDate.parse(yearMonthDay, DATE_PARAM_FORMAT);
+        } catch (final DateTimeParseException e) {
+            throw new ScheduleException.dateFormatException(e);
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/MyCalendarScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/MyCalendarScheduleService.java
@@ -9,6 +9,7 @@ import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
 import team.teamby.teambyteam.schedule.application.dto.SchedulesWithTeamPlaceIdResponse;
+import team.teamby.teambyteam.schedule.application.parser.LocalDateParser;
 import team.teamby.teambyteam.schedule.domain.CalendarPeriod;
 import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
@@ -24,6 +25,7 @@ public class MyCalendarScheduleService {
 
     private final MemberRepository memberRepository;
     private final ScheduleRepository scheduleRepository;
+    private final LocalDateParser localDateParser;
 
     @Transactional(readOnly = true)
     public SchedulesWithTeamPlaceIdResponse findScheduleInPeriod(
@@ -82,8 +84,8 @@ public class MyCalendarScheduleService {
                 .map(TeamPlace::getId)
                 .toList();
 
-        final LocalDate startDate = LocalDateParser.parse(startDateString);
-        final LocalDate endDate = LocalDateParser.parse(endDateString);
+        final LocalDate startDate = localDateParser.parse(startDateString);
+        final LocalDate endDate = localDateParser.parse(endDateString);
 
         final CalendarPeriod period = CalendarPeriod.of(startDate, endDate);
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
@@ -25,7 +25,6 @@ import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @Slf4j
@@ -126,16 +125,10 @@ public class TeamCalendarScheduleService {
     ) {
         checkTeamPlaceExist(teaPlaceId);
 
-        LocalDate startDate;
-        LocalDate endDate;
-        try {
-            startDate = LocalDate.parse(startDateString, DATE_PARAM_FORMAT);
-            endDate = LocalDate.parse(endDateString, DATE_PARAM_FORMAT);
-        } catch (final DateTimeParseException e) {
-            throw new ScheduleException.dateFormatException(e);
-        }
-
+        final LocalDate startDate = LocalDateParser.parse(startDateString);
+        final LocalDate endDate = LocalDateParser.parse(endDateString);
         final CalendarPeriod period = CalendarPeriod.of(startDate, endDate);
+
         final List<Schedule> schedules = scheduleRepository.
                 findAllByTeamPlaceIdAndPeriod(teaPlaceId, period.startDateTime(), period.endDatetime());
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
@@ -13,6 +13,7 @@ import team.teamby.teambyteam.schedule.application.event.ScheduleCreateEvent;
 import team.teamby.teambyteam.schedule.application.event.ScheduleDeleteEvent;
 import team.teamby.teambyteam.schedule.application.event.ScheduleUpdateEvent;
 import team.teamby.teambyteam.schedule.application.event.ScheduleUpdateEventDto;
+import team.teamby.teambyteam.schedule.application.parser.LocalDateParser;
 import team.teamby.teambyteam.schedule.domain.CalendarPeriod;
 import team.teamby.teambyteam.schedule.domain.Schedule;
 import team.teamby.teambyteam.schedule.domain.ScheduleRepository;
@@ -24,7 +25,6 @@ import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Slf4j
@@ -33,11 +33,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeamCalendarScheduleService {
 
-    private static final DateTimeFormatter DATE_PARAM_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
-
     private final ScheduleRepository scheduleRepository;
     private final TeamPlaceRepository teamPlaceRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final LocalDateParser localDateParser;
 
     public Long register(final ScheduleRegisterRequest scheduleRegisterRequest, final Long teamPlaceId) {
         checkTeamPlaceExist(teamPlaceId);
@@ -125,8 +124,8 @@ public class TeamCalendarScheduleService {
     ) {
         checkTeamPlaceExist(teaPlaceId);
 
-        final LocalDate startDate = LocalDateParser.parse(startDateString);
-        final LocalDate endDate = LocalDateParser.parse(endDateString);
+        final LocalDate startDate = localDateParser.parse(startDateString);
+        final LocalDate endDate = localDateParser.parse(endDateString);
         final CalendarPeriod period = CalendarPeriod.of(startDate, endDate);
 
         final List<Schedule> schedules = scheduleRepository.

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleService.java
@@ -87,7 +87,7 @@ public class TeamCalendarScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public SchedulesResponse findScheduleInPeriod(final Long teamPlaceId, final int targetYear, final int targetMonth) {
+    public SchedulesResponse findScheduleInMonth(final Long teamPlaceId, final int targetYear, final int targetMonth) {
         checkTeamPlaceExist(teamPlaceId);
 
         final CalendarPeriod period = CalendarPeriod.of(targetYear, targetMonth);
@@ -98,7 +98,7 @@ public class TeamCalendarScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public SchedulesResponse findScheduleInPeriod(
+    public SchedulesResponse findScheduleInDay(
             final Long teamPlaceId,
             final int targetYear,
             final int targetMonth,

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/application/parser/LocalDateParser.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/application/parser/LocalDateParser.java
@@ -1,16 +1,18 @@
-package team.teamby.teambyteam.schedule.application;
+package team.teamby.teambyteam.schedule.application.parser;
 
+import org.springframework.stereotype.Component;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
+@Component
 public class LocalDateParser {
 
     private static final DateTimeFormatter DATE_PARAM_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    public static LocalDate parse(final String yearMonthDay) {
+    public LocalDate parse(final String yearMonthDay) {
         try {
             return LocalDate.parse(yearMonthDay, DATE_PARAM_FORMAT);
         } catch (final DateTimeParseException e) {

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/CalendarPeriod.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/CalendarPeriod.java
@@ -1,9 +1,18 @@
 package team.teamby.teambyteam.schedule.domain;
 
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+/**
+ * 캘린더 일정
+ * 일정에 해당하려면 startDateTime <= PERIOD < endDateTime
+ *
+ * @param startDateTime inclusive DateTime
+ * @param endDatetime   exclusive DateTime
+ */
 public record CalendarPeriod(
         LocalDateTime startDateTime,
         LocalDateTime endDatetime
@@ -25,5 +34,22 @@ public record CalendarPeriod(
         LocalDate nextDay = dailyDate.plusDays(NEXT_DAY_OFFSET);
 
         return new CalendarPeriod(LocalDateTime.of(dailyDate, START_TIME_OF_DAY), LocalDateTime.of(nextDay, START_TIME_OF_DAY));
+    }
+
+    public static CalendarPeriod of(final LocalDate startDate, final LocalDate endDate) {
+        validateOrder(startDate, endDate);
+        return new CalendarPeriod(
+                LocalDateTime.of(startDate, START_TIME_OF_DAY),
+                LocalDateTime.of(endDate.plusDays(NEXT_DAY_OFFSET), START_TIME_OF_DAY)
+        );
+    }
+
+    private static void validateOrder(final LocalDate startDate, final LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new ScheduleException.SpanWrongOrderException(
+                    LocalDateTime.of(startDate, START_TIME_OF_DAY),
+                    LocalDateTime.of(endDate, START_TIME_OF_DAY)
+            );
+        }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/exception/ScheduleException.java
@@ -8,6 +8,10 @@ public class ScheduleException extends RuntimeException {
         super(message);
     }
 
+    public ScheduleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public static class ScheduleNotFoundException extends ScheduleException {
         public ScheduleNotFoundException(final Long scheduleId) {
             super(String.format("조회한 일정이 존재하지 않습니다. - request info { schedule_id : %d }", scheduleId));
@@ -31,9 +35,14 @@ public class ScheduleException extends RuntimeException {
     }
 
     public static class TitleBlankException extends ScheduleException {
-
         public TitleBlankException() {
             super("일정의 제목은 빈 칸일 수 없습니다.");
+        }
+    }
+
+    public static class dateFormatException extends ScheduleException {
+        public dateFormatException(final Exception e) {
+            super("잘못된 날짜 입력 형식입니다.", e);
         }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/MyCalendarScheduleController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/MyCalendarScheduleController.java
@@ -40,4 +40,15 @@ public class MyCalendarScheduleController {
 
         return ResponseEntity.ok(responseBody);
     }
+
+    @GetMapping(value = "/schedules", params = {"startdate", "enddate"})
+    public ResponseEntity<SchedulesWithTeamPlaceIdResponse> findDailySchedule(
+            @AuthPrincipal final MemberEmailDto memberEmailDto,
+            @RequestParam(value = "startdate") final String startDate,
+            @RequestParam(value = "enddate") final String endDate
+    ) {
+        final SchedulesWithTeamPlaceIdResponse responseBody = myCalendarScheduleService.findScheduleInPeriod(memberEmailDto, startDate, endDate);
+
+        return ResponseEntity.ok(responseBody);
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/TeamCalendarScheduleController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/TeamCalendarScheduleController.java
@@ -38,12 +38,12 @@ public class TeamCalendarScheduleController {
     }
 
     @GetMapping(value = "/{teamPlaceId}/calendar/schedules", params = {"year", "month"})
-    public ResponseEntity<SchedulesResponse> findSchedulesInPeriod(
+    public ResponseEntity<SchedulesResponse> findScheduleInMonth(
             @PathVariable final Long teamPlaceId,
             @RequestParam final Integer year,
             @RequestParam final Integer month
     ) {
-        final SchedulesResponse responseBody = teamCalendarScheduleService.findScheduleInPeriod(teamPlaceId, year, month);
+        final SchedulesResponse responseBody = teamCalendarScheduleService.findScheduleInMonth(teamPlaceId, year, month);
 
         return ResponseEntity.ok(responseBody);
     }
@@ -55,7 +55,7 @@ public class TeamCalendarScheduleController {
             @RequestParam final Integer month,
             @RequestParam final Integer day
     ) {
-        final SchedulesResponse response = teamCalendarScheduleService.findScheduleInPeriod(teamPlaceId, year, month, day);
+        final SchedulesResponse response = teamCalendarScheduleService.findScheduleInDay(teamPlaceId, year, month, day);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/TeamCalendarScheduleController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/presentation/TeamCalendarScheduleController.java
@@ -60,6 +60,17 @@ public class TeamCalendarScheduleController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping(value = "/{teamPlaceId}/calendar/schedules", params = {"startdate", "enddate"})
+    public ResponseEntity<SchedulesResponse> findDailySchedule(
+            @PathVariable final Long teamPlaceId,
+            @RequestParam(value = "startdate") final String startDate,
+            @RequestParam(value = "enddate") final String endDate
+    ) {
+        final SchedulesResponse response = teamCalendarScheduleService.findScheduleInPeriod(teamPlaceId, startDate, endDate);
+
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/{teamPlaceId}/calendar/schedules")
     public ResponseEntity<Void> register(
             @RequestBody @Valid final ScheduleRegisterRequest scheduleRegisterRequest,

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MyCalendarScheduleAcceptanceFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MyCalendarScheduleAcceptanceFixtures.java
@@ -21,6 +21,21 @@ public class MyCalendarScheduleAcceptanceFixtures {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> FIND_PERIOD_SCHEDULE_REQUEST(
+            final String token,
+            final String startDate,
+            final String endDate
+    ) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .queryParam("startdate", startDate)
+                .queryParam("enddate", endDate)
+                .when().log().all()
+                .get("/api/my-calendar/schedules")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> FIND_DAILY_SCHEDULE_REQUEST(final String token, final Integer year, final Integer month, final Integer day) {
         return RestAssured.given().log().all()
                 .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamCalendarScheduleAcceptanceFixtures.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/TeamCalendarScheduleAcceptanceFixtures.java
@@ -44,6 +44,18 @@ public class TeamCalendarScheduleAcceptanceFixtures {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> FIND_PERIOD_SCHEDULE_REQUEST(final String token, final Long teamPlaceId, final String startDate, final String endDate) {
+        return RestAssured.given().log().all()
+                .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))
+                .pathParam("teamPlaceId", teamPlaceId)
+                .queryParam("startdate", startDate)
+                .queryParam("enddate", endDate)
+                .when().log().all()
+                .get("/api/team-place/{teamPlaceId}/calendar/schedules")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> FIND_DAILY_SCHEDULE_REQUEST(final String token, final Long teamPlaceId, final int year, final int month, final int day) {
         return RestAssured.given().log().all()
                 .header(new Header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + token))

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/LocalDateParserTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/LocalDateParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import team.teamby.teambyteam.schedule.application.parser.LocalDateParser;
 import team.teamby.teambyteam.schedule.exception.ScheduleException;
 
 import java.time.LocalDate;
@@ -13,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LocalDateParserTest {
 
+    private final LocalDateParser localDateParser = new LocalDateParser();
+
     @Test
     @DisplayName("LocalDate 파싱을 성공한다")
     void success() {
@@ -20,7 +23,7 @@ class LocalDateParserTest {
         final String input = "20230102";
 
         // when
-        final LocalDate actual = LocalDateParser.parse(input);
+        final LocalDate actual = localDateParser.parse(input);
 
         // then
         assertThat(actual).isEqualTo(LocalDate.of(2023, 1, 2));
@@ -34,7 +37,7 @@ class LocalDateParserTest {
 
         // when
         // then
-        assertThatThrownBy(() -> LocalDateParser.parse(input))
+        assertThatThrownBy(() -> localDateParser.parse(input))
                 .isInstanceOf(ScheduleException.dateFormatException.class)
                 .hasMessage("잘못된 날짜 입력 형식입니다.");
 

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/LocalDateParserTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/LocalDateParserTest.java
@@ -1,0 +1,43 @@
+package team.teamby.teambyteam.schedule.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalDateParserTest {
+
+    @Test
+    @DisplayName("LocalDate 파싱을 성공한다")
+    void success() {
+        // given
+        final String input = "20230102";
+
+        // when
+        final LocalDate actual = LocalDateParser.parse(input);
+
+        // then
+        assertThat(actual).isEqualTo(LocalDate.of(2023, 1, 2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2023-01-01", "2023721", "20230132"})
+    @DisplayName("yyyyMMdd형식이 아닌 경우 예외가 발생한다.")
+    void failWithWrongFormat(final String input) {
+        // given
+
+        // when
+        // then
+        assertThatThrownBy(() -> LocalDateParser.parse(input))
+                .isInstanceOf(ScheduleException.dateFormatException.class)
+                .hasMessage("잘못된 날짜 입력 형식입니다.");
+
+    }
+
+}

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import team.teamby.teambyteam.common.ServiceTest;
@@ -132,6 +133,47 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
                 softly.assertThat(scheduleResponses.get(2).title()).isEqualTo(MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE.getTitle().getValue());
                 softly.assertThat(scheduleResponses.get(3).title()).isEqualTo(MONTH_7_DAY_29_AND_MONTH_8_SCHEDULE.getTitle().getValue());
             });
+        }
+
+        @Test
+        @DisplayName("팀 캘린더에서 입력된 기간내 일정들을 조회한다.")
+        void findAllInSpecificPeriod() {
+            // given
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+            final Schedule MONTH_6_AND_MONTH_7_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
+            final Schedule MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
+            final Schedule MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
+            final Schedule MONTH_7_DAY_29_AND_MONTH_8_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_7_DAY_29_AND_MONTH_8_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
+
+            final String startDate = "20230712";
+            final String endDate = "20230728";
+
+            // when
+            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE.getId(), startDate, endDate);
+            final List<ScheduleResponse> scheduleResponses = schedulesResponse.schedules();
+
+            //then
+            assertSoftly(softly -> {
+                softly.assertThat(scheduleResponses).hasSize(3);
+                softly.assertThat(scheduleResponses.get(0).title()).isEqualTo(MONTH_6_AND_MONTH_7_SCHEDULE.getTitle().getValue());
+                softly.assertThat(scheduleResponses.get(1).title()).isEqualTo(MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getTitle().getValue());
+                softly.assertThat(scheduleResponses.get(2).title()).isEqualTo(MONTH_7_DAY_28_AND_MONTH_8_SCHEDULE.getTitle().getValue());
+            });
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"2023712,20230728", "20230712,0728"}, delimiter = ',')
+        @DisplayName("특정기간 조회시 일정 포멧이 yyyyMMdd와 다르면 예외를 발생시킨다.")
+        void failWithWrongDateFormat(final String startDate, final String endDate) {
+            // given
+            final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
+
+            // when
+            // then
+            assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE.getId(), startDate, endDate))
+                    .isInstanceOf(ScheduleException.dateFormatException.class)
+                    .hasMessage("잘못된 날짜 입력 형식입니다.");
+
         }
 
         @Test

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/application/TeamCalendarScheduleServiceTest.java
@@ -108,8 +108,8 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("팀 캘린더에서 특정 기간 내 일정들을 조회한다.")
-        void findAllInPeriod() {
+        @DisplayName("팀 캘린더에서 1달 내 일정들을 조회한다.")
+        void findAllInMonthlyPeriod() {
             // given
             final TeamPlace ENGLISH_TEAM_PLACE = testFixtureBuilder.buildTeamPlace(ENGLISH_TEAM_PLACE());
             final Schedule MONTH_6_AND_MONTH_7_SCHEDULE = testFixtureBuilder.buildSchedule(MONTH_6_AND_MONTH_7_DAY_12_SCHEDULE(ENGLISH_TEAM_PLACE.getId()));
@@ -121,7 +121,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final int month = 7;
 
             // when
-            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE.getId(), year, month);
+            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInMonth(ENGLISH_TEAM_PLACE.getId(), year, month);
             final List<ScheduleResponse> scheduleResponses = schedulesResponse.schedules();
 
             //then
@@ -143,7 +143,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final int month = 7;
 
             // when
-            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE.getId(), notExistYear, month);
+            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInMonth(ENGLISH_TEAM_PLACE.getId(), notExistYear, month);
             final List<ScheduleResponse> scheduleResponses = schedulesResponse.schedules();
 
             //then
@@ -162,7 +162,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final int month = MONTH_5_FIRST_DAY_SCHEDULE.getSpan().getStartDateTime().getMonthValue();
 
             // when
-            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE.getId(), year, month);
+            final SchedulesResponse schedulesResponse = teamCalendarScheduleService.findScheduleInMonth(ENGLISH_TEAM_PLACE.getId(), year, month);
             final List<ScheduleResponse> scheduleResponses = schedulesResponse.schedules();
 
             //then
@@ -194,7 +194,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
 
             // when
             final SchedulesResponse dailySchedulesResponse =
-                    teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE_ID, year, month, day);
+                    teamCalendarScheduleService.findScheduleInDay(ENGLISH_TEAM_PLACE_ID, year, month, day);
             final List<ScheduleResponse> dailyTeamCalendarSchedulesResponses = dailySchedulesResponse.schedules();
 
             // then
@@ -226,7 +226,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
                 final int day = MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getSpan().getStartDateTime().getDayOfMonth();
 
                 // when & then
-                assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE_ID, wrongYear, month, day))
+                assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInDay(ENGLISH_TEAM_PLACE_ID, wrongYear, month, day))
                         .isInstanceOf(DateTimeException.class)
                         .hasMessageContaining("Invalid value for Year (valid values -999999999 - 999999999)");
             }
@@ -243,7 +243,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
                 final int day = MONTH_7_AND_DAY_12_N_HOUR_SCHEDULE.getSpan().getStartDateTime().getDayOfMonth();
 
                 // when & then
-                assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE_ID, year, wrongMonth, day))
+                assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInDay(ENGLISH_TEAM_PLACE_ID, year, wrongMonth, day))
                         .isInstanceOf(DateTimeException.class)
                         .hasMessageContaining("Invalid value for MonthOfYear (valid values 1 - 12)");
             }
@@ -260,7 +260,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
                 final int wrongDay = -1;
 
                 // when & then
-                assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE_ID, year, month, wrongDay))
+                assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInDay(ENGLISH_TEAM_PLACE_ID, year, month, wrongDay))
                         .isInstanceOf(DateTimeException.class)
                         .hasMessageContaining("Invalid value for DayOfMonth (valid values 1 - 28/31)");
             }
@@ -276,7 +276,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final int day = 1;
 
             // when
-            SchedulesResponse schedules = teamCalendarScheduleService.findScheduleInPeriod(ENGLISH_TEAM_PLACE.getId(), year, month, day);
+            SchedulesResponse schedules = teamCalendarScheduleService.findScheduleInDay(ENGLISH_TEAM_PLACE.getId(), year, month, day);
 
             // then
             assertThat(schedules.schedules()).hasSize(0);
@@ -292,7 +292,7 @@ public class TeamCalendarScheduleServiceTest extends ServiceTest {
             final int day = 1;
 
             // when & then
-            assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInPeriod(notExistTeamPlaceId, year, month, day))
+            assertThatThrownBy(() -> teamCalendarScheduleService.findScheduleInDay(notExistTeamPlaceId, year, month, day))
                     .isInstanceOf(TeamPlaceException.NotFoundException.class)
                     .hasMessageContaining("조회한 팀 플레이스가 존재하지 않습니다.");
         }

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/docs/TeamCalendarScheduleApiDocsTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/docs/TeamCalendarScheduleApiDocsTest.java
@@ -426,7 +426,7 @@ public class TeamCalendarScheduleApiDocsTest extends ApiDocsTest {
             List<Schedule> schedules = List.of(schedule1, schedule2);
             SchedulesResponse response = SchedulesResponse.of(schedules);
 
-            given(teamCalendarScheduleService.findScheduleInPeriod(teamPlaceId, 2023, 7))
+            given(teamCalendarScheduleService.findScheduleInMonth(teamPlaceId, 2023, 7))
                     .willReturn(response);
 
             // when & then
@@ -469,7 +469,7 @@ public class TeamCalendarScheduleApiDocsTest extends ApiDocsTest {
 
             willThrow(new TeamPlaceException.NotFoundException(teamPlaceId))
                     .given(teamCalendarScheduleService)
-                    .findScheduleInPeriod(teamPlaceId, 2023, 7);
+                    .findScheduleInMonth(teamPlaceId, 2023, 7);
 
             // when & then
             mockMvc.perform(get("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)
@@ -504,7 +504,7 @@ public class TeamCalendarScheduleApiDocsTest extends ApiDocsTest {
             List<Schedule> schedules = List.of(schedule1, schedule2);
             SchedulesResponse response = SchedulesResponse.of(schedules);
 
-            given(teamCalendarScheduleService.findScheduleInPeriod(teamPlaceId, 2023, 7, 12))
+            given(teamCalendarScheduleService.findScheduleInDay(teamPlaceId, 2023, 7, 12))
                     .willReturn(response);
 
             // when & then
@@ -549,7 +549,7 @@ public class TeamCalendarScheduleApiDocsTest extends ApiDocsTest {
 
             willThrow(new TeamPlaceException.NotFoundException(teamPlaceId))
                     .given(teamCalendarScheduleService)
-                    .findScheduleInPeriod(teamPlaceId, 2023, 7, 12);
+                    .findScheduleInDay(teamPlaceId, 2023, 7, 12);
 
             // when & then
             mockMvc.perform(get("/api/team-place/{teamPlaceId}/calendar/schedules", teamPlaceId)

--- a/backend/src/test/java/team/teamby/teambyteam/schedule/domain/CalendarPeriodTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/schedule/domain/CalendarPeriodTest.java
@@ -1,0 +1,46 @@
+package team.teamby.teambyteam.schedule.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import team.teamby.teambyteam.schedule.exception.ScheduleException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static team.teamby.teambyteam.schedule.domain.CalendarPeriod.of;
+
+class CalendarPeriodTest {
+
+    @Test
+    @DisplayName("LocalDate로 생성 테스트")
+    void createWithLocalDate() {
+        // given
+        final LocalDate startDate = LocalDate.of(2023, 1, 1);
+        final LocalDate endDate = LocalDate.of(2023, 1, 1);
+
+        // when
+        final CalendarPeriod calendarPeriod = of(startDate, endDate);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(calendarPeriod.startDateTime()).isEqualTo(LocalDateTime.of(2023, 1, 1, 0, 0, 0));
+            softly.assertThat(calendarPeriod.endDatetime()).isEqualTo(LocalDateTime.of(2023, 1, 2, 0, 0, 0));
+        });
+    }
+
+    @Test
+    @DisplayName("시작일보다 이른 종료일로 생성시 예외 발생")
+    void exceptionWithWrongPeriodOrder() {
+        // given
+        final LocalDate startDate = LocalDate.of(2023, 1, 2);
+        final LocalDate endDate = LocalDate.of(2023, 1, 1);
+
+        // when
+        // then
+        assertThatThrownBy(() -> of(startDate, endDate))
+                .isInstanceOf(ScheduleException.SpanWrongOrderException.class)
+                .hasMessageContaining("시작 일자가 종료 일자보다 이후일 수 없습니다.");
+    }
+}


### PR DESCRIPTION
## 이슈번호
> close #884

## PR 내용

- 지정된 범위로 일정 조회 기능 구현
- 팀내일정, 개인일정 모두 구현
- 기존 일정조회 url에서 쿼리파라미터에 `startdate`, `enddate`인 api 각각 추가
- 팀일정 : `/api/team-place/{teamPlaceId}/calendar/schedules?startdate=yyyyMMdd&enddate=yyyyMMdd`
- 내일정 : `/api/my-calendar/schedules?startdate=yyyyMMdd&enddate=yyyyMMdd`
  - 쿼리 모두 필요
  - 일정형식이 yyyyMMdd 8글자 형식이 아니면  `BAD_REQUEST`
  - startdate, enddate에서 enddate가 더 이른 경우 `BAD_REQUEST`
- 응답은 기존 API와 동일형식

자세한 명세는 노션 API 명세 페이지 테이블 참고

## 참고자료

## 의논할 거리
