### PR TITLE
[FE] 일정 표시 문구 개선

### DIFF
--- a/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.tsx
+++ b/frontend/src/components/team_calendar/ScheduleModal/ScheduleModal.tsx
@@ -4,7 +4,6 @@ import { useModal } from '~/hooks/useModal';
 import * as S from './ScheduleModal.styled';
 import { CloseIcon, DeleteIcon, EditIcon } from '~/assets/svg';
 import Button from '~/components/common/Button/Button';
-import { formatDateTime } from '~/utils/formatDateTime';
 import type { SchedulePosition } from '~/types/schedule';
 import { useFetchScheduleById } from '~/hooks/queries/useFetchScheduleById';
 import { useDeleteSchedule } from '~/hooks/queries/useDeleteSchedule';
@@ -13,6 +12,7 @@ import { useToast } from '~/hooks/useToast';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import type { CalendarSize } from '~/types/size';
 import { getIsMobile } from '~/utils/getIsMobile';
+import { generateDateTimeRangeDescription } from '~/utils/generateDateTimeRangeDescription';
 
 interface ScheduleModalProps {
   calendarWidth: number;
@@ -111,11 +111,9 @@ const ScheduleModal = (props: ScheduleModalProps) => {
         </Text>
         <S.PeriodWrapper $isMobile={isMobile}>
           <time>
-            <Text size="lg">{formatDateTime(startDateTime)}</Text>
-          </time>
-          <Text size="lg">~</Text>
-          <time>
-            <Text size="lg">{formatDateTime(endDateTime)}</Text>
+            <Text size="lg">
+              {generateDateTimeRangeDescription(startDateTime, endDateTime)}
+            </Text>
           </time>
         </S.PeriodWrapper>
         <Button

--- a/frontend/src/utils/generateDateTimeRangeDescription.ts
+++ b/frontend/src/utils/generateDateTimeRangeDescription.ts
@@ -1,0 +1,34 @@
+import { formatDateTime } from '~/utils/formatDateTime';
+import type { YYYYMMDDHHMM } from '~/types/schedule';
+
+export const generateDateTimeRangeDescription = (
+  startDateTime: YYYYMMDDHHMM,
+  endDateTime: YYYYMMDDHHMM,
+) => {
+  const [startDate] = startDateTime.split(' ');
+  const [endDate, endTime] = endDateTime.split(' ');
+  const formattedStartDateTime = formatDateTime(startDateTime);
+  const formattedEndDateTime = formatDateTime(endDateTime);
+  const formattedStartDate = formattedStartDateTime
+    .split(' ')
+    .slice(0, 3)
+    .join(' ');
+  const formattedEndDate = formattedEndDateTime
+    .split(' ')
+    .slice(0, 3)
+    .join(' ');
+
+  if (startDateTime === endDateTime) {
+    return formattedStartDateTime;
+  }
+
+  if (endTime === '23:59') {
+    if (startDate === endDate) {
+      return formattedStartDate;
+    }
+
+    return `${formattedStartDate} ~ ${formattedEndDate}`;
+  }
+
+  return `${formattedStartDateTime} ~ ${formattedEndDateTime}`;
+};

--- a/frontend/src/utils/test/generateDateTimeRangeDescription.test.ts
+++ b/frontend/src/utils/test/generateDateTimeRangeDescription.test.ts
@@ -1,0 +1,47 @@
+import { generateDateTimeRangeDescription } from '../generateDateTimeRangeDescription';
+
+describe('Test #1 - 동일한 일정 테스트', () => {
+  it('시작 일정과 끝 일정이 완전히 동일할 경우 시작 일정만을 반환해야 한다.', () => {
+    const startDateTime = '2023-10-21 03:00';
+    const endDateTime = '2023-10-21 03:00';
+    const expected = '2023년 10월 21일 03:00';
+
+    expect(generateDateTimeRangeDescription(startDateTime, endDateTime)).toBe(
+      expected,
+    );
+  });
+});
+
+describe('Test #2 - 종일 일정 테스트', () => {
+  it('하루짜리 종일 일정일 경우, 시간 표시 없이 일정만을 표시해야 한다..', () => {
+    const startDateTime = '1972-11-21 00:00';
+    const endDateTime = '1972-11-21 23:59';
+    const expected = '1972년 11월 21일';
+
+    expect(generateDateTimeRangeDescription(startDateTime, endDateTime)).toBe(
+      expected,
+    );
+  });
+
+  it('여러 날에 걸친 종일 일정일 경우, 시작 일정과 끝 일정을 표시하되 시간은 생략해야 한다.', () => {
+    const startDateTime = '1972-11-21 00:00';
+    const endDateTime = '1972-11-24 23:59';
+    const expected = '1972년 11월 21일 ~ 1972년 11월 24일';
+
+    expect(generateDateTimeRangeDescription(startDateTime, endDateTime)).toBe(
+      expected,
+    );
+  });
+});
+
+describe('Test #3 - 일반 일정 테스트', () => {
+  it('위 테스트에 속하는 일정이 아닌 평범한 일정일 경우, 시작 일정과 끝 일정을 시간을 포함하여 모두 표시하여야 한다.', () => {
+    const startDateTime = '2023-10-21 03:00';
+    const endDateTime = '2023-10-27 18:30';
+    const expected = '2023년 10월 21일 03:00 ~ 2023년 10월 27일 18:30';
+
+    expect(generateDateTimeRangeDescription(startDateTime, endDateTime)).toBe(
+      expected,
+    );
+  });
+});


### PR DESCRIPTION
# [FE] 일정 표시 문구 개선
## 이슈번호
> close #904 

## PR 내용
본 PR에서는 일정을 클릭할 경우 표시되는 문구를 좀 더 깔끔한 문구로써 보이도록 개선하였다. 구체적으로는 아래의 사항을 개선하였다.

1. `2023-01-03 00:00 ~ 2023-01-03 23:59` 와 같은 하루짜리 종일 일정은 `2023-01-03` 과 같이 변경하였다.
2. `2023-01-03 00:00 ~ 2023-01-07 23:59` 와 같은 여러 날짜리 종일 일정은 `2023-01-03 ~ 2023-01-07` 과 같이 변경하였다.
3. `2023-01-03 03:00 ~ 2023-01-03 03:00` 와 같은 시작 일정과 마감 일정이 완전히 같은 경우에는 `2023-01-03 03:00` 과 같이 변경하였다.
4. 위의 어떠한 경우에도 속하지 않는 경우는 본래의 일정 정보를 그대로 보여준다.

3번 케이스의 경우 현재 PR 기준으로 같은 시간으로 시작해 같은 시간으로 끝나는 일정을 생성할 수 없도록 아직 막혀있으므로 `msw` 등의 모킹 데이터를 이용하여 테스트해 보아야 변경 사항이 보일 것이다. 유틸 함수의 테스트 코드를 구현한 것도 작동함을 보이기 위함이다.

## 참고 자료
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/7860b83e-a2b3-4b60-97d7-4eec8ac8193a)

## 의논할 사항
의논했던 요구사항에 기반하여 구현했지만 좀 더 개선할 수 있어보여서 조건을 더 만들고 문구도 더 추가해 보았어. 어떤 것 같아?