### PR TITLE
[FE] 채팅에서 내가 보낸 메시지인지의 여부가 구분이 안 되는 문제 해결

### DIFF
--- a/frontend/src/hooks/queries/useStompThread.ts
+++ b/frontend/src/hooks/queries/useStompThread.ts
@@ -7,6 +7,7 @@ import type { ThreadsResponse } from '~/apis/feed';
 import { Client } from '@stomp/stompjs';
 import type { StompThreadRequest, StompThreadResponse } from '~/types/feed';
 import { baseUrl } from '~/apis/http';
+import { useFetchUserInfo } from '~/hooks/queries/useFetchUserInfo';
 
 const BASE_URL = baseUrl === undefined ? 'http://localhost:3000' : baseUrl;
 
@@ -15,6 +16,7 @@ export const useStompThread = () => {
   const { accessToken } = useToken();
   const { teamPlaceId } = useTeamPlace();
   const [client, setClient] = useState<Client | null>(null);
+  const { userInfo } = useFetchUserInfo();
 
   useEffect(() => {
     if (!teamPlaceId) {
@@ -41,7 +43,11 @@ export const useStompThread = () => {
                 if (oldData) {
                   const newFirstPageThreads = {
                     threads: [
-                      { ...newThread, type: 'thread' },
+                      {
+                        ...newThread,
+                        type: 'thread',
+                        isMe: newThread.authorId === userInfo?.id,
+                      },
                       ...oldData.pages[0].threads,
                     ],
                   };

--- a/frontend/src/mocks/handlers/stomp.ts
+++ b/frontend/src/mocks/handlers/stomp.ts
@@ -25,11 +25,10 @@ export const stompHandlers = [
           const connectOkThread: StompThreadResponse = {
             payload: {
               id: Date.now(),
-              authorId: 1,
+              authorId: 2,
               authorName: 'STOMP 모킹 서버',
               profileImageUrl:
                 'https://github.com/user-attachments/assets/75220af3-66e8-4cda-b164-49de0b3d992b',
-              isMe: false,
               createdAt: generateYYYYMMDDHHMM(new Date()),
               content:
                 '성공적으로 Websocket을 이용한 STOMP 모킹 서버에 연결하였습니다.',
@@ -63,7 +62,6 @@ export const stompHandlers = [
               authorName: '나',
               profileImageUrl:
                 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQYZjvO1QuvfgCfQxBwwzmJcHIT5pTXIBGOLeyBDIbZknn6Dhkd40WrU0ZCdjt-IoXLzI0&usqp=CAU',
-              isMe: true,
               createdAt: generateYYYYMMDDHHMM(new Date()),
               content,
               requestId: '',

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -80,5 +80,5 @@ export interface StompThreadRequest {
 }
 
 export interface StompThreadResponse {
-  payload: Omit<Thread, 'type'> & { requestId: string };
+  payload: Omit<Thread, 'type' | 'isMe'> & { requestId: string };
 }


### PR DESCRIPTION
# [FE] 채팅에서 내가 보낸 메시지인지의 여부가 구분이 안 되는 문제 해결

## PR 내용
핫픽스이자 #993 에 대한 후속 픽스. 이전에 이야기한대로 바뀐 코드베이스도 없으니 즉시 Merge 진행할게.

- 발생하는 문제는 채팅을 입력해 엔터를 누른 경우 내가 보낸 채팅임에도 타인이 보낸 채팅인 것처럼 흰색 배경의 말풍선으로 보이는 점.
- SSE에서 Stomp로 전환하면서 백엔드 측에서 이제 채팅에 포함되는 `isMe` 값을 구분하여 응답하는 것이 기술적으로 어려워짐. 반면 프론트엔드 측에서는 딱 한 번만 API 요청을 하면 유저 정보를 알 수 있으니 `useStompThread`에서 유저 정보를 API 요청한다음 그 이후부터는 메시지를 수신받을 때마다 `authorId` 값이 일치하는지로 나 자신이 보냈는지를 판별하고, `isMe` 값을 결정하여 반환하는 방식으로 해결.

> isMe 관련해서 좀 알아봤는데 서버에서 분리해서 하려면 사용자 정보들을 다 들고있어야 되는거 같더라고 
그리고 이게 프레임워크에서 제공하는 메서드가 개인용 하나 전체용 하나라 한명 개인용으로 isMe:true로  보낸 다음에 반복문으로 나머지 사람들한테 isMe:false로 보내야될거같은데 이것도 하나의 방 안에 있는 유저들을 가져오기가 쉽지는 않을거같아보임
그래서 userId를 채팅창에서 가져올 수 있는지 물어본게 채팅 수신한 다음에 userId가 같으면 내꺼니까 그렇게 구분해서 렌더링할 수 있을거같아서 물어봤음

