### PR TITLE
[BE] Schedule Description null 가능성 제거

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/ical4j/ICal4jParser.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/ical4j/ICal4jParser.java
@@ -35,17 +35,21 @@ public class ICal4jParser implements IcalendarParser {
 
     @Override
     public String parse(final TeamPlace teamPlace, final List<Schedule> schedules) {
+        try {
+            final Calendar calendar = generateCalendar(teamPlace);
 
-        final Calendar calendar = generateCalendar(teamPlace);
+            final List<VEvent> vEvents = schedules.stream()
+                    .map(vEventParser::parse)
+                    .toList();
 
-        final List<VEvent> vEvents = schedules.stream()
-                .map(vEventParser::parse)
-                .toList();
-
-        for (VEvent vEvent : vEvents) {
-            calendar.add(vEvent);
+            for (VEvent vEvent : vEvents) {
+                calendar.add(vEvent);
+            }
+            return calendar.toString();
+        } catch (RuntimeException e) {
+            log.error("ICS parsing 에러 " + e.getMessage());
+            throw e;
         }
-        return calendar.toString();
     }
 
     private Calendar generateCalendar(final TeamPlace teamPlace) {

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/ical4j/VEventParser.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/ical4j/VEventParser.java
@@ -25,7 +25,7 @@ public class VEventParser {
         final Temporal endTemporal = getEndTemporal(schedule);
 
         final VEvent vEvent = new VEvent(startTemporal, endTemporal, title);
-        if (schedule.getDescription().isExist()) {
+        if (schedule.hasDescription()) {
             vEvent.withProperty(new Description(schedule.getDescription().getValue()));
         }
 

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
@@ -48,7 +48,7 @@ public class Schedule extends BaseEntity {
     public Schedule(final Long teamPlaceId, final Title title, final Description description, final Span span) {
         this.teamPlaceId = teamPlaceId;
         this.title = title;
-        this.description = description;
+        this.description = (description != null) ? description : new Description(null);
         this.span = span;
     }
 
@@ -66,6 +66,13 @@ public class Schedule extends BaseEntity {
 
     public void changeSpan(final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
         this.span = new Span(startDateTime, endDateTime);
+    }
+
+    public boolean hasDescription() {
+        if (description == null || !description.isExist()) {
+            return false;
+        }
+        return true;
     }
 
     public LocalDateTime getStartDateTime() {


### PR DESCRIPTION
> #945  

## PR 내용

- Schedule 생성시 `Description` 필드에 null 할당 방지
- Schedule에 Description이 있는지 여부 묻는 메서드 추가
- ICS 파싱중 예외 발생시 로깅 추가