### PR TITLE
[FE] 채팅 시 SSE에 의해 수신되는 내용이 늦게 반영되는 문제 해결

### DIFF
--- a/frontend/src/hooks/queries/useSSE.ts
+++ b/frontend/src/hooks/queries/useSSE.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect } from 'react';
-import { type InfiniteData, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
 import { baseUrl } from '~/apis/http';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useToken } from '~/hooks/useToken';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
-import { type ThreadsResponse } from '~/apis/feed';
+import type { ThreadsResponse } from '~/apis/feed';
 
 export const useSSE = () => {
   const queryClient = useQueryClient();
@@ -34,11 +35,20 @@ export const useSSE = () => {
 
       queryClient.setQueryData<InfiniteData<ThreadsResponse>>(
         ['threadData', teamPlaceId],
-        (old) => {
-          if (old) {
-            old.pages[0].threads = [newThread, ...old.pages[0].threads];
+        (oldData) => {
+          if (oldData) {
+            const newFirstPageThreads = {
+              threads: [newThread, ...oldData.pages[0].threads],
+            };
+            const newData = {
+              pageParams: oldData.pageParams,
+              pages:
+                oldData.pages.length === 1
+                  ? [newFirstPageThreads]
+                  : [newFirstPageThreads, ...oldData.pages.slice(1)],
+            };
 
-            return old;
+            return newData;
           }
         },
       );


### PR DESCRIPTION
# [FE] 채팅 시 SSE에 의해 수신되는 내용이 늦게 반영되는 문제 해결
## 이슈번호
> close #959

## PR 내용
본 PR에서는 새로운 채팅을 입력할 때, 또는 SSE로부터 새로운 메시지를 수신받을 때 바로 새로운 채팅이 제대로 반영되지 않는 문제를 해결하였다.
- 기존 채팅의 경우 SSE로부터 새로운 메시지를 수신했을 때 수신은 감지되나 채팅이 바로 업데이트되지 않고, 사용자가 채팅창에 새로운 내용을 입력하거나, 공지 체크박스를 작동시키는 등 채팅창과 상호작용을 한 경우에 그제서야 반응되는 문제가 있었다.
- 본 PR 반영 이후에는 SSE로부터 새로운 메시지를 수신받았을 때 그 즉시 채팅창을 업데이트해 최신 채팅이 바로 보이도록 반영하였다.

원리 및 작동 화면은 하단의 코멘트에서 보충하여 설명한다.
