### PR TITLE
[FE] 팀 링크 레이아웃 버그 픽스

### DIFF
--- a/frontend/src/components/link/LinkTable/LinkTable.styled.ts
+++ b/frontend/src/components/link/LinkTable/LinkTable.styled.ts
@@ -99,8 +99,7 @@ export const Table = styled.table`
     height: 32px;
   }
 
-  & > tr :not(:first-child),
-  & th {
+  & td:not(:first-child) {
     text-align: center;
   }
 `;

--- a/frontend/src/components/link/LinkTable/LinkTable.styled.ts
+++ b/frontend/src/components/link/LinkTable/LinkTable.styled.ts
@@ -38,64 +38,7 @@ export const TableContainer = styled.div<{
   box-shadow: 0 10px 20px ${({ theme }) => theme.color.GRAY300};
 `;
 
-export const tableProperties = css`
-  & > th,
-  & td {
-    display: table-cell;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    vertical-align: middle;
-
-    height: 48px;
-    padding: 8px;
-  }
-
-  & > tr {
-    border-bottom: 2px solid ${({ theme }) => theme.color.GRAY200};
-  }
-
-  & > th:first-child(),
-  & td:first-child() {
-    width: 40%;
-  }
-
-  & > th:nth-child(2),
-  & td:nth-child(2) {
-    width: 20%;
-  }
-  & > th:nth-child(3),
-  & td:nth-child(3) {
-    width: 30%;
-  }
-
-  & > th:nth-child(4),
-  & td:nth-child(4) {
-    width: 10%;
-  }
-
-  & > tr :not(:first-child),
-  & th {
-    text-align: center;
-  }
-
-  font-size: 18px;
-
-  table-layout: fixed;
-`;
-
-export const TableHeader = styled.table`
-  width: calc(100% - 32px);
-  height: 60px;
-
-  ${tableProperties}
-
-  & > th {
-    font-weight: 600;
-  }
-`;
-
-export const TableBody = styled.div`
+export const TableWrapper = styled.div`
   overflow-y: auto;
 
   width: 100%;
@@ -107,7 +50,44 @@ export const TableBody = styled.div`
 export const Table = styled.table`
   width: 100%;
 
-  ${tableProperties}
+  font-size: 18px;
+
+  table-layout: fixed;
+
+  & td {
+    display: table-cell;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+
+    height: 48px;
+    padding: 8px;
+  }
+
+  & td:first-child(),
+  thead > tr > th:first-child() {
+    width: 40%;
+  }
+
+  & td:nth-child(2),
+  thead > tr > th:nth-child(2) {
+    width: 20%;
+  }
+
+  & td:nth-child(3),
+  thead > tr > th:nth-child(3) {
+    width: 30%;
+  }
+
+  & td:nth-child(4),
+  thead > tr > th:nth-child(4) {
+    width: 10%;
+  }
+
+  tbody > tr {
+    border-bottom: 2px solid ${({ theme }) => theme.color.GRAY200};
+  }
 
   & td > a {
     font-weight: 700;
@@ -117,6 +97,21 @@ export const Table = styled.table`
   & td:nth-child(4) svg {
     width: 32px;
     height: 32px;
+  }
+
+  & > tr :not(:first-child),
+  & th {
+    text-align: center;
+  }
+`;
+
+export const TableHeader = styled.thead`
+  width: calc(100% - 32px);
+  height: 48px;
+
+  tr > th {
+    vertical-align: middle;
+    font-weight: 600;
   }
 `;
 

--- a/frontend/src/components/link/LinkTable/LinkTable.tsx
+++ b/frontend/src/components/link/LinkTable/LinkTable.tsx
@@ -64,44 +64,50 @@ const LinkTable = (props: LinkTableProps) => {
           </Button>
         </S.MenuHeader>
         <S.TableContainer $linkSize={linkSize} $isMobile={isMobile}>
-          <S.TableHeader>
-            {linkTableHeaderValues.map((value) => (
-              <th key={value}>{value}</th>
-            ))}
-          </S.TableHeader>
           {teamLinks.length > 0 ? (
-            <S.TableBody>
+            <S.TableWrapper>
               <S.Table>
-                {teamLinks.map(({ id, title, url, memberName, updatedAt }) => (
-                  <tr key={id}>
-                    <td>
-                      <a
-                        href={generateHttpsUrl(url)}
-                        target="_blank"
-                        rel="noreferrer"
-                        title={title}
-                      >
-                        {title}
-                      </a>
-                    </td>
-                    <td title={memberName}>{memberName}</td>
-                    <td>
-                      <time>{updatedAt}</time>
-                    </td>
-                    <td>
-                      <Button
-                        variant="plain"
-                        css={S.deleteButton}
-                        onClick={() => handleDeleteTeamLink(id, title)}
-                        aria-label="링크 삭제하기"
-                      >
-                        <DeleteIcon />
-                      </Button>
-                    </td>
+                <S.TableHeader>
+                  <tr>
+                    {linkTableHeaderValues.map((value) => (
+                      <th key={value}>{value}</th>
+                    ))}
                   </tr>
-                ))}
+                </S.TableHeader>
+                <tbody>
+                  {teamLinks.map(
+                    ({ id, title, url, memberName, updatedAt }) => (
+                      <tr key={id}>
+                        <td>
+                          <a
+                            href={generateHttpsUrl(url)}
+                            target="_blank"
+                            rel="noreferrer"
+                            title={title}
+                          >
+                            {title}
+                          </a>
+                        </td>
+                        <td title={memberName}>{memberName}</td>
+                        <td>
+                          <time>{updatedAt}</time>
+                        </td>
+                        <td>
+                          <Button
+                            variant="plain"
+                            css={S.deleteButton}
+                            onClick={() => handleDeleteTeamLink(id, title)}
+                            aria-label="링크 삭제하기"
+                          >
+                            <DeleteIcon />
+                          </Button>
+                        </td>
+                      </tr>
+                    ),
+                  )}
+                </tbody>
               </S.Table>
-            </S.TableBody>
+            </S.TableWrapper>
           ) : (
             <EmptyLinkPlaceholder onClick={openModal} />
           )}

--- a/frontend/src/components/link/LinkTable/LinkTable.tsx
+++ b/frontend/src/components/link/LinkTable/LinkTable.tsx
@@ -64,53 +64,50 @@ const LinkTable = (props: LinkTableProps) => {
           </Button>
         </S.MenuHeader>
         <S.TableContainer $linkSize={linkSize} $isMobile={isMobile}>
-          {teamLinks.length > 0 ? (
-            <S.TableWrapper>
-              <S.Table>
-                <S.TableHeader>
-                  <tr>
-                    {linkTableHeaderValues.map((value) => (
-                      <th key={value}>{value}</th>
-                    ))}
+          <S.TableWrapper>
+            <S.Table>
+              <S.TableHeader>
+                <tr>
+                  {linkTableHeaderValues.map((value) => (
+                    <th key={value}>{value}</th>
+                  ))}
+                </tr>
+              </S.TableHeader>
+              <tbody>
+                {teamLinks.map(({ id, title, url, memberName, updatedAt }) => (
+                  <tr key={id}>
+                    <td>
+                      <a
+                        href={generateHttpsUrl(url)}
+                        target="_blank"
+                        rel="noreferrer"
+                        title={title}
+                      >
+                        {title}
+                      </a>
+                    </td>
+                    <td title={memberName}>{memberName}</td>
+                    <td>
+                      <time>{updatedAt}</time>
+                    </td>
+                    <td>
+                      <Button
+                        variant="plain"
+                        css={S.deleteButton}
+                        onClick={() => handleDeleteTeamLink(id, title)}
+                        aria-label="링크 삭제하기"
+                      >
+                        <DeleteIcon />
+                      </Button>
+                    </td>
                   </tr>
-                </S.TableHeader>
-                <tbody>
-                  {teamLinks.map(
-                    ({ id, title, url, memberName, updatedAt }) => (
-                      <tr key={id}>
-                        <td>
-                          <a
-                            href={generateHttpsUrl(url)}
-                            target="_blank"
-                            rel="noreferrer"
-                            title={title}
-                          >
-                            {title}
-                          </a>
-                        </td>
-                        <td title={memberName}>{memberName}</td>
-                        <td>
-                          <time>{updatedAt}</time>
-                        </td>
-                        <td>
-                          <Button
-                            variant="plain"
-                            css={S.deleteButton}
-                            onClick={() => handleDeleteTeamLink(id, title)}
-                            aria-label="링크 삭제하기"
-                          >
-                            <DeleteIcon />
-                          </Button>
-                        </td>
-                      </tr>
-                    ),
-                  )}
-                </tbody>
-              </S.Table>
-            </S.TableWrapper>
-          ) : (
-            <EmptyLinkPlaceholder onClick={openModal} />
-          )}
+                ))}
+              </tbody>
+            </S.Table>
+            {teamLinks.length === 0 && (
+              <EmptyLinkPlaceholder onClick={openModal} />
+            )}
+          </S.TableWrapper>
         </S.TableContainer>
       </S.Container>
       {isModalOpen && <LinkAddModal linkSize={linkSize} />}

--- a/frontend/src/mocks/handlers/link.ts
+++ b/frontend/src/mocks/handlers/link.ts
@@ -36,6 +36,8 @@ export const LinkHandlers = [
 
     if (index === -1) return res(ctx.status(403));
 
+    if (teamPlaceId === 2)
+      return res(ctx.status(200), ctx.json({ teamLinks: [] }));
     return res(ctx.status(200), ctx.json({ teamLinks }));
   }),
 


### PR DESCRIPTION
# [FE] 팀 링크 레이아웃 버그 픽스 
## 이슈번호
> close #891 

## PR 내용
![모아보기 레이아웃 버그](https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/677fcbb2-69c1-4c82-95ab-d7e7aef1d79c)
해당 버그는 팀링크에서 일어난 버그입니다.
이는 테이블 자체가 팀링크의 유무에 따라 있거나 없어지게 되어있기 때문이었습니다. 

해당 PR에서는 이를 해결하고 기존의 잘못된 table 구조때문에 일어나던 아래의 오류를 해결했습니다.
<img width="1312" alt="스크린샷 2023-12-18 오후 9 12 13" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/bdbfbeba-5fdb-4fd8-ac12-fbc840f4f9ad"> 

