### PR TITLE
[FE] 첫 로드 후 조회 요청 없이 채팅을 치면 조회가 안되는 버그

### DIFF
--- a/frontend/src/hooks/queries/useFetchThreads.ts
+++ b/frontend/src/hooks/queries/useFetchThreads.ts
@@ -14,7 +14,7 @@ export const useFetchThreads = (teamPlaceId: number) => {
     {
       enabled: teamPlaceId > 0,
       getNextPageParam: (lastPage) => {
-        if (lastPage.threads.length !== THREAD_SIZE) return undefined;
+        if (lastPage.threads.length < THREAD_SIZE) return undefined;
         return lastPage.threads[THREAD_SIZE - 1].id;
       },
       staleTime: STALE_TIME.TEAM_FEED,


### PR DESCRIPTION
# [FE] 첫 로드 후 조회 요청 없이 채팅을 치면 조회가 안되는 버그
## 이슈번호
> close #931 

## PR 내용
자세한 버그 상황은 이슈에 첨부하였음.

지금 채팅 이벤트를 받으면 맨 앞 스레드페이지(무한스크롤 페이지)의 맨 앞에 끼워넣고 있음.
이때 첫 로드시 채팅이벤트를 받으면  lastPage.threads.length가 THREAD_SIZE와 달라질 수 밖에없음.
(첫 로드시 lastPage는 맨 처음 페이지니까)
때문에 비교연사자를 `같지 않다`에서 `작으면`으로 바꿔 첫 로드시 lastPage가 이벤트르 받게되어 THREAD_SIZE보다 커질 것을 대비할 수 있도록 하였음.
이후 파생될 버그에대해서는 아직 예측할 수 없으니 문제가 생기면 다시 픽스하는걸로

## 참고자료

## 의논할 거리
