### PR TITLE
[BE] common-global package 분배, 일부 양방향 의존 해결

### DIFF
--- a/backend/src/main/java/team/teamby/teambyteam/common/domain/BaseEntity.java
+++ b/backend/src/main/java/team/teamby/teambyteam/common/domain/BaseEntity.java
@@ -1,4 +1,4 @@
-package team.teamby.teambyteam.global.domain;
+package team.teamby.teambyteam.common.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/application/FeedWriteService.java
@@ -21,6 +21,7 @@ import team.teamby.teambyteam.feed.domain.vo.Content;
 import team.teamby.teambyteam.feed.exception.FeedException;
 import team.teamby.teambyteam.filesystem.AllowedImageExtension;
 import team.teamby.teambyteam.filesystem.FileStorageManager;
+import team.teamby.teambyteam.filesystem.exception.FileControlException;
 import team.teamby.teambyteam.filesystem.util.FileUtil;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.MemberRepository;
@@ -107,8 +108,16 @@ public class FeedWriteService {
         if (image.getSize() > LIMIT_IMAGE_SIZE) {
             throw new FeedException.ImageSizeException(LIMIT_IMAGE_SIZE, image.getSize());
         }
-        if (AllowedImageExtension.isNotContain(FileUtil.getFileExtension(image))) {
+        if (AllowedImageExtension.isNotContain(getFileExtension(image))) {
             throw new FeedException.NotAllowedImageExtensionException(image.getOriginalFilename());
+        }
+    }
+
+    private String getFileExtension(final MultipartFile file) {
+        try {
+            return FileUtil.getFileExtension(file);
+        } catch (final FileControlException.FileExtensionException e) {
+            throw new FeedException.NotFoundImageExtensionException(file.getOriginalFilename());
         }
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/Feed.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/Feed.java
@@ -13,7 +13,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.feed.domain.vo.Content;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 
 @DiscriminatorColumn(name = "type")
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/backend/src/main/java/team/teamby/teambyteam/feed/domain/image/FeedThreadImage.java
+++ b/backend/src/main/java/team/teamby/teambyteam/feed/domain/image/FeedThreadImage.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 import team.teamby.teambyteam.feed.domain.FeedThread;
 import team.teamby.teambyteam.feed.domain.image.vo.ImageName;
 import team.teamby.teambyteam.feed.domain.image.vo.ImageUrl;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/exception/FileControlException.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/exception/FileControlException.java
@@ -5,7 +5,17 @@ public class FileControlException extends RuntimeException {
         super(cause);
     }
 
+    public FileControlException(final String message) {
+        super(message);
+    }
+
     public FileControlException(final String message, final Throwable cause) {
         super(message, cause);
+    }
+
+    public static class FileExtensionException extends FileControlException {
+        public FileExtensionException(final String message) {
+            super(message);
+        }
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/filesystem/util/FileUtil.java
+++ b/backend/src/main/java/team/teamby/teambyteam/filesystem/util/FileUtil.java
@@ -1,12 +1,14 @@
 package team.teamby.teambyteam.filesystem.util;
 
-import java.util.Objects;
 import org.springframework.web.multipart.MultipartFile;
-import team.teamby.teambyteam.feed.exception.FeedException;
+import team.teamby.teambyteam.filesystem.exception.FileControlException;
+
+import java.util.Objects;
 
 public class FileUtil {
 
-    private FileUtil() {}
+    private FileUtil() {
+    }
 
     public static String getFileExtension(final MultipartFile file) {
         final String originalFilename = file.getOriginalFilename();
@@ -17,6 +19,6 @@ public class FileUtil {
             }
         }
 
-        throw new FeedException.NotFoundImageExtensionException(originalFilename);
+        throw new FileControlException.FileExtensionException("파일 확장자를 찾을 수 없습니다.");
     }
 }

--- a/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/PublishedIcalendar.java
+++ b/backend/src/main/java/team/teamby/teambyteam/icalendar/domain/PublishedIcalendar.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.icalendar.domain.vo.IcalendarFileName;
 import team.teamby.teambyteam.icalendar.domain.vo.PublishUrl;
 

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/MemberService.java
@@ -9,7 +9,7 @@ import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
-import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
+import team.teamby.teambyteam.member.application.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.domain.IdOnly;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;

--- a/backend/src/main/java/team/teamby/teambyteam/member/application/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/application/dto/MemberUpdateRequest.java
@@ -1,4 +1,4 @@
-package team.teamby.teambyteam.member.configuration.dto;
+package team.teamby.teambyteam.member.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/Member.java
@@ -11,7 +11,7 @@ import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.Email;
 import team.teamby.teambyteam.member.domain.vo.Name;

--- a/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/domain/MemberTeamPlace.java
@@ -13,7 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.member.domain.vo.DisplayMemberName;
 import team.teamby.teambyteam.member.domain.vo.DisplayTeamPlaceName;
 import team.teamby.teambyteam.teamplace.domain.TeamPlace;

--- a/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
+++ b/backend/src/main/java/team/teamby/teambyteam/member/presentation/MemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.teamby.teambyteam.member.application.MemberService;
-import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
+import team.teamby.teambyteam.member.application.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.application.dto.MemberInfoResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.configuration.AuthPrincipal;

--- a/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/application/NoticeService.java
@@ -1,11 +1,5 @@
 package team.teamby.teambyteam.notice.application;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team.teamby.teambyteam.filesystem.AllowedImageExtension;
 import team.teamby.teambyteam.filesystem.FileStorageManager;
+import team.teamby.teambyteam.filesystem.exception.FileControlException;
 import team.teamby.teambyteam.filesystem.util.FileUtil;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
 import team.teamby.teambyteam.member.domain.IdOnly;
@@ -38,6 +33,13 @@ import team.teamby.teambyteam.notice.exception.NoticeException;
 import team.teamby.teambyteam.notice.exception.NoticeException.WritingRequestEmptyException;
 import team.teamby.teambyteam.teamplace.domain.TeamPlaceRepository;
 import team.teamby.teambyteam.teamplace.exception.TeamPlaceException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -116,8 +118,16 @@ public class NoticeService {
         if (image.getSize() > LIMIT_IMAGE_SIZE) {
             throw new NoticeException.ImageSizeException(LIMIT_IMAGE_SIZE, image.getSize());
         }
-        if (AllowedImageExtension.isNotContain(FileUtil.getFileExtension(image))) {
+        if (AllowedImageExtension.isNotContain(getFileExtension(image))) {
             throw new NoticeException.NotAllowedImageExtensionException(image.getOriginalFilename());
+        }
+    }
+
+    private String getFileExtension(final MultipartFile file) {
+        try {
+            return FileUtil.getFileExtension(file);
+        } catch (final FileControlException.FileExtensionException e) {
+            throw new NoticeException.NotFoundImageExtensionException(file.getOriginalFilename());
         }
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/notice/domain/Notice.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/domain/Notice.java
@@ -11,7 +11,7 @@ import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.notice.domain.image.NoticeImage;
 import team.teamby.teambyteam.notice.domain.vo.Content;
 

--- a/backend/src/main/java/team/teamby/teambyteam/notice/domain/image/NoticeImage.java
+++ b/backend/src/main/java/team/teamby/teambyteam/notice/domain/image/NoticeImage.java
@@ -11,7 +11,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.notice.domain.Notice;
 import team.teamby.teambyteam.notice.domain.image.vo.ImageName;
 import team.teamby.teambyteam.notice.domain.image.vo.ImageUrl;

--- a/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
+++ b/backend/src/main/java/team/teamby/teambyteam/schedule/domain/Schedule.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.schedule.domain.vo.Description;
 import team.teamby.teambyteam.schedule.domain.vo.Span;
 import team.teamby.teambyteam.schedule.domain.vo.Title;

--- a/backend/src/main/java/team/teamby/teambyteam/sharedlink/domain/SharedLink.java
+++ b/backend/src/main/java/team/teamby/teambyteam/sharedlink/domain/SharedLink.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.sharedlink.domain.vo.SharedURL;
 import team.teamby.teambyteam.sharedlink.domain.vo.Title;
 import team.teamby.teambyteam.sharedlink.exception.SharedLinkException;

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlace.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlace.java
@@ -8,7 +8,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.teamplace.domain.vo.Name;
 
 @Getter

--- a/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceInviteCode.java
+++ b/backend/src/main/java/team/teamby/teambyteam/teamplace/domain/TeamPlaceInviteCode.java
@@ -11,7 +11,7 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.teamplace.domain.vo.InviteCode;
 
 @Getter

--- a/backend/src/main/java/team/teamby/teambyteam/token/domain/Token.java
+++ b/backend/src/main/java/team/teamby/teambyteam/token/domain/Token.java
@@ -11,7 +11,7 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.teamby.teambyteam.global.domain.BaseEntity;
+import team.teamby.teambyteam.common.domain.BaseEntity;
 import team.teamby.teambyteam.member.domain.Member;
 
 @Entity

--- a/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/team/teamby/teambyteam/common/fixtures/acceptance/MemberAcceptanceFixture.java
@@ -6,7 +6,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
+import team.teamby.teambyteam.member.application.dto.MemberUpdateRequest;
 
 public class MemberAcceptanceFixture {
 

--- a/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/acceptance/MemberAcceptanceTest.java
@@ -14,7 +14,7 @@ import team.teamby.teambyteam.common.fixtures.MemberFixtures;
 import team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures;
 import team.teamby.teambyteam.common.fixtures.TokenFixtures;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
-import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
+import team.teamby.teambyteam.member.application.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.teamplace.application.dto.TeamPlaceParticipantResponse;

--- a/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/member/application/MemberServiceTest.java
@@ -16,7 +16,7 @@ import team.teamby.teambyteam.member.application.dto.TeamPlaceResponse;
 import team.teamby.teambyteam.member.application.dto.TeamPlacesResponse;
 import team.teamby.teambyteam.member.application.event.MemberLeaveEvent;
 import team.teamby.teambyteam.member.configuration.dto.MemberEmailDto;
-import team.teamby.teambyteam.member.configuration.dto.MemberUpdateRequest;
+import team.teamby.teambyteam.member.application.dto.MemberUpdateRequest;
 import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberRepository;
 import team.teamby.teambyteam.member.domain.MemberTeamPlace;

--- a/backend/src/test/java/team/teamby/teambyteam/sharedlink/application/SharedLinkServiceTest.java
+++ b/backend/src/test/java/team/teamby/teambyteam/sharedlink/application/SharedLinkServiceTest.java
@@ -1,7 +1,6 @@
 package team.teamby.teambyteam.sharedlink.application;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,8 +15,6 @@ import team.teamby.teambyteam.member.domain.Member;
 import team.teamby.teambyteam.member.domain.MemberTeamPlaceRepository;
 import team.teamby.teambyteam.sharedlink.application.dto.SharedLinkCreateRequest;
 import team.teamby.teambyteam.sharedlink.application.dto.SharedLinksResponse;
-import team.teamby.teambyteam.sharedlink.application.event.SharedLinkCreateEvent;
-import team.teamby.teambyteam.sharedlink.application.event.SharedLinkDeleteEvent;
 import team.teamby.teambyteam.sharedlink.domain.SharedLink;
 import team.teamby.teambyteam.sharedlink.domain.SharedLinkRepository;
 import team.teamby.teambyteam.sharedlink.exception.SharedLinkException;
@@ -27,7 +24,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static team.teamby.teambyteam.common.fixtures.SharedLinkFixtures.TEAM_BY_TEAM_LINK;
-import static team.teamby.teambyteam.common.fixtures.TeamPlaceFixtures.ENGLISH_TEAM_PLACE;
 
 class SharedLinkServiceTest extends ServiceTest {
 


### PR DESCRIPTION
## PR 내용

- global -> domain pacakges -> common 방향으로 의존성 흐름 정리
- filesystem package에서 feed패키지에 의존하는 문제 해결

### 추후 참고사항

- Member 관련 패키지 추가 작업필요
  - 인증관련해서 변화가 복잡할것으로 판단되어 PR분리
  - 마찬가지로 member - memberTeamPlace - teamPlace 사이 관계도 분리