### PR TITLE
[FE] 팀 피드의 채팅을 Stomp/Websocket에 연결

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@stomp/stompjs": "^7.0.0",
         "@storybook/addon-controls": "^8.4.7",
         "@tanstack/react-query": "^4.29.25",
         "@tanstack/react-query-devtools": "^4.36.1",
@@ -3387,6 +3388,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@storybook/addon-actions": {
       "version": "8.4.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.0.0",
     "@storybook/addon-controls": "^8.4.7",
     "@tanstack/react-query": "^4.29.25",
     "@tanstack/react-query-devtools": "^4.36.1",

--- a/frontend/src/hooks/queries/useStompThread.ts
+++ b/frontend/src/hooks/queries/useStompThread.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
+import { useToken } from '~/hooks/useToken';
+import { useTeamPlace } from '~/hooks/useTeamPlace';
+import type { ThreadsResponse } from '~/apis/feed';
+import { Client } from '@stomp/stompjs';
+import type { StompThreadRequest, StompThreadResponse } from '~/types/feed';
+import { baseUrl } from '~/apis/http';
+
+const BASE_URL = baseUrl === undefined ? 'http://localhost:3000' : baseUrl;
+
+export const useStompThread = () => {
+  const queryClient = useQueryClient();
+  const { accessToken } = useToken();
+  const { teamPlaceId } = useTeamPlace();
+  const [client, setClient] = useState<Client | null>(null);
+
+  useEffect(() => {
+    if (!teamPlaceId) {
+      return;
+    }
+
+    const stompClient = new Client({
+      brokerURL: `${BASE_URL}/ws/chat`,
+      connectHeaders: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      onConnect: () => {
+        stompClient.subscribe(
+          `/topic/room/${teamPlaceId}`,
+          (incomingMessage) => {
+            const stompThreadResponse: StompThreadResponse = JSON.parse(
+              incomingMessage.body,
+            );
+            const { requestId, ...newThread } = stompThreadResponse;
+
+            queryClient.setQueryData<InfiniteData<ThreadsResponse>>(
+              ['threadData', teamPlaceId],
+              (oldData) => {
+                if (oldData) {
+                  const newFirstPageThreads = {
+                    threads: [
+                      { ...newThread, type: 'thread' },
+                      ...oldData.pages[0].threads,
+                    ],
+                  };
+                  const newData = {
+                    pageParams: oldData.pageParams,
+                    pages:
+                      oldData.pages.length === 1
+                        ? [newFirstPageThreads]
+                        : [newFirstPageThreads, ...oldData.pages.slice(1)],
+                  };
+
+                  return newData;
+                }
+              },
+            );
+          },
+          { Authorization: `Bearer ${accessToken}` },
+        );
+      },
+      reconnectDelay: 5000,
+    });
+
+    setClient(stompClient);
+    stompClient.activate();
+
+    return () => {
+      if (stompClient) {
+        stompClient.deactivate();
+      }
+    };
+  }, [accessToken, queryClient, teamPlaceId]);
+
+  const sendThreadToStomp = (threadRequestInfo: StompThreadRequest) => {
+    const { content, imageIds, requestId } = threadRequestInfo;
+
+    if (!client || (content.trim() === '' && imageIds.length === 0)) {
+      return;
+    }
+
+    client.publish({
+      destination: `/app/room/${teamPlaceId}`,
+      body: JSON.stringify({ content, imageIds }),
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        RequestId: requestId,
+        body: JSON.stringify({ content, imageIds }),
+      },
+    });
+  };
+
+  return { sendThreadToStomp };
+};

--- a/frontend/src/hooks/thread/useTeamFeedPage.ts
+++ b/frontend/src/hooks/thread/useTeamFeedPage.ts
@@ -6,12 +6,15 @@ import type {
 import { useEffect, useRef, useState } from 'react';
 import { useFetchNoticeThread } from '~/hooks/queries/useFetchNoticeThread';
 import { useSendNoticeThread } from '~/hooks/queries/useSendNoticeThread';
-import { useSendThread } from '~/hooks/queries/useSendThread';
 import { useImageUpload } from '~/hooks/thread/useImageUpload';
 import { useTeamPlace } from '~/hooks/useTeamPlace';
 import { useToast } from '~/hooks/useToast';
+import type { StompThreadRequest } from '~/types/feed';
+import { generateUuid } from '~/utils/generateUuid';
 
-export const useTeamFeedPage = () => {
+export const useTeamFeedPage = (
+  onSendThreadToStomp: (threadRequestInfo: StompThreadRequest) => void,
+) => {
   const { teamPlaceId } = useTeamPlace();
   const { showToast } = useToast();
   const {
@@ -22,7 +25,6 @@ export const useTeamFeedPage = () => {
     deleteAllImages,
   } = useImageUpload();
   const { noticeThread } = useFetchNoticeThread(teamPlaceId);
-  const { mutateSendThread, isSendThreadLoading } = useSendThread(teamPlaceId);
   const { mutateSendNoticeThread, isSendNoticeThreadLoading } =
     useSendNoticeThread(teamPlaceId);
 
@@ -33,9 +35,7 @@ export const useTeamFeedPage = () => {
   const [chatContent, setChatContent] = useState('');
   const ref = useRef<HTMLDivElement>(null);
 
-  const isSendingImage =
-    (isSendNoticeThreadLoading || isSendThreadLoading) &&
-    imageFiles.length !== 0;
+  const isSendingImage = isSendNoticeThreadLoading && imageFiles.length !== 0;
 
   const handleIsNoticeChange = () => {
     setIsNotice((prev) => !prev);
@@ -110,19 +110,12 @@ export const useTeamFeedPage = () => {
       return;
     }
 
-    mutateSendThread(
-      { content: chatContent, images: imageFiles },
-      {
-        onSuccess: () => {
-          resetChatBox();
-          deleteAllImages();
-          if (isImageDrawerOpen) handleImageDrawerToggle();
-        },
-        onError: () => {
-          showToast('error', '스레드 등록에 실패했습니다.');
-        },
-      },
-    );
+    onSendThreadToStomp({
+      content: chatContent,
+      imageIds: [],
+      requestId: generateUuid(),
+    });
+    resetChatBox();
   };
 
   const resetChatBox = () => {

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -3,6 +3,7 @@ import { calendarHandlers } from '~/mocks/handlers/calendar';
 import { feedHandlers } from '~/mocks/handlers/feed';
 import { LinkHandlers } from '~/mocks/handlers/link';
 import { teamHandlers } from '~/mocks/handlers/team';
+import { stompHandlers } from '~/mocks/handlers/stomp';
 
 export const handlers = [
   ...userHandlers,
@@ -10,4 +11,5 @@ export const handlers = [
   ...feedHandlers,
   ...teamHandlers,
   ...LinkHandlers,
+  ...stompHandlers,
 ];

--- a/frontend/src/mocks/handlers/stomp.ts
+++ b/frontend/src/mocks/handlers/stomp.ts
@@ -1,0 +1,81 @@
+import { ws } from 'msw';
+import type { StompThreadResponse } from '~/types/feed';
+import { generateYYYYMMDDHHMM } from '~/utils/generateYYYYMMDDHHMM';
+
+const chat = ws.link('/ws/chat');
+
+export const stompHandlers = [
+  chat.addEventListener('connection', ({ client }) => {
+    client.addEventListener('message', (event) => {
+      const message = String(event.data);
+      const [command, ...headers] = message.split('\n\n')[0].split('\n');
+      const rawBody = message
+        .split('\n\n')
+        .slice(1)
+        .join('\n\n')
+        .replace('\0', '');
+      const body = rawBody === '' ? undefined : JSON.parse(rawBody);
+
+      if (command === 'CONNECT') {
+        client.send(
+          'CONNECTED\nversion:1.2\nheart-beat:0,0\nserver:TeamByTeamStompMockServer\n\n\0',
+        );
+
+        setTimeout(() => {
+          const connectOkThread: StompThreadResponse = {
+            id: Date.now(),
+            authorId: 1,
+            authorName: 'STOMP 모킹 서버',
+            profileImageUrl:
+              'https://github.com/user-attachments/assets/75220af3-66e8-4cda-b164-49de0b3d992b',
+            isMe: false,
+            createdAt: generateYYYYMMDDHHMM(new Date()),
+            content:
+              '성공적으로 Websocket을 이용한 STOMP 모킹 서버에 연결하였습니다.',
+            images: [],
+            requestId: '',
+          };
+
+          client.send(
+            `MESSAGE\ndestination:https://localhost:3000/topic/room/1\nsubscription:sub-0\nmessage-id:1\ncontent-type:text/plain\n\n${JSON.stringify(
+              connectOkThread,
+            )}\0`,
+          );
+        }, 100);
+
+        return;
+      }
+
+      if (command === 'SUBSCRIBE') {
+        return;
+      }
+
+      if (command === 'SEND') {
+        console.log(headers, body);
+
+        const { content } = body;
+
+        setTimeout(() => {
+          const myThread: StompThreadResponse = {
+            id: Date.now(),
+            authorId: 1,
+            authorName: '나',
+            profileImageUrl:
+              'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQYZjvO1QuvfgCfQxBwwzmJcHIT5pTXIBGOLeyBDIbZknn6Dhkd40WrU0ZCdjt-IoXLzI0&usqp=CAU',
+            isMe: true,
+            createdAt: generateYYYYMMDDHHMM(new Date()),
+            content,
+            requestId: '',
+            images: [],
+          };
+
+          client.send(
+            `MESSAGE\ndestination:/topic/room/1\nsubscription:sub-0\nmessage-id:1\ncontent-type:text/plain\n\n${JSON.stringify(
+              myThread,
+            )}\0`,
+          );
+        }, 100);
+      }
+    });
+  }),
+];

--- a/frontend/src/mocks/handlers/stomp.ts
+++ b/frontend/src/mocks/handlers/stomp.ts
@@ -51,8 +51,6 @@ export const stompHandlers = [
       }
 
       if (command === 'SEND') {
-        console.log(headers, body);
-
         const { content } = body;
 
         setTimeout(() => {

--- a/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
+++ b/frontend/src/pages/TeamFeedPage/TeamFeedPage.tsx
@@ -15,6 +15,7 @@ import { useModal } from '~/hooks/useModal';
 import { useState } from 'react';
 import type { ThreadImage } from '~/types/feed';
 import { getIsMobile } from '~/utils/getIsMobile';
+import { useStompThread } from '~/hooks/queries/useStompThread';
 
 interface TeamFeedPageProps {
   threadSize?: ThreadSize;
@@ -23,6 +24,7 @@ interface TeamFeedPageProps {
 const TeamFeedPage = (props: TeamFeedPageProps) => {
   const { threadSize = 'md' } = props;
   const isMobile = getIsMobile();
+  const { sendThreadToStomp } = useStompThread();
 
   const {
     ref,
@@ -44,7 +46,7 @@ const TeamFeedPage = (props: TeamFeedPageProps) => {
       updateImages,
       deleteImageByUuid,
     },
-  } = useTeamFeedPage();
+  } = useTeamFeedPage(sendThreadToStomp);
 
   const { isModalOpen, openModal } = useModal();
   const [modalImageInfo, setModalImageInfo] = useState<{

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -59,3 +59,26 @@ interface ThreadLink {
 export type ParsedThreadContent = (ThreadText | ThreadLink)[];
 
 export type NotificationType = 'normal' | 'join' | 'leave' | 'date';
+
+/**
+ * 채팅 전송 시 Stomp 서버로 보낼, 사용자가 입력한 채팅의 정보입니다.
+ */
+export interface StompThreadRequest {
+  /**
+   * 채팅의 내용입니다.
+   */
+  content: string;
+  /**
+   * 채팅에 첨부할 이미지의 ID값입니다. 이 ID값은 이미지를 업로드하여 **API 서버에 요청한 이후 응답으로 받은, 이미지에 대응하는 ID 값**이어야 합니다.
+   */
+  imageIds: string[];
+  /**
+   * **채팅을 식별할 때 사용할** 문자열 형태의 ID 값입니다. 이후 이 채팅이 올바르게 서버로 전달되어 서버를 통해 채팅이 내려올 경우, 서버에서 이 ID를 함께 반환하므로 이를 이용해 식별할 수 있습니다.
+   * 어떠한 문자열 값이어도 상관없으나, 충돌할 가능성이 매우 적어야 하며, 너무 긴 문자열, 공백 등 ID 값으로 적합하지 않은 값은 사용하지 말아야 합니다. UUID 값을 두는 것이 추천될 것입니다.
+   */
+  requestId: string;
+}
+
+export interface StompThreadResponse extends Omit<Thread, 'type'> {
+  requestId: string;
+}


### PR DESCRIPTION
# [FE] 팀 피드의 채팅을 Stomp/Websocket에 연결

## PR 내용
본 PR에서는 팀 피드의 채팅을 Stomp/Websocket에 연결하였다.

## 기본적인 플로우
코드가 난잡한 편인데, `useStompThread` 커스텀 훅을 위주로 보면 될 것 같아. `/mocks/handlers/stomp.ts` 에 있는 테스트 코드는 너무 주의깊게는 볼 필요가 없어. 그건 Stomp 프로토콜을 기본적으로 지원하지 않는 `msw` 라이브러리에서 어떻게든 Stomp 프로토콜을 이용하는 서버 입장에서 응답하는 상황을 노가다한 거라 코드가 더러운 편이야. 난이도도 기능보다 테스트 코드 짜는 게 더 어려워


`useStompThread`가 하는 일은 아래와 같아.
- 커스텀 훅을 실행하면 자동으로 백엔드 측의 Stomp 서버로 연결
- 채팅을 Stomp 서버를 통해 송신 가능
  - 발신 방법: 커스텀 훅이 리턴하는 `sendThreadToStomp` 함수를 사용
  - 수신 방법: 서버로부터 메시지가 도착하면 자동으로 직접 피드 페이지에 메시지에 대응되는 컴포넌트를 추가 (= SSE 때와 동일)

Stomp가 뭔지, 기본 용어가 뭔지 긴가민가하면, [이 글](https://velog.io/@gillog/Protocol-STOMP) 을 가볍게 읽고 넘어가도 좋을 것 같아. 이 PR에서는 **프로토콜**, **프레임**이라는 용어는 별도의 용어 설명 없이 사용할 거야.

[Stomp v1.2](https://stomp.github.io/stomp-specification-1.2.html) 문서도 정독해 보면 좋아. 프레임에 대한 설명은 여기 대부분 있어. 규약을 포함해서.

절차는 아래와 같아.

1. **클라이언트 측**에서 `brokerUrl`에 명시된 주소로 `CONNECT` 프레임을 보내. 이게 Stomp 프로토콜을 사용하는 웹소켓 서버로의 연결 절차야.
2. **서버 측**에서는 `CONNECTED` 프레임으로 연결되었음을 **클라이언트 측**에 통보해. 클라이언트가 `CONNECTED` 프레임이 포함된 메시지를 받았다면 연결 성공.
3. **클라이언트 측**에서 필요에 따라 원하는 만큼 `SUBSCRIBE` 프레임을 보내. 이 때 어느 `topic`에 연결할 지를 반드시 명시해야 돼. `topic`에 연결해 **구독**을 해 두면 메시지를 받을 수 있게 돼. 편의상 `topic`을 **채널**이라 생각해도 좋아. TV를 켜고 특정 채널로 돌려놓으면 그 채널에서 나오는 방송을 볼 수 있잖아? 그런 거야. 여기에서는 팀플레이스 ID에 대응되는 `topic`에 연결해. 이번에는 서버에서 별도의 프레임을 이용해 응답하지는 않아.
4. **클라이언트 측**에서 메시지를 보낼 때마다, `SEND` 프레임을 서버에 보내게 돼. 이게 채팅을 쳐서 엔터를 눌렀을 때 일어나는 일이야.
5. **서버 측**으로부터 메시지가 도착하면, `MESSAGE` 프레임이 포함된 메시지를 수신받게 돼. 어떤 `topic`들을 구독하고 있느냐에 따라 받는 메시지가 달라. 참고로 주의할 점은 클라이언트의 `SEND`에 대해 서버가 `MESSAGE`로 바로 응답하는 구조는 아니란 것. 둘은 독립적이야. 굳이 비유하자면 서로 허공에 대고 이야기하는 두 사람? 아무튼, 채팅방을 구현했다면 `MESSAGE`는 보낸 사람을 포함해 그 채팅방에 대응하는 `topic`을 구독하고 있는 모든 사용자의 클라이언트로 전송되겠지. 그럼 그걸 감지하고 새로 온 메시지를 화면에 그려내면 되는 거야.
6. 연결을 종료할 때, **클라이언트 측**에서 `UNSUBSCRIBE`, `DISCONNECT` 프레임을 서버에 보내. `UNSUBSCRIBE`는 특정 `topic`에 대한 구독을 끊는다는 거고, `DISCONNECT`는 아예 웹소켓 연결을 끊는다는 것. 지금은 `useEffect`의 cleanup 함수에 적어놓은 로직이 그 역할을 할 거야.
7. 이번에는 대응하지 않았지만, **서버 측**에서 **클라이언트 측**에 오류를 전달해야 할 때도 있어. 그 때는 `ERROR` 프레임을 사용하게 돼. 별도의 예외 처리를 하지 않았다면 웹소켓 연결은 끊기고, 설정에 따라 자동으로 재연결을 시도해. (현재 설정은 5초 후 재연결)

사정 상 모든 내용을 설명하기는 어려워, 만약 막히는 게 있으면 알려줘. 사실 나도 완벽하게 아는 건 아니야 (엔델이 훨씬 잘 알듯)

## 로그 확인 방법

`useStompThread` 코드의 일부분을 아래와 같이 변경해주면 돼. `logRawCommunication`의 경우 필수는 아니나 넣는 걸 추천하는 이유는 넣었을 때 메시지의 `body`에 해당하는 부분도 보이기 때문에 더 디버깅하기 수월해서야.

```diff
return newData;
            }
          },
        );
      },
      { Authorization: `Bearer ${accessToken}` },
    );
  },
+ debug: (content) => {
+   console.log(content);
+ },
  reconnectDelay: 5000,
+ logRawCommunication: true,
});
```

- 디버깅 리스너를 작성해 활성화한 경우 아래의 추가 로그 메시지가 나타나. 이 메시지가 (서버에 전달/서버로부터 수신)되는 메시지야.

<img src="https://github.com/user-attachments/assets/74d2bfee-4c22-4b95-8979-7c799d4f7e2d" width="600" />


- 디버깅 리스너를 작성해 활성화하고, `lowRawCommunication`까지 `true`로 설정한 경우에는, 더 자세하게 메시지가 보여. 참고로 이건 로그일 뿐이므로 서버에 전달되는 메시지가 달라진다든가 그런 건 아니야.

<img src="https://github.com/user-attachments/assets/dffa4767-b6c3-49b8-ae39-f9d8c5baa620" width="600" />


## 주의사항
1. Stomp/Websocket은 **채팅에 한하여** 적용된 상태야. 공지의 경우 여전히 기존 방식인 SSE를 사용 중이고, 이에 따라 SSE 관련 코드도 제거되지 않은 상태야.
9. 엔델이랑 같이 맞춰보고 버그를 수정하는 과정은 거쳤지만, Merge 이후 예상치 못한 버그가 발생하거나 오작동할 수 있어. 이 경우에는 여러 번 다시 수정해서 PR 적어볼 것 같은데 승인 없이 Merge 시켜도 괜찮을까?