### PR TITLE
[FE] 팀 피드/팀 링크에서의 최상위 도메인명 조건 완화

### DIFF
--- a/frontend/src/components/feed/Thread/Thread.stories.ts
+++ b/frontend/src/components/feed/Thread/Thread.stories.ts
@@ -224,3 +224,19 @@ export const ThreadWithLinkAndSentByMe: Story = {
     },
   },
 };
+
+export const ThreadWithLinkAndLongDomain: Story = {
+  args: {
+    authorName: '엣지케이스를 제공하는 필립',
+    isMe: false,
+    profileImageUrl:
+      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQYZjvO1QuvfgCfQxBwwzmJcHIT5pTXIBGOLeyBDIbZknn6Dhkd40WrU0ZCdjt-IoXLzI0&usqp=CAU',
+    createdAt: '2024-03-08 15:48',
+    content: '지금 바로 접속: https://whatever.community/mock-resume',
+    images: [],
+    isContinue: false,
+    onClickImage: (images, selectedImage) => {
+      alert(JSON.stringify({ images, selectedImage }));
+    },
+  },
+};

--- a/frontend/src/constants/link.ts
+++ b/frontend/src/constants/link.ts
@@ -1,4 +1,4 @@
 export const linkTableHeaderValues = ['링크명', '이름', '날짜', ''];
 
 export const URL_REGEX =
-  /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i;
+  /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,12}(:[0-9]{1,5})?(\/.*)?$/i;


### PR DESCRIPTION
# [FE] 팀 피드/팀 링크에서의 최상위 도메인명 조건 완화
## 이슈번호
> close #953 

## PR 내용
본 이슈에서는 팀 피드/팀 링크에서 사용되는 URL을 검증하는 정규 표현식의 조건을 완화시켜, 이름이 긴 최상위 도메인명들 또한 유효한 링크로 판정할 수 있도록 로직을 수정하였다. 

- 올바른 URL인지를 판정하는 정규 표현식의 조건을, 최상위 도메인 **2~5**자에서 **2~12**자로 조건을 수정하였다.

바뀐 URL의 조건은 팀 피드에서 입력된 링크를 하이퍼링크로 인식할 것인지, 팀 링크에서 링크를 등록할 때 올바른 URL인지를 판별하는 로직에 영향을 준다.

## 참고자료
![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/518235ba-1812-45b4-8853-fe6574bd3c52)

![image](https://github.com/woowacourse-teams/2023-team-by-team/assets/87642422/583a905d-ec78-444a-bef7-ae9b52bb7eb5)
