### PR TITLE
 [FE] 스크롤 useEffect에서 threadPage 수 비교 로직 삭제

### DIFF
--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -31,7 +31,6 @@ const ThreadList = (props: ThreadListProps) => {
     useFetchThreads(teamPlaceId);
 
   const threadEndRef = useRef<HTMLDivElement>(null);
-  const threadPagesRef = useRef<number>(0);
   const observeRef = useRef<HTMLDivElement>(null);
   const [scrollHeight, setScrollHeight] = useState(0);
 
@@ -64,19 +63,16 @@ const ThreadList = (props: ThreadListProps) => {
   }, [teamPlaceId]);
 
   useEffect(() => {
-    if (threadPages?.pages[0].threads.length !== threadPagesRef.current) {
-      threadPagesRef.current = threadPages?.pages[0].threads.length ?? 0;
-    } else {
-      if (!threadEndRef.current) {
-        return;
-      }
-
-      if (isShowScrollBottomButton) {
-        return;
-      }
-
-      threadEndRef.current.scrollIntoView();
+    if (!threadEndRef.current) {
+      return;
     }
+
+    if (isShowScrollBottomButton) {
+      return;
+    }
+
+    threadEndRef.current.scrollIntoView();
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadPages]);
 


### PR DESCRIPTION
#  [FE] 스크롤 useEffect에서 threadPage 수 비교 로직 삭제
## 이슈번호
> #892 

## PR 내용

#775 에서 추가되었던 threadPage length 비교가 도대체 왜 필요했었던걸까? 로직이 이해가 안돼,,, 비슷하게 하면 돌아가겠지라고 생각해서
#888 에서 기존 페이지 수로 비교하던 것을 page 안의 thread수로 비교하게끔 한거거든
스크롤 할때 이 로직이 필요했을까? 라는 의문이 들어서 일단 삭제해봤어

얘가 있는 이유가 있을텐데 도대체 뭐였을까 왜 비교를 하고 값을 저장했던 걸까? 왜????왜?!?!?!?!?

