### PR TITLE
[FE] 모바일에서 채팅 입력창에 자동으로 포커스 하지 않도록 변경

### DIFF
--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -120,7 +120,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
                 : '여기에 채팅을 입력하세요. \n\nShift + Enter로 새 행을 추가합니다.'
             }
             maxLength={10000}
-            autoFocus={isMobile ? false : true}
+            autoFocus={!isMobile}
             readOnly={isSendingImage}
           />
           <S.ButtonContainer $isMobile={isMobile}>

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -120,7 +120,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
                 : '여기에 채팅을 입력하세요. \n\nShift + Enter로 새 행을 추가합니다.'
             }
             maxLength={10000}
-            autoFocus
+            autoFocus={isMobile ? false : true}
             readOnly={isSendingImage}
           />
           <S.ButtonContainer $isMobile={isMobile}>


### PR DESCRIPTION
# [FE] 모바일에서 채팅 입력창에 자동으로 포커스 하지 않도록 변경
## 이슈번호
> close #933 

## PR 내용
- 채팅 페이지 입장시 채팅 입력창에 자동으로 포커스 하지 않도록 변경
    - 이유: 메뉴에 단순 입장한 것만으로 자동 포커스가 되면, 키패드가 자동으로 열려 UX 저하를 유발할 수 있어보인다