### PR TITLE
[BE] websocket configuration

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-rsocket'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-logging'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'mysql:mysql-connector-java:8.0.33'

--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebSocketConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebSocketConfiguration.java
@@ -18,7 +18,6 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     @Override
     public void registerStompEndpoints(final StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/chat")
-                .setAllowedOrigins("*")
                 .withSockJS();
     }
 

--- a/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebSocketConfiguration.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/configuration/WebSocketConfiguration.java
@@ -1,0 +1,30 @@
+package team.teamby.teambyteam.global.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import team.teamby.teambyteam.global.presentation.ConnectInboundChannelInterceptor;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer {
+
+    private final ConnectInboundChannelInterceptor connectInboundChannelInterceptor;
+
+    @Override
+    public void registerStompEndpoints(final StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOrigins("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(final ChannelRegistration registration) {
+        registration.interceptors(connectInboundChannelInterceptor);
+        WebSocketMessageBrokerConfigurer.super.configureClientInboundChannel(registration);
+    }
+}

--- a/backend/src/main/java/team/teamby/teambyteam/global/presentation/ConnectInboundChannelInterceptor.java
+++ b/backend/src/main/java/team/teamby/teambyteam/global/presentation/ConnectInboundChannelInterceptor.java
@@ -1,0 +1,50 @@
+package team.teamby.teambyteam.global.presentation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import team.teamby.teambyteam.auth.exception.AuthenticationException;
+import team.teamby.teambyteam.auth.jwt.JwtTokenProvider;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public final class ConnectInboundChannelInterceptor implements ChannelInterceptor {
+
+    private static final String PREFIX_BEARER = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        if (!StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        final String token = extractAccessToken(accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+        try {
+            jwtTokenProvider.extractEmailFromAccessToken(token);
+            return message;
+        } catch (RuntimeException ignored) {
+            log.error("socket not connected.{}", ignored.getMessage());
+        }
+
+        return null;
+    }
+
+    private String extractAccessToken(final String authorizationHeader) {
+        if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith(PREFIX_BEARER)) {
+            return authorizationHeader.substring(PREFIX_BEARER.length());
+        }
+        final String logMessage = "인증 실패(액세스 토큰 추출 실패) - 토큰 : " + authorizationHeader;
+        throw new AuthenticationException.FailAuthenticationException(logMessage);
+    }
+}


### PR DESCRIPTION
> 개인이 올린 PR은 Action이 안됩니다. 이후 다시 올리도록 하겠습니다.

# [BE] PR websocket configuration 
## 이슈번호
> 해당되는 모든 번호를 태그해주세요
#975 

## PR 내용
웹소켓 handshake 이후 stomp CONNECT 과정 까지의 설정입니다.

## 참고자료

## 의논할 거리
1. 생각해보니 에러관련된 이야기를 해본적이 없긴 한데 웹소켓 에러처리는 REST API랑 다르게 가져가야되나 고민입니다. 일단은 return null;을 해서 요청을 무시시킵니다.
2. JwtTokenExtractor는 HttpServletRequest로 받고 있어서 호환이 되지 않고, JwtTokenProvider는 검증용으로 사용하는 중이긴 한데 적절히 책임분리를 추가로 진행할 필요가 있어보입니다. 근데 지금 태스크가 아니라 일단 넘어갔습니다.
