### PR TITLE
[BE] 팀채팅시 이벤트 발행에 db조회 제거

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedReadService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedReadService.java
@@ -101,12 +101,7 @@ public class FeedReadService {
 
     private List<FeedImageResponse> mapToFeedImageResponse(final FeedThread feedThread) {
         final List<FeedThreadImage> images = feedThread.getImages();
-        return images.stream().map(feedThreadImage ->
-                        new FeedImageResponse(
-                                feedThreadImage.getId(),
-                                feedThreadImage.isExpired(),
-                                feedThreadImage.getImageName().getValue(),
-                                feedThreadImage.getImageUrl().getValue()))
+        return images.stream().map(FeedImageResponse::from)
                 .toList();
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
@@ -81,7 +81,7 @@ public class FeedWriteService {
                 imageResponses,
                 memberEmailDto.email()
         );
-        sendFeedWritingEvent(responseForMe);
+        sendFeedWritingEvent(responseForMe, teamPlaceId);
 
         return threadId;
     }
@@ -126,7 +126,7 @@ public class FeedWriteService {
                 .toList();
     }
 
-    private void sendFeedWritingEvent(final FeedResponse response) {
-        applicationEventPublisher.publishEvent(new FeedEvent(response));
+    private void sendFeedWritingEvent(final FeedResponse response, final Long teamPlaceId) {
+        applicationEventPublisher.publishEvent(new FeedEvent(response, teamPlaceId));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import team.teamby.teambyteam.feed.application.dto.FeedImageResponse;
+import team.teamby.teambyteam.feed.application.dto.FeedResponse;
 import team.teamby.teambyteam.feed.application.dto.FeedThreadWritingRequest;
 import team.teamby.teambyteam.feed.application.event.FeedEvent;
 import team.teamby.teambyteam.feed.domain.FeedRepository;
@@ -22,9 +24,11 @@ import team.teamby.teambyteam.filesystem.FileStorageManager;
 import team.teamby.teambyteam.filesystem.util.FileUtil;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.MemberRepository;
+import team.teamby.teambyteam.member.domain.MemberTeamPlace;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.exception.MemberException;
+import team.teamby.teambyteam.member.exception.MemberTeamPlaceException;
 
 import java.util.List;
 import java.util.Objects;
@@ -43,6 +47,7 @@ public class FeedWriteService {
     private final FeedRepository feedRepository;
     private final FeedThreadImageRepository feedThreadImageRepository;
     private final MemberRepository memberRepository;
+    private final MemberTeamPlaceRepository memberTeamPlaceRepository;
     private final FileStorageManager fileStorageManager;
 
     @Value("${aws.s3.image-directory}")
@@ -61,14 +66,22 @@ public class FeedWriteService {
         final Long memberId = memberRepository.findIdByEmail(new Email(memberEmailDto.email()))
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(memberEmailDto.email()))
                 .id();
+        final MemberTeamPlace author = memberTeamPlaceRepository.findByTeamPlaceIdAndMemberId(teamPlaceId, memberId)
+                .orElseThrow(() -> new MemberTeamPlaceException.NotFoundParticipatedTeamPlaceException(memberEmailDto.email(), teamPlaceId));
 
         final FeedThread savedFeedThread = feedRepository.save(new FeedThread(teamPlaceId, new Content(content), memberId));
-        saveImages(images, savedFeedThread);
+        final List<FeedImageResponse> imageResponses = saveImages(images, savedFeedThread);
 
         final Long threadId = savedFeedThread.getId();
         log.info("스레드 생성 - 생성자 이메일 : {}, 스레드 아이디 : {}", memberEmailDto.email(), threadId);
 
-        sendFeedWritingEvent(savedFeedThread);
+        final FeedResponse responseForMe = FeedResponse.from(
+                savedFeedThread,
+                author,
+                imageResponses,
+                memberEmailDto.email()
+        );
+        sendFeedWritingEvent(responseForMe);
 
         return threadId;
     }
@@ -99,19 +112,21 @@ public class FeedWriteService {
         }
     }
 
-    private void saveImages(final List<MultipartFile> images, final FeedThread savedFeedThread) {
-        images.forEach(image -> {
-            final String originalFilename = image.getOriginalFilename();
-            final String generatedImageUrl = fileStorageManager.upload(image, imageDirectory + "/" + UUID.randomUUID(), originalFilename);
-            final ImageUrl imageUrl = new ImageUrl(generatedImageUrl);
-            final ImageName imageName = new ImageName(originalFilename);
-            final FeedThreadImage feedThreadImage = new FeedThreadImage(imageUrl, imageName);
-            feedThreadImage.confirmFeedThread(savedFeedThread);
-            feedThreadImageRepository.save(feedThreadImage);
-        });
+    private List<FeedImageResponse> saveImages(final List<MultipartFile> images, final FeedThread savedFeedThread) {
+        return images.stream().map(image -> {
+                    final String originalFilename = image.getOriginalFilename();
+                    final String generatedImageUrl = fileStorageManager.upload(image, imageDirectory + "/" + UUID.randomUUID(), originalFilename);
+                    final ImageUrl imageUrl = new ImageUrl(generatedImageUrl);
+                    final ImageName imageName = new ImageName(originalFilename);
+                    final FeedThreadImage feedThreadImage = new FeedThreadImage(imageUrl, imageName);
+                    feedThreadImage.confirmFeedThread(savedFeedThread);
+                    return feedThreadImageRepository.save(feedThreadImage);
+                })
+                .map(FeedImageResponse::from)
+                .toList();
     }
 
-    private void sendFeedWritingEvent(final FeedThread savedFeedThread) {
-        applicationEventPublisher.publishEvent(new FeedEvent(savedFeedThread.getId()));
+    private void sendFeedWritingEvent(final FeedResponse response) {
+        applicationEventPublisher.publishEvent(new FeedEvent(response));
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/dto/FeedImageResponse.java
@@ -1,9 +1,20 @@
 package team.teamby.teambyteam.feed.application.dto;
 
+import team.teamby.teambyteam.feed.domain.image.FeedThreadImage;
+
 public record FeedImageResponse(
         Long id,
         Boolean isExpired,
         String name,
         String url
 ) {
+
+    public static FeedImageResponse from(final FeedThreadImage feedThreadImage) {
+        return new FeedImageResponse(
+                feedThreadImage.getId(),
+                feedThreadImage.isExpired(),
+                feedThreadImage.getImageName().getValue(),
+                feedThreadImage.getImageUrl().getValue()
+        );
+    }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedEvent.java
@@ -5,11 +5,13 @@ import team.teamby.teambyteam.feed.application.dto.FeedResponse;
 
 public class FeedEvent implements DomainEvent<Long> {
     private final Long feedId;
+    private final Long teamPlaceId;
     private final FeedResponse response;
 
-    public FeedEvent(final FeedResponse response) {
+    public FeedEvent(final FeedResponse response, final Long teamPlaceId) {
         this.feedId = response.id();
         this.response = response;
+        this.teamPlaceId = teamPlaceId;
     }
 
     @Override
@@ -19,5 +21,9 @@ public class FeedEvent implements DomainEvent<Long> {
 
     public FeedResponse response() {
         return response;
+    }
+
+    public Long getTeamPlaceId() {
+        return teamPlaceId;
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedEvent.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/event/FeedEvent.java
@@ -1,16 +1,23 @@
 package team.teamby.teambyteam.feed.application.event;
 
 import team.teamby.teambyteam.common.domain.DomainEvent;
+import team.teamby.teambyteam.feed.application.dto.FeedResponse;
 
 public class FeedEvent implements DomainEvent<Long> {
     private final Long feedId;
+    private final FeedResponse response;
 
-    public FeedEvent(final Long feedId) {
-        this.feedId = feedId;
+    public FeedEvent(final FeedResponse response) {
+        this.feedId = response.id();
+        this.response = response;
     }
 
     @Override
     public Long getDomainId() {
         return feedId;
+    }
+
+    public FeedResponse response() {
+        return response;
     }
 }

--- a/backend/src/test/java/team/teamby/teambyteam/sse/domain/converter/FeedEventConverterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/domain/converter/FeedEventConverterTest.java
@@ -61,7 +61,7 @@ class FeedEventConverterTest {
                 savedMember.getEmailValue()
         );
 
-        final FeedEvent testEvent = new FeedEvent(response);
+        final FeedEvent testEvent = new FeedEvent(response, savedTeamPlace.getId());
 
         // when
         final TeamPlaceSseEvent sseEvent = feedEventConverter.convert(testEvent);

--- a/backend/src/test/java/team/teamby/teambyteam/sse/domain/converter/FeedEventConverterTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sse/domain/converter/FeedEventConverterTest.java
@@ -54,7 +54,14 @@ class FeedEventConverterTest {
 
         final Feed savedFeed = testFixtureBuilder.buildFeed(FeedThreadFixtures.CONTENT_ONLY_AND_IMAGE_EMPTY(savedTeamPlace.getId(), savedMember.getId()));
 
-        final FeedEvent testEvent = new FeedEvent(savedFeed.getId());
+        final FeedResponse response = FeedResponse.from(
+                savedFeed,
+                savedMemberTeamplcae,
+                null,
+                savedMember.getEmailValue()
+        );
+
+        final FeedEvent testEvent = new FeedEvent(response);
 
         // when
         final TeamPlaceSseEvent sseEvent = feedEventConverter.convert(testEvent);


### PR DESCRIPTION
## PR 내용

- 채팅으로 인한 sse 이벤트 발행시 채팅 내용 조회를 위한 db조회 제거

초기  db조회 없이 발행을 하도록 하였다가 코드의 일관성 (domain event) 을 위해 이벤트에는 내용등 정보 없이 이벤트 발행시 최초 1회 다시 db조회를 하도록 변경

해당 기능 구현 이후 db조회로 인한 채팅 성능의 하락이 눈에 띌 정도로 생김

일단은 사용자들의 불편함 없는 경험이 중요하다고 생각하여 db조회 없이 피드 sse 를 발행할 수 있도록 재 변경 진행

## 참고자료

## 의논할 거리
