### PR TITLE
[FE] 채팅을 올리면 애플리케이션이 터지는 문제를 해결

### DIFF
--- a/frontend/src/hooks/queries/useStompThread.ts
+++ b/frontend/src/hooks/queries/useStompThread.ts
@@ -33,7 +33,7 @@ export const useStompThread = () => {
             const stompThreadResponse: StompThreadResponse = JSON.parse(
               incomingMessage.body,
             );
-            const { requestId, ...newThread } = stompThreadResponse;
+            const { requestId, ...newThread } = stompThreadResponse.payload;
 
             queryClient.setQueryData<InfiniteData<ThreadsResponse>>(
               ['threadData', teamPlaceId],

--- a/frontend/src/mocks/handlers/stomp.ts
+++ b/frontend/src/mocks/handlers/stomp.ts
@@ -23,17 +23,19 @@ export const stompHandlers = [
 
         setTimeout(() => {
           const connectOkThread: StompThreadResponse = {
-            id: Date.now(),
-            authorId: 1,
-            authorName: 'STOMP 모킹 서버',
-            profileImageUrl:
-              'https://github.com/user-attachments/assets/75220af3-66e8-4cda-b164-49de0b3d992b',
-            isMe: false,
-            createdAt: generateYYYYMMDDHHMM(new Date()),
-            content:
-              '성공적으로 Websocket을 이용한 STOMP 모킹 서버에 연결하였습니다.',
-            images: [],
-            requestId: '',
+            payload: {
+              id: Date.now(),
+              authorId: 1,
+              authorName: 'STOMP 모킹 서버',
+              profileImageUrl:
+                'https://github.com/user-attachments/assets/75220af3-66e8-4cda-b164-49de0b3d992b',
+              isMe: false,
+              createdAt: generateYYYYMMDDHHMM(new Date()),
+              content:
+                '성공적으로 Websocket을 이용한 STOMP 모킹 서버에 연결하였습니다.',
+              images: [],
+              requestId: '',
+            },
           };
 
           client.send(
@@ -55,16 +57,18 @@ export const stompHandlers = [
 
         setTimeout(() => {
           const myThread: StompThreadResponse = {
-            id: Date.now(),
-            authorId: 1,
-            authorName: '나',
-            profileImageUrl:
-              'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQYZjvO1QuvfgCfQxBwwzmJcHIT5pTXIBGOLeyBDIbZknn6Dhkd40WrU0ZCdjt-IoXLzI0&usqp=CAU',
-            isMe: true,
-            createdAt: generateYYYYMMDDHHMM(new Date()),
-            content,
-            requestId: '',
-            images: [],
+            payload: {
+              id: Date.now(),
+              authorId: 1,
+              authorName: '나',
+              profileImageUrl:
+                'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQYZjvO1QuvfgCfQxBwwzmJcHIT5pTXIBGOLeyBDIbZknn6Dhkd40WrU0ZCdjt-IoXLzI0&usqp=CAU',
+              isMe: true,
+              createdAt: generateYYYYMMDDHHMM(new Date()),
+              content,
+              requestId: '',
+              images: [],
+            },
           };
 
           client.send(

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -79,6 +79,6 @@ export interface StompThreadRequest {
   requestId: string;
 }
 
-export interface StompThreadResponse extends Omit<Thread, 'type'> {
-  requestId: string;
+export interface StompThreadResponse {
+  payload: Omit<Thread, 'type'> & { requestId: string };
 }


### PR DESCRIPTION
# [FE] 채팅을 올리면 애플리케이션이 터지는 문제를 해결

## PR 내용
핫픽스이자 #993 에 대한 후속 픽스. 이전에 이야기한대로 바뀐 코드베이스도 없으니 즉시 Merge 진행할게.

- 발생하는 문제는 채팅을 입력해 엔터를 누른 상황에서 애플리케이션이 흰 화면이 되면서 터져. 그런데 새로고침을 하면 작성한 메시지는 제대로 반영되어 있어.
- 왜 이 문제가 있었냐면, 서버로부터 받아오는 응답 타입에 대해 내가 실수로 명세와 다른 타입으로 구현해서 그래. 

이게 올바른 타입인데

```ts
{
  payload: {
    // <스레드에 대응하는 데이터...>
  }
}
```

기존 스레드 타입과 비슷하게 이렇게 구현해 버린 상황이었어.

```ts
{
   // <스레드에 대응하는 데이터...>
}
```

그래서 타입 불일치 확인하고 수정한 거고, 여전히 문제가 발생하면 다시 원인 분석하고 새로운 PR 올릴 계획이야.
궁금한 게 있으면 질문해도 좋아!