### PR TITLE
[BE] 팀플레이스 공지 등록시 실시간 SSE 알림 추가

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
@@ -43,7 +43,6 @@ public class FeedWriteService {
     private final FeedRepository feedRepository;
     private final FeedThreadImageRepository feedThreadImageRepository;
     private final MemberRepository memberRepository;
-    private final MemberTeamPlaceRepository memberTeamPlaceRepository;
     private final FileStorageManager fileStorageManager;
 
     @Value("${aws.s3.image-directory}")

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +28,7 @@ import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
 import team.teamby.teambyteam.notice.application.dto.NoticeResponse;
 import team.teamby.teambyteam.notice.domain.Notice;
 import team.teamby.teambyteam.notice.domain.NoticeRepository;
+import team.teamby.teambyteam.notice.domain.event.NoticeCreationEvent;
 import team.teamby.teambyteam.notice.domain.image.NoticeImage;
 import team.teamby.teambyteam.notice.domain.image.NoticeImageRepository;
 import team.teamby.teambyteam.notice.domain.image.vo.ImageName;
@@ -52,6 +54,7 @@ public class NoticeService {
 
     private final Clock clock;
 
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final NoticeRepository noticeRepository;
     private final TeamPlaceRepository teamPlaceRepository;
     private final MemberRepository memberRepository;
@@ -75,9 +78,10 @@ public class NoticeService {
         final Notice savedNotice = noticeRepository.save(new Notice(contentVo, teamPlaceId, memberId.id()));
         saveImages(images, savedNotice);
 
-        Long savedNoticeId = savedNotice.getId();
+        final Long savedNoticeId = savedNotice.getId();
         log.info("공지 등록 - 등록자 이메일 : {}, 팀플레이스 아이디 : {}, 공지 아이디 : {}", memberEmailDto.email(), teamPlaceId,
                 savedNoticeId);
+        applicationEventPublisher.publishEvent(new NoticeCreationEvent(savedNotice));
         return savedNoticeId;
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/notice/domain/NoticeRepository.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/domain/NoticeRepository.java
@@ -16,4 +16,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             "LIMIT 1"
     )
     Optional<Notice> findMostRecentByTeamPlaceId(Long teamPlaceId);
+
+    @Query("SELECT n.teamPlaceId FROM Notice n WHERE n.id = :id")
+    Optional<Long> findTeamPlaceIdByNoticeId(Long id);
 }

--- a/backend/src/main/java/team/teamby/teambyteam/notice/domain/event/NoticeCreationEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/domain/event/NoticeCreationEvent.java
@@ -1,0 +1,26 @@
+package team.teamby.teambyteam.notice.domain.event;
+
+import team.teamby.teambyteam.common.domain.DomainEvent;
+import team.teamby.teambyteam.notice.domain.Notice;
+
+public class NoticeCreationEvent implements DomainEvent<Long> {
+
+    public static final String NOTICE_NOT_CREATED_MESSAGE_FORMAT = "아직 생성되지 않은 공지입니다. teamplaceId: %d";
+    private final Long id;
+
+    public NoticeCreationEvent(final Notice notice) {
+        validate(notice);
+        this.id = notice.getId();
+    }
+
+    private static void validate(Notice notice) {
+        if(notice.getId() == null) {
+            throw new RuntimeException(String.format(NOTICE_NOT_CREATED_MESSAGE_FORMAT, notice.getTeamPlaceId()));
+        }
+    }
+
+    @Override
+    public Long getDomainId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/converter/FeedEventConverter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/converter/FeedEventConverter.java
@@ -22,15 +22,15 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class FeedEventConverter implements TeamPlaceSseConverter {
+public class FeedEventConverter implements TeamPlaceSseConverter<Long> {
 
     private final FeedRepository feedRepository;
     private final MemberTeamPlaceRepository memberTeamPlaceRepository;
 
     @Override
     @Transactional(readOnly = true)
-    public TeamPlaceSseEvent convert(final DomainEvent event) {
-        final Long feedId = (Long) event.getDomainId();
+    public TeamPlaceSseEvent convert(final DomainEvent<Long> event) {
+        final Long feedId =  event.getDomainId();
         final Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> {
                     final String message = "No FeedFound ID : " + feedId;

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/converter/NoticeCreatedEventConverter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/converter/NoticeCreatedEventConverter.java
@@ -1,0 +1,58 @@
+package team.teamby.teambyteam.sse.domain.converter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import team.teamby.teambyteam.common.domain.DomainEvent;
+import team.teamby.teambyteam.notice.domain.NoticeRepository;
+import team.teamby.teambyteam.notice.domain.event.NoticeCreationEvent;
+import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
+import team.teamby.teambyteam.sse.domain.emitter.TeamPlaceEmitterId;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeCreatedEventConverter implements TeamPlaceSseConverter<Long> {
+
+    private final NoticeRepository noticeRepository;
+
+    @Override
+    public TeamPlaceSseEvent convert(DomainEvent<Long> event) {
+        final Long noticeId = event.getDomainId();
+        final Long teamPlaceId = noticeRepository.findTeamPlaceIdByNoticeId(noticeId)
+                .orElseThrow(() -> new RuntimeException(String.format("팀플레이스 공지를 찾을 수 없습니다. id : %d", noticeId)));
+        return new NoticeCreatedSse(noticeId, teamPlaceId);
+    }
+
+    @Override
+    public String supportEventName() {
+        return NoticeCreationEvent.class.getName();
+    }
+
+    private static class NoticeCreatedSse implements TeamPlaceSseEvent {
+
+        private static final String EVENT_NAME = "new_notice";
+
+        private final NoticeSse event;
+
+        public NoticeCreatedSse(final Long id, final Long teamPlaceId) {
+            this.event = new NoticeSse(id, teamPlaceId);
+        }
+
+        @Override
+        public Long getTeamPlaceId() {
+            return event.teamPlaceId;
+        }
+
+        @Override
+        public String getEventName() {
+            return EVENT_NAME;
+        }
+
+        @Override
+        public Object getEvent(TeamPlaceEmitterId emitterId) {
+            return event;
+        }
+
+        private record NoticeSse(Long id, Long teamPlaceId) {
+        }
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/sse/domain/converter/TeamPlaceSseConverter.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sse/domain/converter/TeamPlaceSseConverter.java
@@ -3,8 +3,8 @@ package team.teamby.teambyteam.sse.domain.converter;
 import team.teamby.teambyteam.common.domain.DomainEvent;
 import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
 
-public interface TeamPlaceSseConverter {
-    TeamPlaceSseEvent convert(DomainEvent event);
+public interface TeamPlaceSseConverter<T> {
+    TeamPlaceSseEvent convert(DomainEvent<T> event);
 
     String supportEventName();
 }

--- a/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/notice/application/NoticeServiceTest.java
@@ -44,6 +44,7 @@ import team.teamby.teambyteam.notice.application.dto.NoticeRegisterRequest;
 import team.teamby.teambyteam.notice.application.dto.NoticeResponse;
 import team.teamby.teambyteam.notice.domain.Notice;
 import team.teamby.teambyteam.notice.domain.NoticeRepository;
+import team.teamby.teambyteam.notice.domain.event.NoticeCreationEvent;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException.NotFoundException;
 
@@ -91,6 +92,23 @@ class NoticeServiceTest extends ServiceTest {
 
             // then
             assertThat(registeredId).isNotNull();
+        }
+
+        @Test
+        @DisplayName("공지 등록 이벤트를 발행한다")
+        void publishCreatedEvent() {
+            // given
+
+            // when
+            final Long registeredId = noticeService.register(request, teamPlace.getId(), memberEmailDto);
+
+            // then
+            final Optional<NoticeCreationEvent> event = applicationEvents.stream(NoticeCreationEvent.class).findAny();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(event).isNotEmpty();
+                softly.assertThat(event.get().getDomainId()).isEqualTo(registeredId);
+            });
+
         }
 
         @Test

--- a/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/application/TeamPlaceSsePublisherTest.java
@@ -50,10 +50,10 @@ class TeamPlaceSsePublisherTest {
             return new TestSseConverter();
         }
 
-        public static class TestSseConverter implements TeamPlaceSseConverter {
+        public static class TestSseConverter implements TeamPlaceSseConverter<Long> {
 
             @Override
-            public TeamPlaceSseEvent convert(DomainEvent event) {
+            public TeamPlaceSseEvent convert(DomainEvent<Long> event) {
                 return ((TestDomainEvent) event).getTestSseEvent();
             }
 

--- a/backend/src/test/java/team/teamby/teambyteam/sse/domain/converter/NoticeCreatedEventConverterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/domain/converter/NoticeCreatedEventConverterTest.java
@@ -1,0 +1,61 @@
+package team.teamby.teambyteam.sse.domain.converter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import team.teamby.teambyteam.common.builder.TestFixtureBuilder;
+import team.teamby.teambyteam.common.fixtures.MemberFixtures;
+import team.teamby.teambyteam.common.fixtures.NoticeFixtures;
+import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
+import team.teamby.teambyteam.member.domain.Member;
+import team.teamby.teambyteam.notice.domain.Notice;
+import team.teamby.teambyteam.notice.domain.event.NoticeCreationEvent;
+import team.teamby.teambyteam.sse.domain.TeamPlaceSseEvent;
+import team.teamby.teambyteam.teamplace.domain.TeamPlace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Sql({"/h2-truncate.sql"})
+class NoticeCreatedEventConverterTest {
+
+    @Autowired
+    private NoticeCreatedEventConverter noticeCreatedEventConverter;
+
+    @Autowired
+    private TestFixtureBuilder testFixtureBuilder;
+
+    @Test
+    @DisplayName("NoticeCreatedEvent 지원 확인")
+    void isSupportNoticeCreatedEvent() {
+        // given
+        final String expected = NoticeCreationEvent.class.getName();
+
+        // when
+        final String actual = noticeCreatedEventConverter.supportEventName();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Notice 이벤트 변환 테스트")
+    void convert() {
+        // given
+        final Member member = testFixtureBuilder.buildMember(MemberFixtures.ROY());
+        final TeamPlace teamPlace = testFixtureBuilder.buildTeamPlace(TeamPlaceFixtures.CONTROLS_TEAM_PLACE());
+        testFixtureBuilder.buildMemberTeamPlace(member, teamPlace);
+        final Notice createdNotice = testFixtureBuilder.buildNotice(NoticeFixtures.NOTICE_1ST(teamPlace.getId(), member.getId()));
+
+        final NoticeCreationEvent noticeCreationEvent = new NoticeCreationEvent(createdNotice);
+
+        // when
+        final TeamPlaceSseEvent convertedEvent = noticeCreatedEventConverter.convert(noticeCreationEvent);
+
+        // then
+        assertThat(convertedEvent.getTeamPlaceId()).isEqualTo(teamPlace.getId());
+
+    }
+}


### PR DESCRIPTION
## PR 내용

- 팀플레이스 내 공지 등록시 팀플레이스 SSE connection을 통해 이벤트 발행
- 발행 이벤트 정보
```
event: new_notice
data: {"teamPlaceId": 1,"threadId": 1637}
```

우선은 재조회 방식으로 정보를 읽어들여와 이벤트에는 내용 추가 안함
이유
- 공지는 피드에 비해 갱신 주기가 매우 길것으로 판단
- SSE를 발행하는데 더 리소스를 쏟기보다는 기존 api 활용 하도록 하는것으로도 충분할것이라 판단.

