### PR TITLE
[FE] 하루 전체 일정을 불러오지 못하는 버그 수정

### DIFF
--- a/frontend/src/hooks/queries/useFetchDailySchedules.ts
+++ b/frontend/src/hooks/queries/useFetchDailySchedules.ts
@@ -10,7 +10,12 @@ export const useFetchDailySchedules = (
 ) => {
   const { data } = useQuery(
     ['dailySchedules', year, month, day],
-    () => fetchSchedules(teamPlaceId, year, month + 1, day),
+    () =>
+      fetchSchedules(
+        teamPlaceId,
+        `${year}${month + 1}${day}`,
+        `${year}${month + 1}${day}`,
+      ),
     {
       enabled: teamPlaceId > 0,
       staleTime: STALE_TIME.DAILY_SCHEDULES,


### PR DESCRIPTION
# [FE] 하루 전체 일정을 불러오지 못하는 버그 수정 
## 이슈번호
> close #929 

## PR 내용
<img width="801" alt="image" src="https://github.com/woowacourse-teams/2023-team-by-team/assets/79538610/72b211ba-16fa-49a7-82b4-71e44473e44e">

일정 조회에 관한 endpoint가 변경되었음에도 하루전체일정에는 적용되지 않아 발생한 문제