### PR TITLE
[FE] 채팅 스크롤 버그 픽스

### DIFF
--- a/frontend/src/components/feed/ThreadList/ThreadList.tsx
+++ b/frontend/src/components/feed/ThreadList/ThreadList.tsx
@@ -75,7 +75,7 @@ const ThreadList = (props: ThreadListProps) => {
     threadEndRef.current.scrollIntoView();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [threadPages]);
+  }, [threadPages?.pages[0].threads.length]);
 
   return (
     <>


### PR DESCRIPTION
# [FE|BE|ALL] PR 타이틀 
## 이슈번호
> #892 

## PR 내용

기존 채팅 스크롤을 관리하던 useEffect의 dependency가 threadPages였는데 
이를 threadPages?.pages[0].threads.length로 변경하였다.